### PR TITLE
Removing forcing Attribute.CODE.ATOMIC_AGGREGATE into _generate_json loop.

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/attributes.py
+++ b/lib/exabgp/bgp/message/update/attribute/attributes.py
@@ -94,7 +94,7 @@ class Attributes (dict):
 					yield ' attribute [ 0x%02X 0x%02X %s ]' % (code,attribute.FLAG,str(attribute))
 
 	def _generate_json (self):
-		for code in sorted(self.keys() + [Attribute.CODE.ATOMIC_AGGREGATE,]):
+		for code in sorted(self.keys()):
 			# remove the next-hop from the attribute as it is define with the NLRI
 			if code in Attributes.NO_GENERATION:
 				continue


### PR DESCRIPTION
`_generate_json` in `exabgp.bgp.message.update.attribute.attributes.Attributes` loops through the keys of the dict given, *plus* `Attribute.CODE.ATOMIC_AGGREGATE`. Forcing that into the loop causes a `KeyError` if it wasn't already there. If it *was* already there, then adding it again isn't needed.

This also brings `_generate_json` in line with what `_generate_text` loops through.