### PR TITLE
bin/exabgp: simplify starter script

### DIFF
--- a/sbin/exabgp
+++ b/sbin/exabgp
@@ -1,51 +1,22 @@
 #!/bin/sh
 
-dirname=`dirname $0`
+dirname="$(dirname $0)"
 
-case $dirname in
-	/*)
-		cd $dirname/.. > /dev/null
-		path=`pwd`
-		cd - > /dev/null
-	;;
-	*)
-		cd `pwd`/$dirname/.. > /dev/null
-		path=`pwd`
-		cd - > /dev/null
-	;;
-esac
+path="$(readlink -f $dirname/..)"
 
-export PYTHONPATH=$path/lib:/usr/share/exabgp/lib/3.4.4
+export PYTHONPATH="$path"/lib:/usr/share/exabgp/lib/3.4.4
 
-PYPY=`which pypy 2>/dev/null`
-PYTHON27=`which python2.7 2>/dev/null`
-PYTHON26=`which python2.6 2>/dev/null`
-PYTHON2=`which python2 2>/dev/null`
-PYTHON=`which python 2>/dev/null`
+for INTERPRETER in "$INTERPRETER" pypy python2.7 python2.6 python2 python; do
+	INTERPRETER="$(command -v "$INTERPRETER")" && break
+done
 
-if [ "$INTERPRETER" != "" ]
-then
-	INTERPRETER=`which $INTERPRETER`
-elif [ -f "$PYPY" ]
-then
-	INTERPRETER=$PYPY
-elif [ -f "$PYTHON27" ]
-then
-	INTERPRETER=$PYTHON27
-elif [ -f "$PYTHON26" ]
-then
-	INTERPRETER=$PYTHON26
-elif [ -f "$PYTHON2" ]
-then
-	INTERPRETER=$PYTHON2
-elif [ -f "$PYTHON" ]
-then
-	INTERPRETER=$PYTHON
-else
-	INTERPRETER=python
-fi
+APPLICATION="$("$INTERPRETER" -c "
+import sys
+import os
 
-APPLICATIONS=`$INTERPRETER -c "import sys,os; print ' '.join(os.path.join(_,'exabgp','application','bgp.py') for _ in sys.path if os.path.isfile('/'.join((_,'exabgp','application','bgp.py'))))"`
-APPLICATION=`echo $APPLICATIONS | awk '{ print $1; }'`
+print [os.path.join(_, 'exabgp', 'application', 'bgp.py')
+       for _ in sys.path
+       if os.path.isfile('/'.join((_, 'exabgp', 'application', 'bgp.py')))][0]
+")"
 
-exec $INTERPRETER $APPLICATION --folder $path/etc/exabgp "$@"
+exec "$INTERPRETER" "$APPLICATION" --folder "$path"/etc/exabgp "$@"


### PR DESCRIPTION
 - Use of `readlink -f` to get absolute pathname to parent directory.
 - Use a for loop to test for available interpreters.
 - Unroll the Python script.
 - Select the first application matching directly in Python.
 - Quote everything appropriately in case someone put a space in a directory.

Tell me what you think of those changes and I can make the same in similar files.