### PR TITLE
Fix AS_PATH with AS_SET handling

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,8 @@ Version 3.4.8
     reported by: Tim Preston
  * Fix: handle numeric community parsing correctly
     reported by: Aaron Kalin
+ * Fix: bug in AS_PATH with AS_SET handling
+    patch by: Eiichiro Watanabe
 
 Version 3.4.7
  * Package: be more pythonic and use enty points with pip installation

--- a/lib/exabgp/bgp/message/update/attribute/aspath.py
+++ b/lib/exabgp/bgp/message/update/attribute/aspath.py
@@ -122,7 +122,7 @@ class ASPath (Attribute):
 				string = '[ %s ]' % ' '.join([str(_) for _ in aseq])
 		else:  # lseq == 0
 			if lset:
-				string = '[ %s]' % '( %s ) ' % (' '.join([str(_) for _ in aset]))
+				string = '[ ( %s )]' % (' '.join([str(_) for _ in aset]))
 			else:
 				string = '[ ]'
 		return string

--- a/lib/exabgp/bgp/message/update/attribute/aspath.py
+++ b/lib/exabgp/bgp/message/update/attribute/aspath.py
@@ -121,7 +121,10 @@ class ASPath (Attribute):
 			else:
 				string = '[ %s ]' % ' '.join([str(_) for _ in aseq])
 		else:  # lseq == 0
-			string = '[ ]'
+			if lset:
+				string = '[ %s]' % '( %s ) ' % (' '.join([str(_) for _ in aset]))
+			else:
+				string = '[ ]'
 		return string
 
 	def json (self,name):


### PR DESCRIPTION
In the case of using the following configuration, exabgp would send 2 routes with incorrect AS_PATH attributes.
```
neighbor 192.168.0.100 {
        router-id 192.168.0.1;
        local-address 192.168.0.1;
        local-as 65001;
        peer-as 65100;
        hold-time 90;

        family {
                ipv4 unicast;
        }

        static {
                route 172.16.1.0/24 {
                        origin igp;
                        as-path [ ( 65002 ) ];
                        next-hop 192.168.0.1;
                }
                route 172.16.2.0/24 {
                        origin igp;
                        as-path [ ( 65002 65003 ) ];
                        next-hop 192.168.0.1;
                }
        }
}
```
The first route would be advertised with correct AS_PATH attribute to the neighbor, but the second one would be advertised with incorrect attributes.
```
Remote router> 
   Network          Next Hop            Metric LocPrf Weight Path
*> 172.16.1.0/24    192.168.0.1                            0 {65002} i
*> 172.16.2.0/24    192.168.0.1                            0 {65002} i
```
It should be:
```
Remote router> 
   Network          Next Hop            Metric LocPrf Weight Path
*> 172.16.1.0/24    192.168.0.1                            0 {65002} i
*> 172.16.2.0/24    192.168.0.1                            0 {65002,65003} i
```
In the latest code, It seems to return [ ] even if AS_SET exists when AS_PATH doesn't have AS_SEQ.