### PR TITLE
More consistent APIOptions dict

### DIFF
--- a/lib/exabgp/bgp/neighbor.py
+++ b/lib/exabgp/bgp/neighbor.py
@@ -152,11 +152,11 @@ class Neighbor (object):
 
 		_receive  = []
 
-		_receive.extend(['      parsed;\n',]           if self.api['receive_parsed'] else [])
-		_receive.extend(['      packets;\n',]          if self.api['receive_packets'] else [])
+		_receive.extend(['      parsed;\n',]           if self.api['receive-parsed'] else [])
+		_receive.extend(['      packets;\n',]          if self.api['receive-packets'] else [])
 		_receive.extend(['      consolidate;\n',]      if self.api['consolidate'] else [])
 
-		_receive.extend(['      neighbor-changes;\n',] if self.api['neighbor_changes'] else [])
+		_receive.extend(['      neighbor-changes;\n',] if self.api['neighbor-changes'] else [])
 		_receive.extend(['      notification;\n',]     if self.api[Message.ID.NOTIFICATION] else [])
 		_receive.extend(['      open;\n',]             if self.api[Message.ID.OPEN] else [])
 		_receive.extend(['      keepalive;\n',]        if self.api[Message.ID.KEEPALIVE] else [])
@@ -170,7 +170,7 @@ class Neighbor (object):
 		receive = ''.join(_receive)
 
 		_send = []
-		_send.extend(['      packets;\n',]          if self.api['send_packets'] else [])
+		_send.extend(['      packets;\n',]          if self.api['send-packets'] else [])
 		send = ''.join(_send)
 
 		return """\

--- a/lib/exabgp/reactor/api/encoding.py
+++ b/lib/exabgp/reactor/api/encoding.py
@@ -25,10 +25,10 @@ class APIOptions (dict):
 		self['consolidate'] = self.get('consolidate',False) | value
 
 	def send_packets (self,value):
-		self['send_packets'] = self.get('send_packets',False) | value
+		self['send-packets'] = self.get('send_packets',False) | value
 
 	def neighbor_changes (self,value):
-		self['neighbor_changes'] = self.get('neighbor_changes',False) | value
+		self['neighbor-changes'] = self.get('neighbor_changes',False) | value
 
 	def receive_notifications (self,value):
 		self[Message.ID.NOTIFICATION] = self.get(Message.ID.NOTIFICATION,False) | value

--- a/lib/exabgp/reactor/protocol.py
+++ b/lib/exabgp/reactor/protocol.py
@@ -141,7 +141,7 @@ class Protocol (object):
 			if not length:
 				yield _NOP
 
-		if self.neighbor.api['receive_packets'] and not self.neighbor.api['consolidate']:
+		if self.neighbor.api['receive-packets'] and not self.neighbor.api['consolidate']:
 			self.peer.reactor.processes.receive(self.peer,msg,header,body)
 
 		if msg == Message.ID.UPDATE and not self.neighbor.api['receive-parsed'] and not self.log_routes:


### PR DESCRIPTION
Previously we mixed up neighbor_changes, neighbor-changes, receive-packets, receive_packets. Now made all consistent. It also caused the neighbor-changes JSON objects not to be created, this is fixed with this patch.
