### PR TITLE
MPLSVPN and EVPN __eq__ fixes

### DIFF
--- a/lib/exabgp/bgp/message/update/nlri/evpn/mac.py
+++ b/lib/exabgp/bgp/message/update/nlri/evpn/mac.py
@@ -62,7 +62,7 @@ class MAC (EVPN):
 
 	def __eq__ (self, other):
 		return \
-			NLRI.__eq__(self,other) and \
+			isinstance(other, MAC) and \
 			self.CODE == other.CODE and \
 			self.rd == other.rd and \
 			self.etag == other.etag and \

--- a/lib/exabgp/bgp/message/update/nlri/mpls.py
+++ b/lib/exabgp/bgp/message/update/nlri/mpls.py
@@ -129,10 +129,11 @@ class MPLSVPN (MPLS):
 		# this is why the test below does not look at self.labels nor
 		# self.nexthop or self.action
 		return \
-			NLRI.__eq__(self, other) and \
-			CIDR.__eq__(self, other) and \
+			isinstance(other, MPLSVPN) and \
 			self.path_info == other.path_info and \
-			self.rd == other.rd
+			self.rd == other.rd and \
+			self.mask == other.mask and \
+			self._packed == other._packed
 
 	def __ne__ (self, other):
 		return not self.__eq__(other)


### PR DESCRIPTION
EVPN and MPLSVPN can't inherit __eq__ from NLRI and CIDR, because
they have to ignore certain fields.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/309)
<!-- Reviewable:end -->
