### PR TITLE
tests: don't use assert, use self.assertXXX

### DIFF
--- a/qa/tests/control_test.py
+++ b/qa/tests/control_test.py
@@ -38,7 +38,7 @@ class TestControl (unittest.TestCase):
 		control = Control()
 		try:
 			result = control.init()
-			assert result is False
+			self.assertFalse(result)
 		except IOError:
 			# could not write in the location
 			pass
@@ -50,13 +50,13 @@ class TestControl (unittest.TestCase):
 		control = Control(name,False)
 		try:
 			result = control.init()
-			assert result is True
+			self.assertTrue(result)
 
 			p = Process(target=speak, args=(name,message))
 			p.start()
 
 			string = control.loop()
-			assert string == check
+			self.assertEqual(string, check)
 			p.join()
 		finally:
 			control.cleanup()


### PR DESCRIPTION
In `qa/tests/control_test.py`, `assert` was still used. On failure, it's
not possible to know how the expected and the obtained results differ.