### PR TITLE
systemd: fix exabgp paths

### DIFF
--- a/etc/systemd/exabgp.service
+++ b/etc/systemd/exabgp.service
@@ -5,7 +5,7 @@ After=network.target
 [Service]
 Environment=exabgp.daemon.daemonize=false
 Environment=exabgp.log.destination=stdout
-ExecStart=/usr/bin/exabgp /etc/exabgp.conf
+ExecStart=/usr/sbin/exabgp /etc/exabgp/exabgp.conf
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
README and SysV init scripts are expecting exabgp to be in
/usr/sbin. We fix the path in systemd service file. Moreover, SysV
init script looks at ExaBGP configuration in
/etc/exabgp/exabgp.conf. We also fix this for systemd.
