### PR TITLE
systemd: make exabgp runs as exabgp:exabgp with systemd

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -83,6 +83,8 @@ Version 4.0.0
    reported by: Dmitry Onuchin
  * Fix: reading large buffered data from helper process caused truncation
    reported by: qqTYXn7
+ * Change: ExaBGP is now run as user/group exabgp/exabgp with the systemd
+   service file.
 
 Version 3.4.10
  * Fix: Fix parsing attributes with PARTIAL flag set

--- a/etc/systemd/exabgp.service
+++ b/etc/systemd/exabgp.service
@@ -3,6 +3,8 @@ Description=ExaBGP
 After=network.target
 
 [Service]
+User=exabgp
+Group=exabgp
 Environment=exabgp_daemon_daemonize=false
 Environment=exabgp_log_destination=stdout
 Environment=ETC=/etc

--- a/etc/sysusers.d/exabgp.conf
+++ b/etc/sysusers.d/exabgp.conf
@@ -1,0 +1,1 @@
+u exabgp - "ExaBGP"


### PR DESCRIPTION
Both SysV init script and upstart job are using exabgp:exabgp as a user
to run exabgp. Do the same thing for systemd.

Made as a PR because the systemd script is not distribution-specific. We could also create the appropriate file to let systemd create this user/group if it doesn't exist.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/319)
<!-- Reviewable:end -->
