### PR TITLE
healthcheck: don't advertise community either when withdrawing a route

### DIFF
--- a/etc/exabgp/processes/healthcheck.py
+++ b/etc/exabgp/processes/healthcheck.py
@@ -322,9 +322,9 @@ def loop(options):
                                                            options.next_hop or "self")
             if command == "announce":
                 announce = "{0} med {1}".format(announce, metric)
-            if options.community:
-                announce = "{0} community [ {1} ]".format(announce,
-                                                          options.community)
+                if options.community:
+                    announce = "{0} community [ {1} ]".format(announce,
+                                                              options.community)
             logger.debug("exabgp: {0} {1}".format(command, announce))
             print("{0} {1}".format(command, announce))
             metric += options.increase


### PR DESCRIPTION
Only the prefix is advertised in a withdraw message. While exabgp
doesn't have a problem with getting more stuff, it seems cleaner to not
advertise anything else while this is just ignored.

Closes: #184
