### PR TITLE
Fix KeyError, when sending "down" neighbor-state message

### DIFF
--- a/lib/exabgp/reactor/api/encoding.py
+++ b/lib/exabgp/reactor/api/encoding.py
@@ -171,7 +171,10 @@ class JSON (object):
 		self._counter[peer.neighbor.peer_address] = 1
 
 	def increase (self,peer):
-		self._counter[peer.neighbor.peer_address] += 1
+                if peer.neighbor.peer_address in self._counter:
+                        self._counter[peer.neighbor.peer_address] += 1
+                else:
+                        self._counter[peer.neighbor.peer_address] = 1
 
 	def count (self,peer):
 		return self._counter.get(peer.neighbor.peer_address,1)


### PR DESCRIPTION
If initial connection to bgp peer fails, json api raises KeyError exception, trying to write state message.
The reason: JSON.reset() is only called upon successful connection, and reset() is only function, which inserts peer into _counter dictionary.

Stack trace: https://gist.github.com/dneiter/a9d2542662e53203c511

The fix: let JSON.increment() insert peer into self._counter() dictionary, if necessary.
