### PR TITLE
cleanup NLRI code wrt bagpipe-specific things

### DIFF
--- a/lib/exabgp/bgp/message/update/nlri/inet.py
+++ b/lib/exabgp/bgp/message/update/nlri/inet.py
@@ -48,13 +48,6 @@ class INET (NLRI):
 			self.path_info == other.path_info and \
 			self.nexthop == other.nexthop
 
-	# bagpipe specific code
-	def eq (self, other):
-		return \
-			NLRI.eq(self, other) and \
-			self.cidr == other.cidr and \
-			self.path_info == other.path_info
-
 	def __ne__ (self, other):
 		return not self.__eq__(other)
 

--- a/lib/exabgp/bgp/message/update/nlri/labelled.py
+++ b/lib/exabgp/bgp/message/update/nlri/labelled.py
@@ -13,6 +13,8 @@ from exabgp.bgp.message.update.nlri.inet import INET
 from exabgp.bgp.message.update.nlri.qualifier import PathInfo
 from exabgp.bgp.message.update.nlri.qualifier import Labels
 
+# ====================================================== MPLS
+# RFC 3107
 
 @NLRI.register(AFI.ipv4,SAFI.nlri_mpls)
 @NLRI.register(AFI.ipv6,SAFI.nlri_mpls)

--- a/lib/exabgp/bgp/message/update/nlri/nlri.py
+++ b/lib/exabgp/bgp/message/update/nlri/nlri.py
@@ -45,10 +45,6 @@ class NLRI (Family):
 	def __eq__ (self,other):
 		return self.index() == other.index()
 
-	# bagpipe specific code
-	def eq (self,other):
-		return self.index() == other.index()
-
 	def __ne__ (self,other):
 		return not self.__eq__(other)
 


### PR DESCRIPTION
* revert previous change: have nexthop as a string for IPVPN.new

Bagpipe now subclasses IPVPN, so:
* remove eq  (not used by exabgp)
* remove \__hash\__ (which was inconsistent with \__eq\__/\__neq\__ anyways)