### PR TITLE
Fix send-packets and receive-packets encoding

### DIFF
--- a/lib/exabgp/reactor/api/encoding.py
+++ b/lib/exabgp/reactor/api/encoding.py
@@ -43,10 +43,10 @@ class Text (object):
 		return 'shutdown'
 
 	def receive (self,neighbor,category,header,body):
-		return 'neighbor %s received %s header %s body %s\n' % (neighbor,ord(category),hexstring(header),hexstring(body))
+		return 'neighbor %s received %d header %s body %s\n' % (neighbor,category,hexstring(header),hexstring(body))
 
 	def send (self,neighbor,category,header,body):
-		return 'neighbor %s sent %s header %s body %s\n' % (neighbor,ord(category),hexstring(header),hexstring(body))
+		return 'neighbor %s sent %d header %s body %s\n' % (neighbor,category,hexstring(header),hexstring(body))
 
 	def update (self,neighbor,update):
 		r = 'neighbor %s update start\n' % neighbor
@@ -144,10 +144,10 @@ class JSON (object):
 		return self._header(self._kv({'notification':'shutdown'}))
 
 	def receive (self,neighbor,category,header,body):
-		return self._header(self._neighbor(neighbor,'"update": { %s } ' % self._minimalkv({'received':ord(category),'header':hexstring(header),'body':hexstring(body)})))
+		return self._header(self._neighbor(neighbor,'"update": { %s } ' % self._minimalkv({'received':category,'header':hexstring(header),'body':hexstring(body)})))
 
 	def send (self,neighbor,category,header,body):
-		return self._header(self._neighbor(neighbor,'"update": { %s } ' % self._minimalkv({'sent':ord(category),'header':hexstring(header),'body':hexstring(body)})))
+		return self._header(self._neighbor(neighbor,'"update": { %s } ' % self._minimalkv({'sent':category,'header':hexstring(header),'body':hexstring(body)})))
 
 	def _update (self,update):
 		plus = {}

--- a/lib/exabgp/reactor/protocol.py
+++ b/lib/exabgp/reactor/protocol.py
@@ -117,7 +117,7 @@ class Protocol (object):
 
 	def write (self,message):
 		if self.neighbor.api.send_packets:
-			self.peer.reactor.processes.send(self.peer.neighbor.peer_address,message[18],message[:19],message[19:])
+			self.peer.reactor.processes.send(self.peer.neighbor.peer_address,ord(message[18]),message[:19],message[19:])
 		for boolean in self.connection.writer(message):
 			yield boolean
 


### PR DESCRIPTION
When logging received bgp messages, message type is already converted
to integer in Connection.reader (exabgp/lib/exabgp/reactor/network/connection.py:226).
This causes exceptions, when receive-packets is enabled for watcher
process. Fix is to change encoding api to expect message type as an
integer.
Tested by running exabgp with send-packets&receive-packets watcher in
both text and json encodings.
