### PR TITLE
add NSS_SDB_USE_CACHE to healthcheck.py command

### DIFF
--- a/etc/exabgp/processes/healthcheck.py
+++ b/etc/exabgp/processes/healthcheck.py
@@ -284,6 +284,7 @@ def check (cmd, timeout):
 
     logger.debug("Checking command {0}".format(repr(cmd)))
     p = subprocess.Popen(cmd, shell=True,
+                         env = {"NSS_SDB_USE_CACHE":"YES"},
                          stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT,
                          preexec_fn=setpgrp_preexec_fn)


### PR DESCRIPTION
We saw an issue with nss-softtkn 3.14 and 3.16 where the excessive curling for the healthcheck command would cause available memory to be eaten up by dentry. 

Setting `NSS_SDB_USE_CACHE` in the `Popen` for the command portion ensured that curl would utilize the nss cache, and not continue to issue frivolous directory operations and eat up memory. 

See the following bug report for related information: https://bugzilla.redhat.com/show_bug.cgi?id=1044666