### PR TITLE
Teach Listener to accept IPv6 peers

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -22,6 +22,8 @@ Version 3.4.4
  * Feature: accept packet with confedation (RFC 3065)
     requested by: oriordan (with a patch, thank you)
  * Fix: do not bark if an unknown ASPath attribute is found
+ * Fix: correctly accept connection on AF_INET6 socket
+    patch by: John W. O'Brien
 
 Version 3.4.3
  * Fix: JSON message increment


### PR DESCRIPTION
The `getpeername` method on the socket object returns an address of the form corresponding to the address family of the socket. For AF_INET and AF_INET6 this is always a tuple, and the first and second elements of the tuple are the host address and port number respectively.
