### PR TITLE
Adding TTL protection for outgoing sessions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -3,6 +3,9 @@ Version explained:
  minor : increase on risk of code breakage during a major release
  bug   : increase on bug or incremental changes
 
+Version 3.4.14
+ * Fix: the ttl-security parameter didn´t really work. Fixed for outgoing connections now.
+   patch by: Borja Marcos
 Version 3.4.13
  * Fix: add semicolon in syslog entry so it can be parsed by tools
  * Fix: duplication of message following helper process death

--- a/lib/exabgp/reactor/network/outgoing.py
+++ b/lib/exabgp/reactor/network/outgoing.py
@@ -28,6 +28,7 @@ class Outgoing (Connection):
 			MD5(self.io,peer,port,md5)
 			bind(self.io,local,afi)
 			async(self.io,peer)
+			TTL(self.io,peer,ttl)
 			connect(self.io,peer,port,afi,md5)
 			self.init = True
 		except NetworkError,exc:

--- a/lib/exabgp/reactor/network/tcp.py
+++ b/lib/exabgp/reactor/network/tcp.py
@@ -165,7 +165,7 @@ def TTL (io, ip, ttl):
 	# None (ttl-security unset) or zero (maximum TTL) is the same thing
 	if ttl:
 		try:
-			io.setsockopt(socket.IPPROTO_IP,socket.IP_TTL, 20)
+			io.setsockopt(socket.IPPROTO_IP,socket.IP_TTL, ttl)
 		except socket.error,exc:
 			raise TTLError('This OS does not support IP_TTL (ttl-security) for %s (%s)' % (ip,errstr(exc)))
 


### PR DESCRIPTION
As I guess there might be more additions to 3.4, it would be good to add the ttl-security feature for the 3.4 branch.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/345)
<!-- Reviewable:end -->
