### PR TITLE
Fix healthcheck.py script to accept the loopback IP

### DIFF
--- a/etc/exabgp/processes/healthcheck.py
+++ b/etc/exabgp/processes/healthcheck.py
@@ -236,7 +236,7 @@ def loopback_ips(label):
                 lmo = labelre.match(line)
                 if not lmo or not lmo.group("label").startswith(label):
                     continue
-            addresses.append(ip)
+        addresses.append(ip)
     if not addresses:
         raise RuntimeError("No loopback IP found")
     logger.debug("Loopback addresses: {0}".format(addresses))


### PR DESCRIPTION
IPs that are considered loopback IPs were not added to the addresses list. This caused the `healthcheck.py` script to not run.

@thomas-mangin 