### PR TITLE
Fixed keepalive JSON object

### DIFF
--- a/lib/exabgp/reactor/api/encoding.py
+++ b/lib/exabgp/reactor/api/encoding.py
@@ -196,7 +196,7 @@ class JSON (object):
 		'}' % (self.version,self.time(time.time()),peer,pid,ppid,counter,mtype,header,body,content)
 
 	def _neighbor (self,peer,content):
-		peer_neighbor_adress='"ip": "%s", ' % peer.neighbor.peer_address
+		peer_neighbor_adress='"ip": "%s", ' % peer.neighbor.peer_address if content else '"ip:": "%s"' % peer.neighbor.peer_address
 		return \
 		'"neighbor": { ' \
 			'%s' \


### PR DESCRIPTION
The keepalive message is invalid with the current keepalive encoding method, with this pull request it will be fixed.

Previous:

``` Text
{
    "exabgp": "3.4.0",
    "time": 1405934239,
    "host": "producer.local",
    "pid": "14590",
    "ppid": "14460",
    "counter": 3,
    "type": "keepalive",
    "header": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF001304",
    "neighbor": {
        "ip": "192.168.33.12",

    }
}
```

Now:

``` Text
{
    "exabgp": "3.4.0",
    "time": 1405936047,
    "host": "producer.local",
    "pid": "15171",
    "ppid": "14460",
    "counter": 4,
    "type": "keepalive",
    "header": "FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF001304",
    "neighbor": {
        "ip:": "192.168.33.12"
    }
}
```
