### PR TITLE
bin/*: don't use `readlink -f`, not portable enough

### DIFF
--- a/bin/exabgp
+++ b/bin/exabgp
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-path="$(readlink -f "$(dirname "$0")"/..)"
+path="$(cd "$(dirname "$0")"/.. ; pwd)"
 
 export PYTHONPATH="$path"/lib:/usr/share/exabgp/lib/3.4.4
 

--- a/dev/bin/unittest
+++ b/dev/bin/unittest
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-path="$(readlink -f "$(dirname "$0")"/../..)"
+path="$(cd "$(dirname "$0")"/../.. ; pwd)"
 
 export PYTHONPATH=$path/lib
 

--- a/qa/bin/ip
+++ b/qa/bin/ip
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-path="$(readlink -f "$(dirname "$0")"/../..)"
+path="$(cd "$(dirname "$0")"/../.. ; pwd)"
 
 export PYTHONPATH=$path/lib:/usr/share/exabgp/lib/3.4.4
 

--- a/qa/bin/route
+++ b/qa/bin/route
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-path="$(readlink -f "$(dirname "$0")"/../..)"
+path="$(cd "$(dirname "$0")"/../.. ; pwd)"
 
 export PYTHONPATH=$path/lib:/usr/share/exabgp/lib/3.4.4
 

--- a/sbin/exabgp
+++ b/sbin/exabgp
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-path="$(readlink -f "$(dirname "$0")"/..)"
+path="$(cd "$(dirname "$0")"/.. ; pwd)"
 
 export PYTHONPATH="$path"/lib:/usr/share/exabgp/lib/3.4.4
 


### PR DESCRIPTION
`readlink -f` doesn't work on OSX. Close #231.

Sorry. :)