### PR TITLE
fixes/improvements related to RTC NLRIs

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/mprnlri.py
+++ b/lib/exabgp/bgp/message/update/attribute/mprnlri.py
@@ -115,7 +115,7 @@ class MPRNLRI (Attribute,Family):
 
 		rd = 0
 
-		# check next-hope size
+		# check next-hop size
 		if afi == AFI.ipv4:
 			if safi in (SAFI.unicast,SAFI.multicast):
 				if len_nh != 4:
@@ -130,6 +130,9 @@ class MPRNLRI (Attribute,Family):
 			elif safi in (SAFI.flow_vpn,):
 				if len_nh not in (0,4):
 					raise Notify(3,0,'invalid ipv4 flow_vpn next-hop length %d expected 4' % len_nh)
+			elif safi in (SAFI.rtc,):
+				if len_nh not in (4,16):
+					raise Notify(3,0,'invalid ipv4 rtc next-hop length %d expected 4' % len_nh)
 		elif afi == AFI.ipv6:
 			if safi in (SAFI.unicast,):
 				if len_nh not in (16,32):

--- a/lib/exabgp/bgp/message/update/nlri/rtc.py
+++ b/lib/exabgp/bgp/message/update/nlri/rtc.py
@@ -39,8 +39,6 @@ class RTC (NLRI):
 	def __eq__ (self, other):
 		return \
 			NLRI.__eq__(self,other) and \
-			self.action == other.action and \
-			self.nexthop == other.action and \
 			self.origin == other.origin and \
 			self.rt == other.rt
 
@@ -79,7 +77,8 @@ class RTC (NLRI):
 		if length == 0:
 			return 1,cls(afi,safi,action,NoNextHop,ASN(0),None)
 
-		# XXX: Why are we reseting the flags on the RouteTarget extended community ?
+		# We are reseting the flags on the RouteTarget extended
+		# community, because they do not make sense for an RTC route
 
 		return 13,cls(
 			afi, safi, action, nexthop,


### PR DESCRIPTION
* RTC.__eq__ should ignore .nexthop and .action
* safeguard for nexthop len of RTC routes in mprnlri

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/285)
<!-- Reviewable:end -->
