### PR TITLE
Fix parsing attributes with PARTIAL flag set

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,10 @@ Version explained:
  minor : increase on risk of code breakage during a major release
  bug   : increase on bug or incremental changes
 
+Version 3.4.10
+ * Fix: Fix parsing attributes with PARTIAL flag set
+    patch by: Daniel Neiter
+
 Version 3.4.9
  * Fix: very bad bug where NLRI where not associated to the right AFI/SAFI pair ( #235 )
     reported by: esequei

--- a/lib/exabgp/bgp/message/update/attribute/attributes.py
+++ b/lib/exabgp/bgp/message/update/attribute/attributes.py
@@ -294,8 +294,8 @@ class Attributes (dict):
 
 		# remove the PARTIAL bit before comparaison if the attribute is optional
 		if aid in Attribute.attributes_optional:
-			aid &= Attribute.Flag.MASK_PARTIAL & 0xFF
-			# aid &= ~Attribute.Flag.PARTIAL & 0xFF  # cleaner than above (python use signed integer for ~)
+			flag &= Attribute.Flag.MASK_PARTIAL & 0xFF
+			# flag &= ~Attribute.Flag.PARTIAL & 0xFF  # cleaner than above (python use signed integer for ~)
 
 		# handle the attribute if we know it
 		if Attribute.registered(aid,flag):


### PR DESCRIPTION
Previously we were masking PARTIAL bit in attribute id instead of flag, which is wrong. As result, we were silently discarding received TRANSITIVE OPTIONAL attributes with PARTIAL flag set.