### PR TITLE
Fix bug that causes crash when using the JSON API

### DIFF
--- a/lib/exabgp/reactor/api/encoding.py
+++ b/lib/exabgp/reactor/api/encoding.py
@@ -121,7 +121,7 @@ class JSON (object):
 		for family in plus:
 			nlris = plus[family]
 			s  = '"%s %s": { ' % family
-			s += ', '.join('%s' % nlri.json() for nlri in nlris)
+			s += ', '.join('%s' % str(nlri) for nlri in nlris)
 			s += ' }'
 			add.append(s)
 


### PR DESCRIPTION
Hi,

I saw the following dump when trying to use the API. I think I fixed it! (touch wood)

Thanks,

Peter.

-- Version

2.6.5 (r265:79063, Apr 16 2010, 13:57:41) 
[GCC 4.4.3]

-- Configuration

group routes {
    process backend-routes-process {
        encoder json;
        run /usr/local/etc/exabgp/dump;
    }

```
neighbor 85.116.180.84 {
    description "mk-tgw-01";
    router-id 10.10.10.243;
    local-address 10.10.10.243;
    local-as 8689;
    peer-as 8689;
    hold-time 180;

    process {
        neighbor-changes;
        receive-routes;
    }

    static {
    }
}
```

}

-- Logging History

Mon, 02 Sep 2013 09:21:10 | message  | 14883  | info          | Peer   85.116.180.84 ASN 8689    << UPDATE
Mon, 02 Sep 2013 09:21:10 | routes   | 14883  | info          | Peer   85.116.180.84 ASN 8689    announced route 10.10.126.8/30 label [ 1153 ] route-distinguisher 8689:142 next-hop 85.116.164.13 origin incomplete local-preference 100 med 2 extended-community [ target:8689:0.0.0.142 0x00050000008E0200 0x8000000000000200 0x80010AE101170000 ] originator-id 85.116.164.13 cluster-list [ 85.116.179.253 85.116.167.249 ]
Mon, 02 Sep 2013 09:21:10 | routes   | 14883  | info          | Peer   85.116.180.84 ASN 8689    announced route 10.10.126.12/30 label [ 1152 ] route-distinguisher 8689:142 next-hop 85.116.164.13 origin incomplete local-preference 100 med 2 extended-community [ target:8689:0.0.0.142 0x00050000008E0200 0x8000000000000200 0x80010AE101170000 ] originator-id 85.116.164.13 cluster-list [ 85.116.179.253 85.116.167.249 ]
Mon, 02 Sep 2013 09:21:10 | routes   | 14883  | info          | Peer   85.116.180.84 ASN 8689    announced route 10.10.126.64/29 label [ 1149 ] route-distinguisher 8689:142 next-hop 85.116.164.13 origin incomplete local-preference 100 med 2 extended-community [ target:8689:0.0.0.142 0x00050000008E0200 0x8000000000000200 0x80010AE101170000 ] originator-id 85.116.164.13 cluster-list [ 85.116.179.253 85.116.167.249 ]
Mon, 02 Sep 2013 09:21:10 | routes   | 14883  | info          | Peer   85.116.180.84 ASN 8689    announced route 10.10.126.80/28 label [ 1141 ] route-distinguisher 8689:142 next-hop 85.116.164.13 origin incomplete local-preference 100 med 2 extended-community [ target:8689:0.0.0.142 0x00050000008E0200 0x8000000000000200 0x80010AE101170000 ] originator-id 85.116.164.13 cluster-list [ 85.116.179.253 85.116.167.249 ]
Mon, 02 Sep 2013 09:21:10 | routes   | 14883  | info          | Peer   85.116.180.84 ASN 8689    announced route 10.225.4.23/32 label [ 1158 ] route-distinguisher 8689:142 next-hop 85.116.164.13 origin incomplete local-preference 100 med 2 extended-community [ target:8689:0.0.0.142 0x00050000008E0200 0x8000000000000200 0x80010AE101170000 ] originator-id 85.116.164.13 cluster-list [ 85.116.179.253 85.116.167.249 ]
Mon, 02 Sep 2013 09:21:10 | routes   | 14883  | info          | Peer   85.116.180.84 ASN 8689    announced route 10.225.5.23/32 label [ 1160 ] route-distinguisher 8689:142 next-hop 85.116.164.13 origin incomplete local-preference 100 med 2 extended-community [ target:8689:0.0.0.142 0x00050000008E0200 0x8000000000000200 0x80010AE101170000 ] originator-id 85.116.164.13 cluster-list [ 85.116.179.253 85.116.167.249 ]
Mon, 02 Sep 2013 09:21:10 | timers   | 14883  | debug         | Peer   85.116.180.84 ASN 8689    Receive Timer 179 second(s) left
Mon, 02 Sep 2013 09:21:10 | timers   | 14883  | debug         | Peer   85.116.180.84 ASN 8689    Sending Timer 56 second(s) left
Mon, 02 Sep 2013 09:21:10 | wire     | 14883  | debug         | Peer   85.116.180.84 RECV FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF 0081 02
Mon, 02 Sep 2013 09:21:10 | wire     | 14883  | debug         | Peer   85.116.180.84 RECV 0000 006A 4001 0100 4002 0080 0404 0000 0001 4005 0400 0000 64C0 1020 0002 21F1 0000 008E 0005 0000 008E 0200 8000 0000 0000 0501 8001 0AE1 0117 0000 800A 0855 74B3 FD55 74A7 F980 0904 5574 A40D 800E 1D00 0180 0C00 0000 0000 0000 0055 74A4 0D00 5800 48C1 0000 21F1 0000 008E
Mon, 02 Sep 2013 09:21:10 | message  | 14883  | info          | Peer   85.116.180.84 ASN 8689    << UPDATE
Mon, 02 Sep 2013 09:21:10 | routes   | 14883  | info          | Peer   85.116.180.84 ASN 8689    announced route 0.0.0.0/0 label [ 1164 ] route-distinguisher 8689:142 next-hop 85.116.164.13 origin igp local-preference 100 med 1 extended-community [ target:8689:0.0.0.142 0x00050000008E0200 0x8000000000000501 0x80010AE101170000 ] originator-id 85.116.164.13 cluster-list [ 85.116.179.253 85.116.167.249 ]
Mon, 02 Sep 2013 09:21:10 | timers   | 14883  | debug         | Peer   85.116.180.84 ASN 8689    Receive Timer 179 second(s) left
Mon, 02 Sep 2013 09:21:10 | timers   | 14883  | debug         | Peer   85.116.180.84 ASN 8689    Sending Timer 56 second(s) left
Mon, 02 Sep 2013 09:21:10 | wire     | 14883  | debug         | Peer   85.116.180.84 RECV FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF 001D 02
Mon, 02 Sep 2013 09:21:10 | wire     | 14883  | debug         | Peer   85.116.180.84 RECV 0000 0006 800F 0300 0180
Mon, 02 Sep 2013 09:21:10 | message  | 14883  | info          | Peer   85.116.180.84 ASN 8689    << UPDATE
Mon, 02 Sep 2013 09:21:10 | routes   | 14883  | info          | Peer   85.116.180.84 ASN 8689    announced eor 1/128 (ipv4 mpls-vpn)
Mon, 02 Sep 2013 09:21:10 | ERROR    | 14883  | supervisor    | Peer   85.116.180.84 ASN 8689    UNHANDLED EXCEPTION
Mon, 02 Sep 2013 09:21:10 | message  | 14883  | info          | Peer   85.116.180.84 ASN 8689    clearing MESSAGE(s) buffer

-- Traceback

Traceback (most recent call last):
  File "/usr/lib/python2.6/runpy.py", line 122, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.6/runpy.py", line 34, in _run_code
    exec code in run_globals
  File "/usr/local/lib/python2.6/dist-packages/exabgp/debug.py", line 71, in <module>
    execfile(sys.argv[0])
  File "/usr/local/lib/python2.6/dist-packages/exabgp/application/bgp.py", line 388, in <module>
    main()
  File "/usr/local/lib/python2.6/dist-packages/exabgp/application/bgp.py", line 314, in main
    run(env,comment,configuration)
  File "/usr/local/lib/python2.6/dist-packages/exabgp/application/bgp.py", line 352, in run
    Supervisor(configuration).run()
  File "/usr/local/lib/python2.6/dist-packages/exabgp/structure/supervisor.py", line 114, in run
    if peer.run() is not True:
  File "/usr/local/lib/python2.6/dist-packages/exabgp/bgp/peer.py", line 127, in run
    return self._loop.next()
  File "/usr/local/lib/python2.6/dist-packages/exabgp/bgp/peer.py", line 256, in _run
    message = self.bgp.read_message()
  File "/usr/local/lib/python2.6/dist-packages/exabgp/bgp/protocol.py", line 161, in read_message
    self.peer.supervisor.processes.routes(self.neighbor.peer_address,update.routes)
  File "/usr/local/lib/python2.6/dist-packages/exabgp/structure/processes.py", line 228, in routes
    self.write(process,self._api_encoder[process].routes(neighbor,routes))
  File "/usr/local/lib/python2.6/dist-packages/exabgp/structure/api.py", line 147, in routes
    return self._header(self._neighbor(neighbor,self._routes(routes)))
  File "/usr/local/lib/python2.6/dist-packages/exabgp/structure/api.py", line 124, in _routes
    s += ', '.join('%s' % _.nlri.json() for _ in routes)
  File "/usr/local/lib/python2.6/dist-packages/exabgp/structure/api.py", line 124, in <genexpr>
    s += ', '.join('%s' % _.nlri.json() for _ in routes)
AttributeError: 'Address' object has no attribute 'json'
