### PR TITLE
Corrected call to TTL()

### DIFF
--- a/lib/exabgp/reactor/network/outgoing.py
+++ b/lib/exabgp/reactor/network/outgoing.py
@@ -26,6 +26,7 @@ class Outgoing (Connection):
 		try:
 			self.io = create(afi)
 			MD5(self.io,peer,port,md5)
+			TTL(self.io, peer, self.ttl)
 			bind(self.io,local,afi)
 			async(self.io,peer)
 			connect(self.io,peer,port,afi,md5)
@@ -55,5 +56,5 @@ class Outgoing (Connection):
 			return
 
 		nagle(self.io,self.peer)
-		TTL(self.io,self.peer,self.ttl)
+		# Not working after connect() at least on FreeBSD TTL(self.io,self.peer,self.ttl)
 		yield True


### PR DESCRIPTION
The TTL function was called from the established() method, which is called after the socket is connect()ed. 

At least on FreeBSD it doesn't work, would need testing on other platforms. Calling TTL() *before* the connect() is made, works.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/341)
<!-- Reviewable:end -->
