### PR TITLE
Allow generic attribute not only in single line but also multiple lines

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ Version explained:
 
 Version 3.4.7
  * Change: be more pythonic and use enty points with pip installation
+ * Fix: allow generic attribute not only in single line but also in multiple lines
+    patch by: Eiichiro Watanabe (issue #214)
 
 Version 3.4.6
  * Fix: a badly formated flow route would throw the parser in limbo

--- a/lib/exabgp/configuration/ancient.py
+++ b/lib/exabgp/configuration/ancient.py
@@ -1658,7 +1658,7 @@ class Configuration (object):
 					'local-preference','atomic-aggregate','aggregator',
 					'path-information','community','originator-id','cluster-list',
 					'extended-community','split','label','rd','route-distinguisher',
-					'watchdog','withdraw'
+					'watchdog','withdraw','attribute'
 				]
 			)
 			if r is False: return False


### PR DESCRIPTION
eg.)
```
neighbor 127.0.0.1 {
  --snip--
  static {
    route 111.111.111.111 {
      next-hop: 192.168.1.100;
      attribute: [ 0x99 0x70 0x00000064 ];
    }
  }
}
```