### PR TITLE
Open message can now be send to the helper application.

### DIFF
--- a/lib/exabgp/reactor/api/processes.py
+++ b/lib/exabgp/reactor/api/processes.py
@@ -274,8 +274,8 @@ class Processes (object):
 		for process in self._notify(peer,'neighbor-changes'):
 			self.write(process,self._api_encoder[process].notification(peer,code,subcode,data))
 
-	def message (self,message_id,peer,message,header,body):
-		self._dispatch[message_id](self,peer,message,header,body)
+	def message (self,message_id,peer,message,header,*body):
+		self._dispatch[message_id](self,peer,message,header,*body)
 
 	# registering message functions
 
@@ -288,7 +288,7 @@ class Processes (object):
 		return closure
 
 	@register_process(Message.ID.OPEN,_dispatch)
-	def _open (self,peer,direction,open_msg,header,body):
+	def _open (self,peer,open_msg,header,body,direction='received'):
 		if self.silence: return
 		for process in self._notify(peer,'receive-opens'):
 			self.write(process,self._api_encoder[process].open(peer,direction,open_msg,header,body))

--- a/lib/exabgp/reactor/protocol.py
+++ b/lib/exabgp/reactor/protocol.py
@@ -238,9 +238,9 @@ class Protocol (object):
 			if self.neighbor.api['consolidate']:
 				header = msg_send[0:38]
 				body = msg_send[38:]
-				self.peer.reactor.processes.message(Message.ID.OPEN,self.peer,'sent',sent_open,header,body)
+				self.peer.reactor.processes.message(Message.ID.OPEN,self.peer,sent_open,header,body,'sent')
 			else:
-				self.peer.reactor.processes.message(Message.ID.OPEN,self.peer,'sent',sent_open,'','')
+				self.peer.reactor.processes.message(Message.ID.OPEN,self.peer,sent_open,'','','sent')
 		yield sent_open
 
 	def new_keepalive (self,comment=''):


### PR DESCRIPTION
Fixes the following bug:

``` Text
Thu, 17 Jul 2014 10:47:30 | ERROR    | 4225   | reactor       | peer 192.168.33.12 ASN 4       UNHANDLED PROBLEM, please report
Thu, 17 Jul 2014 10:47:30 | ERROR    | 4225   | reactor       | peer 192.168.33.12 ASN 4       <type 'exceptions.TypeError'>
Thu, 17 Jul 2014 10:47:30 | ERROR    | 4225   | reactor       | peer 192.168.33.12 ASN 4       message() takes exactly 6 arguments (7 given)
Thu, 17 Jul 2014 10:47:30 | ERROR    | 4225   |               | Traceback (most recent call last):
Thu, 17 Jul 2014 10:47:30 | ERROR    | 4225   |               |   File "/home/vagrant/venv/lib/python2.6/site-packages/exabgp/reactor/peer.py", line 564, in _run
Thu, 17 Jul 2014 10:47:30 | ERROR    | 4225   |               |     for action in self._[direction]['code']():
Thu, 17 Jul 2014 10:47:30 | ERROR    | 4225   |               |   File "/home/vagrant/venv/lib/python2.6/site-packages/exabgp/reactor/peer.py", line 320, in _connect
Thu, 17 Jul 2014 10:47:30 | ERROR    | 4225   |               |     for message in proto.new_open(self._restarted):
Thu, 17 Jul 2014 10:47:30 | ERROR    | 4225   |               |   File "/home/vagrant/venv/lib/python2.6/site-packages/exabgp/reactor/protocol.py", line 241, in new_open
Thu, 17 Jul 2014 10:47:30 | ERROR    | 4225   |               |     self.peer.reactor.processes.message(Message.ID.OPEN,self.peer,'sent',sent_open,header,body)
Thu, 17 Jul 2014 10:47:30 | ERROR    | 4225   |               | TypeError: message() takes exactly 6 arguments (7 given)
Thu, 17 Jul 2014 10:47:30 | ERROR    | 4225   |               | 
Thu, 17 Jul 2014 10:47:30 | INFO     | 4225   | network       | Peer   192.168.33.12 ASN 4       out loop reset  
^CThu, 17 Jul 2014 10:47:31 | INFO     | 4225   | reactor       | ^C received
Thu, 17 Jul 2014 10:47:31 | INFO     | 4225   | reactor       | Performing shutdown
```
