### PR TITLE
Fixes encoding/decoding of transitive bit in extended communities

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/community/extended/encapsulation.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/encapsulation.py
@@ -51,8 +51,8 @@ class Encapsulation (ExtendedCommunity):
 		self.tunnel_type = tunnel_type
 		ExtendedCommunity.__init__(
 			self,community if community is not None else pack(
-				"!BBLH",
-				0x03,0x0C,
+				"!2sLH",
+				self._packedTypeSubtype(),
 				0,self.tunnel_type
 			)
 		)

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/l2info.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/l2info.py
@@ -32,8 +32,8 @@ class L2Info (ExtendedCommunity):
 		ExtendedCommunity.__init__(
 			self,
 			community if community is not None else pack(
-				"!BBBBHH",
-				0x80,0x0A,
+				"!2sBBHH",
+				self._packedTypeSubtype(),
 				encaps,control,
 				mtu,reserved
 			)

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/origin.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/origin.py
@@ -51,8 +51,8 @@ class OriginASNIP (Origin):
 		Origin.__init__(
 			self,
 			community if community else pack(
-				'!BBH4s',
-				self.COMMUNITY_TYPE | 0x40 if transitive else self.COMMUNITY_TYPE,0x02,
+				'!2sH4s',
+				self._packedTypeSubtype(),
 				asn,
 				IPv4.pton(ip)
 			)
@@ -83,8 +83,8 @@ class OriginIPASN (Origin):
 		Origin.__init__(
 			self,
 			community if community else pack(
-				'!BB4sH',
-				self.COMMUNITY_TYPE | 0x40 if transitive else self.COMMUNITY_TYPE,0x02,
+				'!2s4sH',
+				self._packedTypeSubtype(),
 				IPv4.pton(ip),
 				asn
 			)
@@ -113,8 +113,8 @@ class OriginASN4Number (Origin):
 		Origin.__init__(
 			self,
 			community if community else pack(
-				'!BBLH',
-				self.COMMUNITY_TYPE | 0x40 if transitive else self.COMMUNITY_TYPE,0x02,
+				'!2sLH',
+				self._packedTypeSubtype(),
 				asn,
 				number
 			)

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/rt.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/rt.py
@@ -56,8 +56,8 @@ class RouteTargetASN2Number (RouteTarget):
 		RouteTarget.__init__(
 			self,
 			community if community else pack(
-				'!BBHL',
-				self.COMMUNITY_TYPE | Attribute.Flag.TRANSITIVE if transitive else self.COMMUNITY_TYPE,0x02,
+				'!2sHL',
+				self._packedTypeSubtype(transitive),
 				asn,number
 			)
 		)
@@ -91,8 +91,8 @@ class RouteTargetIPNumber (RouteTarget):
 		RouteTarget.__init__(
 			self,
 			community if community else pack(
-				'!BB4sH',
-				self.COMMUNITY_TYPE | Attribute.Flag.TRANSITIVE if transitive else self.COMMUNITY_TYPE,0x02,
+				'!2s4sH',
+				self._packedTypeSubtype(transitive),
 				IPv4.pton(ip),number
 			)
 		)
@@ -127,8 +127,8 @@ class RouteTargetASN4Number (RouteTarget):
 		RouteTarget.__init__(
 			self,
 			community if community else pack(
-				'!BBLH',
-				self.COMMUNITY_TYPE | Attribute.Flag.TRANSITIVE if transitive else self.COMMUNITY_TYPE,0x02,
+				'!2sLH',
+				self._packedTypeSubtype(transitive),
 				asn,number
 			)
 		)

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/traffic.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/traffic.py
@@ -29,8 +29,8 @@ class TrafficRate (ExtendedCommunity):
 		ExtendedCommunity.__init__(
 			self,
 			community if community is not None else pack(
-				"!BBHf",
-				0x80,0x06,
+				"!2sHf",
+				self._packedTypeSubtype(),
 				asn,rate
 			)
 		)
@@ -68,7 +68,14 @@ class TrafficAction (ExtendedCommunity):
 		self.sample = sample
 		self.terminal = terminal
 		bitmask = self._sample[sample] | self._terminal[terminal]
-		ExtendedCommunity.__init__(self,community if community is not None else pack('!BBLBB',0x80,0x07,0,0,bitmask))
+		ExtendedCommunity.__init__(
+			self,
+			community if community is not None else pack(
+				'!2sLBB',
+				self._packedTypeSubtype(),
+				0,0,bitmask
+			)
+		)
 
 	def __repr__ (self):
 		s = []
@@ -102,8 +109,8 @@ class TrafficRedirect (ExtendedCommunity):
 		ExtendedCommunity.__init__(
 			self,
 			community if community is not None else pack(
-				"!BBHL",
-				0x80,0x08,
+				"!2sHL",
+				self._packedTypeSubtype(),
 				asn,target
 			)
 		)
@@ -132,8 +139,8 @@ class TrafficMark (ExtendedCommunity):
 		ExtendedCommunity.__init__(
 			self,
 			community if community is not None else pack(
-				"!BBLBB",
-				0x80,0x09,
+				"!2sLBB",
+				self._packedTypeSubtype(),
 				0,0,dscp
 			)
 		)
@@ -164,8 +171,8 @@ class TrafficNextHop (ExtendedCommunity):
 		ExtendedCommunity.__init__(
 			self,
 			community if community is not None else pack(
-				"!BBLH",
-				0x80,0x00,
+				"!2sLH",
+				self._packedTypeSubtype(),
 				0,1 if copy else 0
 			)
 		)


### PR DESCRIPTION
There is a trick: bit set means "not transitive". ::

>>   RFC4360:
>>        T - Transitive bit
>>  -->         Value 0: The community is transitive across ASes
>>               Value 1: The community is non-transitive across ASes

This patch:
* factors out the code to packed community type and subtype
* avoids hardcoded 0x.. values in each ext com
* makes this code produce the right bit value for the transitive bit (applies only to RT at this point)
* fixes Origin ext com packing which was using wrong subtype (0x02 instead of 0x03)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/288)
<!-- Reviewable:end -->
