### PR TITLE
bin/*: simplify remaining starter scripts

### DIFF
--- a/bin/exabgp
+++ b/bin/exabgp
@@ -1,51 +1,20 @@
 #!/bin/sh
 
-dirname=`dirname $0`
+path="$(readlink -f "$(dirname "$0")"/..)"
 
-case $dirname in
-	/*)
-		cd $dirname/.. > /dev/null
-		path=`pwd`
-		cd - > /dev/null
-	;;
-	*)
-		cd `pwd`/$dirname/.. > /dev/null
-		path=`pwd`
-		cd - > /dev/null
-	;;
-esac
+export PYTHONPATH="$path"/lib:/usr/share/exabgp/lib/3.4.4
 
-export PYTHONPATH=$path/lib:/usr/share/exabgp/lib/3.4.4
+for INTERPRETER in "$INTERPRETER" pypy python2.7 python2.6 python2 python; do
+	INTERPRETER="$(command -v "$INTERPRETER")" && break
+done
 
-PYPY=`which pypy 2>/dev/null`
-PYTHON27=`which python2.7 2>/dev/null`
-PYTHON26=`which python2.6 2>/dev/null`
-PYTHON2=`which python2 2>/dev/null`
-PYTHON=`which python 2>/dev/null`
+APPLICATION="$("$INTERPRETER" -c "
+import sys
+import os
 
-if [ "$INTERPRETER" != "" ]
-then
-	INTERPRETER=`which $INTERPRETER`
-elif [ -f "$PYPY" ]
-then
-	INTERPRETER=$PYPY
-elif [ -f "$PYTHON27" ]
-then
-	INTERPRETER=$PYTHON27
-elif [ -f "$PYTHON26" ]
-then
-	INTERPRETER=$PYTHON26
-elif [ -f "$PYTHON2" ]
-then
-	INTERPRETER=$PYTHON2
-elif [ -f "$PYTHON" ]
-then
-	INTERPRETER=$PYTHON
-else
-	INTERPRETER=python
-fi
+print [os.path.join(_, 'exabgp', 'application', 'cli.py')
+       for _ in sys.path
+       if os.path.isfile('/'.join((_, 'exabgp', 'application', 'cli.py')))][0]
+")"
 
-APPLICATIONS=`$INTERPRETER -c "import sys,os; print ' '.join(os.path.join(_,'exabgp','application','cli.py') for _ in sys.path if os.path.isfile('/'.join((_,'exabgp','application','cli.py'))))"`
-APPLICATION=`echo $APPLICATIONS | awk '{ print $1; }'`
-
-exec env ETC=$path/etc/exabgp $INTERPRETER $APPLICATION "$@"
+exec env ETC="$path"/etc/exabgp "$INTERPRETER" "$APPLICATION" "$@"

--- a/dev/bin/unittest
+++ b/dev/bin/unittest
@@ -1,58 +1,11 @@
 #!/bin/sh
 
-dirname=`dirname $0`
-
-case $dirname in
-	/*)
-		cd $dirname/../.. > /dev/null
-		path=`pwd`
-		cd - > /dev/null
-	;;
-	*)
-		cd `pwd`/$dirname/../.. > /dev/null
-		path=`pwd`
-		cd - > /dev/null
-	;;
-esac
+path="$(readlink -f "$(dirname "$0")"/../..)"
 
 export PYTHONPATH=$path/lib
 
-if [ "$INTERPRETER" != "" ]
-then
-	INTERPRETER=`which $INTERPRETER`
-fi
+for INTERPRETER in "$INTERPRETER" pypy python2.7 python2.6 python2 python; do
+	INTERPRETER="$(command -v "$INTERPRETER")" && break
+done
 
-PYPY=`which pypy 2>/dev/null`
-PYTHON27=`which python2.7 2>/dev/null`
-PYTHON26=`which python2.6 2>/dev/null`
-PYTHON25=`which python2.5 2>/dev/null`
-PYTHON24=`which python2.4 2>/dev/null`
-PYTHON2=`which python2 2>/dev/null`
-PYTHON=`which python 2>/dev/null`
-
-if [ -f "$PYPY" ]
-then
-	INTERPRETER=$PYPY
-elif [ -f "$PYTHON27" ]
-then
-	INTERPRETER=$PYTHON27
-elif [ -f "$PYTHON26" ]
-then
-	INTERPRETER=$PYTHON26
-elif [ -f "$PYTHON25" ]
-then
-	INTERPRETER=$PYTHON25
-elif [ -f "$PYTHON24" ]
-then
-	INTERPRETER=$PYTHON24
-elif [ -f "$PYTHON2" ]
-then
-	INTERPRETER=$PYTHON2
-elif [ -f "$PYTHON" ]
-then
-	INTERPRETER=$PYTHON
-else
-	INTERPRETER=python
-fi
-
-exec $INTERPRETER -m exabgp.debug $*
+exec "$INTERPRETER" -m exabgp.debug "$@"

--- a/qa/bin/ip
+++ b/qa/bin/ip
@@ -1,48 +1,11 @@
 #!/bin/sh
 
-dirname=`dirname $0`
-
-case $dirname in
-	/*)
-		cd $dirname/../.. > /dev/null
-		path=`pwd`
-		cd - > /dev/null
-	;;
-	*)
-		cd `pwd`/$dirname/../.. > /dev/null
-		path=`pwd`
-		cd - > /dev/null
-	;;
-esac
+path="$(readlink -f "$(dirname "$0")"/../..)"
 
 export PYTHONPATH=$path/lib:/usr/share/exabgp/lib/3.4.4
 
-PYPY=`which pypy 2>/dev/null`
-PYTHON27=`which python2.7 2>/dev/null`
-PYTHON26=`which python2.6 2>/dev/null`
-PYTHON2=`which python2 2>/dev/null`
-PYTHON=`which python 2>/dev/null`
+for INTERPRETER in "$INTERPRETER" pypy python2.7 python2.6 python2 python; do
+	INTERPRETER="$(command -v "$INTERPRETER")" && break
+done
 
-if [ "$INTERPRETER" != "" ]
-then
-	INTERPRETER=`which $INTERPRETER`
-elif [ -f "$PYPY" ]
-then
-	INTERPRETER=$PYPY
-elif [ -f "$PYTHON27" ]
-then
-	INTERPRETER=$PYTHON27
-elif [ -f "$PYTHON26" ]
-then
-	INTERPRETER=$PYTHON26
-elif [ -f "$PYTHON2" ]
-then
-	INTERPRETER=$PYTHON2
-elif [ -f "$PYTHON" ]
-then
-	INTERPRETER=$PYTHON
-else
-	INTERPRETER=python
-fi
-
-exec $INTERPRETER $path/qa/prg/ip.py "$@"
+exec "$INTERPRETER" "$path"/qa/prg/ip.py "$@"

--- a/qa/bin/route
+++ b/qa/bin/route
@@ -1,48 +1,11 @@
 #!/bin/sh
 
-dirname=`dirname $0`
-
-case $dirname in
-	/*)
-		cd $dirname/../.. > /dev/null
-		path=`pwd`
-		cd - > /dev/null
-	;;
-	*)
-		cd `pwd`/$dirname/../.. > /dev/null
-		path=`pwd`
-		cd - > /dev/null
-	;;
-esac
+path="$(readlink -f "$(dirname "$0")"/../..)"
 
 export PYTHONPATH=$path/lib:/usr/share/exabgp/lib/3.4.4
 
-PYPY=`which pypy 2>/dev/null`
-PYTHON27=`which python2.7 2>/dev/null`
-PYTHON26=`which python2.6 2>/dev/null`
-PYTHON2=`which python2 2>/dev/null`
-PYTHON=`which python 2>/dev/null`
+for INTERPRETER in "$INTERPRETER" pypy python2.7 python2.6 python2 python; do
+	INTERPRETER="$(command -v "$INTERPRETER")" && break
+done
 
-if [ "$INTERPRETER" != "" ]
-then
-	INTERPRETER=`which $INTERPRETER`
-elif [ -f "$PYPY" ]
-then
-	INTERPRETER=$PYPY
-elif [ -f "$PYTHON27" ]
-then
-	INTERPRETER=$PYTHON27
-elif [ -f "$PYTHON26" ]
-then
-	INTERPRETER=$PYTHON26
-elif [ -f "$PYTHON2" ]
-then
-	INTERPRETER=$PYTHON2
-elif [ -f "$PYTHON" ]
-then
-	INTERPRETER=$PYTHON
-else
-	INTERPRETER=python
-fi
-
-exec $INTERPRETER $path/qa/prg/route.py "$@"
+exec "$INTERPRETER" "$path"/qa/prg/route.py "$@"

--- a/sbin/exabgp
+++ b/sbin/exabgp
@@ -1,8 +1,6 @@
 #!/bin/sh
 
-dirname="$(dirname $0)"
-
-path="$(readlink -f $dirname/..)"
+path="$(readlink -f "$(dirname "$0")"/..)"
 
 export PYTHONPATH="$path"/lib:/usr/share/exabgp/lib/3.4.4
 

--- a/sbin/exabmp
+++ b/sbin/exabmp
@@ -1,61 +1,20 @@
 #!/bin/sh
 
-dirname=`dirname $0`
-
-case $dirname in
-	/*)
-		cd $dirname/.. > /dev/null
-		path=`pwd`
-		cd - > /dev/null
-	;;
-	*)
-		cd `pwd`/$dirname/.. > /dev/null
-		path=`pwd`
-		cd - > /dev/null
-	;;
-esac
+path="$(readlink -f "$(dirname "$0")"/..)"
 
 export PYTHONPATH=$path/lib:/usr/share/exabgp/lib/3.4.4
 
-if [ "$INTERPRETER" != "" ]
-then
-	INTERPRETER=`which $INTERPRETER`
-fi
+for INTERPRETER in "$INTERPRETER" pypy python2.7 python2.6 python2 python; do
+	INTERPRETER="$(command -v "$INTERPRETER")" && break
+done
 
-PYPY=`which pypy 2>/dev/null`
-PYTHON27=`which python2.7 2>/dev/null`
-PYTHON26=`which python2.6 2>/dev/null`
-PYTHON25=`which python2.5 2>/dev/null`
-PYTHON24=`which python2.4 2>/dev/null`
-PYTHON2=`which python2 2>/dev/null`
-PYTHON=`which python 2>/dev/null`
+APPLICATION="$("$INTERPRETER" -c "
+import sys
+import os
 
-if [ -f "$PYPY" ]
-then
-	INTERPRETER=$PYPY
-elif [ -f "$PYTHON27" ]
-then
-	INTERPRETER=$PYTHON27
-elif [ -f "$PYTHON26" ]
-then
-	INTERPRETER=$PYTHON26
-elif [ -f "$PYTHON25" ]
-then
-	INTERPRETER=$PYTHON25
-elif [ -f "$PYTHON24" ]
-then
-	INTERPRETER=$PYTHON24
-elif [ -f "$PYTHON2" ]
-then
-	INTERPRETER=$PYTHON2
-elif [ -f "$PYTHON" ]
-then
-	INTERPRETER=$PYTHON
-else
-	INTERPRETER=python
-fi
+print [os.path.join(_, 'exabgp', 'application', 'bmp.py')
+       for _ in sys.path
+       if os.path.isfile('/'.join((_, 'exabgp', 'application', 'bmp.py')))][0]
+")"
 
-APPLICATIONS=`$INTERPRETER -c "import sys,os; print ' '.join(os.path.join(_,'exabgp','application','bmp.py') for _ in sys.path if os.path.isfile('/'.join((_,'exabgp','application','bgp.py'))))"`
-APPLICATION=`echo $APPLICATIONS | awk '{ print $1; }'`
-
-exec $INTERPRETER $APPLICATION $*
+echo exec "$INTERPRETER" "$APPLICATION" "$@"


### PR DESCRIPTION
Like for 41672c0cb56f, simplify other starter scripts:

 - Use of `readlink -f` to get absolute pathname to parent directory.
 - Use a for loop to test for available interpreters.
 - Remove support for python2.4 and python2.5 when they were still present.
 - Unroll the Python script.
 - Select the first application matching directly in Python.
 - Quote everything appropriately in case someone put a space in a directory.