### PR TITLE
init: don't use ETC, use --folder instead

### DIFF
--- a/debian/exabgp.init
+++ b/debian/exabgp.init
@@ -21,15 +21,12 @@ USER=exabgp
 NAME=exabgp
 CONFIG="/etc/exabgp/exabgp.conf"
 DAEMON=/usr/sbin/exabgp
-DAEMON_OPTS="$CONFIG"
+DAEMON_OPTS="--folder /etc/exabgp $CONFIG"
 PIDFILE=/var/run/$NAME/$NAME.pid
 SCRIPTNAME=/etc/init.d/$NAME
 
 # Exit if the package is not installed
 [ -x $DAEMON ] || exit 0
-
-# Some env var the daemon will need
-export ETC="/etc/exabgp/"
 
 # Read configuration variable file if it is present
 [ -r /etc/default/$NAME ] && . /etc/default/$NAME

--- a/debian/exabgp.upstart
+++ b/debian/exabgp.upstart
@@ -15,7 +15,6 @@ env DAEMON=/usr/sbin/exabgp
 env DAEMON_OPTS=/etc/exabgp/exabgp.conf
 env CONFIG=/etc/exabgp/exabgp.conf
 env PIDFILE=/var/run/exabgp/exabgp.pid
-env ETC=/etc
 
 pre-start script
   [ -f /etc/default/$NAME ] && . /etc/default/$NAME start
@@ -33,5 +32,5 @@ script
   export exabgp_daemon_user
   exabgp_daemon_pid=$PIDFILE
   export exabgp_daemon_pid
-  $DAEMON $DAEMON_OPTS
+  $DAEMON --folder /etc/exabgp $DAEMON_OPTS
 end script

--- a/etc/systemd/exabgp.service
+++ b/etc/systemd/exabgp.service
@@ -7,9 +7,8 @@ User=exabgp
 Group=exabgp
 Environment=exabgp_daemon_daemonize=false
 Environment=exabgp_log_destination=stdout
-Environment=ETC=/etc
 ConditionPathExists=/etc/exabgp/exabgp.conf
-ExecStart=/usr/sbin/exabgp /etc/exabgp/exabgp.conf
+ExecStart=/usr/sbin/exabgp --folder /etc/exabgp /etc/exabgp/exabgp.conf
 ExecReload=/bin/kill -USR1 $MAINPID
 
 [Install]


### PR DESCRIPTION
This should be compatible with both 3.4 and master.

It seems to be the best way to be consistent with 3.4 and master. See #319 for some explanations on the problems of ETC in 3.4.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/320)
<!-- Reviewable:end -->
