### PR TITLE
healthcheck: don't raise an error when specifying IP on the command-line

### DIFF
--- a/etc/exabgp/processes/healthcheck.py
+++ b/etc/exabgp/processes/healthcheck.py
@@ -237,8 +237,6 @@ def loopback_ips(label):
                 if not lmo or not lmo.group("label").startswith(label):
                     continue
             addresses.append(ip)
-    if not addresses:
-        raise RuntimeError("No loopback IP found")
     logger.debug("Loopback addresses: {0}".format(addresses))
     return addresses
 
@@ -423,6 +421,8 @@ if __name__ == "__main__":
     try:
         # Setup IP to use
         options.ips = options.ips or loopback_ips(options.label)
+        if not options.ips:
+            raise RuntimeError("No IP found")
         if options.ip_setup:
             setup_ips(options.ips, options.label)
         options.ips = collections.deque(options.ips)


### PR DESCRIPTION
When no loopback IPs are present and the IPs are specified on the
command-line instead, we still trigger an error due to a check in the
function retrieving the loopback IPs. We move this check in the outer
program instead. The check will fail only if there is no loopback IPs
and no IP specified on the command-line.

This should fix #216.