### PR TITLE
init: let ExaBGP drop privileges itself

### DIFF
--- a/debian/exabgp.init
+++ b/debian/exabgp.init
@@ -17,7 +17,6 @@
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="BGP route injector"
-USER=exabgp
 NAME=exabgp
 CONFIG="/etc/exabgp/exabgp.conf"
 DAEMON=/usr/sbin/exabgp
@@ -54,7 +53,7 @@ do_start()
 	#   1 if daemon was already running
 	#   2 if daemon could not be started
 	# We create the PID file and we do background thanks to start-stop-daemon
-	start-stop-daemon --start --quiet --pidfile $PIDFILE -c $USER -b -m --exec $DAEMON -- $DAEMON_OPTS
+	start-stop-daemon --start --quiet --pidfile $PIDFILE -b -m --exec $DAEMON -- $DAEMON_OPTS
 	return $?
 }
 
@@ -68,7 +67,7 @@ do_stop()
 	#   1 if daemon was already stopped
 	#   2 if daemon could not be stopped
 	#   other if a failure occurred
-	start-stop-daemon --stop --quiet --signal TERM --pidfile $PIDFILE -c $USER
+	start-stop-daemon --stop --quiet --signal TERM --pidfile $PIDFILE
 	RETVAL="$?"
 	sleep 1
 	# clean stale PID file
@@ -90,18 +89,18 @@ do_stop()
 # Function that sends a SIGUSR1 to the daemon/service
 #
 do_reload() {
-	start-stop-daemon --stop --signal USR1 --quiet --pidfile $PIDFILE -c $USER
+	start-stop-daemon --stop --signal USR1 --quiet --pidfile $PIDFILE
 	return 0
 }
 
 do_force_reload() {
-	start-stop-daemon --stop --signal USR2 --quiet --pidfile $PIDFILE -c $USER
+	start-stop-daemon --stop --signal USR2 --quiet --pidfile $PIDFILE
 	return 0
 }
 
 case "$1" in
   start)
-	start-stop-daemon --status --quiet --pidfile $PIDFILE -c $USER
+	start-stop-daemon --status --quiet --pidfile $PIDFILE
 	retval=$?
 	if [ $retval -eq 0 ] ; then
 		log_warning_msg "$NAME is already running"

--- a/etc/systemd/exabgp.service
+++ b/etc/systemd/exabgp.service
@@ -3,8 +3,6 @@ Description=ExaBGP
 After=network.target
 
 [Service]
-User=exabgp
-Group=exabgp
 Environment=exabgp_daemon_daemonize=false
 Environment=exabgp_log_destination=stdout
 ConditionPathExists=/etc/exabgp/exabgp.conf


### PR DESCRIPTION
We don't know exactly what kind of privileges ExaBGP may need at
start. It is likely to have to bind to port 179 and therefore requires
root privileges. systemd and SysV init script shouldn't drop
privileges. ExaBGP should do it after initialization.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/322)
<!-- Reviewable:end -->
