### PR TITLE
Correct hard coded value in the TTL function

### DIFF
--- a/lib/exabgp/reactor/network/tcp.py
+++ b/lib/exabgp/reactor/network/tcp.py
@@ -165,7 +165,7 @@ def TTL (io, ip, ttl):
 	# None (ttl-security unset) or zero (maximum TTL) is the same thing
 	if ttl:
 		try:
-			io.setsockopt(socket.IPPROTO_IP,socket.IP_TTL, 20)
+			io.setsockopt(socket.IPPROTO_IP,socket.IP_TTL, ttl)
 		except socket.error,exc:
 			raise TTLError('This OS does not support IP_TTL (ttl-security) for %s (%s)' % (ip,errstr(exc)))
 


### PR DESCRIPTION
The TTL function passed a hard coded value of 20 to setsockopt*( instead of the value of the TTL parameter. Now it passes the proper
value.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/340)
<!-- Reviewable:end -->
