### PR TITLE
Bug fix: ConditionPathExists is a systemd.unit directive

### DIFF
--- a/etc/systemd/exabgp.service
+++ b/etc/systemd/exabgp.service
@@ -1,10 +1,10 @@
 [Unit]
 Description=ExaBGP
 After=network.target
+ConditionPathExists=/etc/exabgp/exabgp.conf
 
 [Service]
 Environment=exabgp_daemon_daemonize=false
-ConditionPathExists=/etc/exabgp/exabgp.conf
 ExecStart=/usr/sbin/exabgp --folder /etc/exabgp /etc/exabgp/exabgp.conf
 ExecReload=/bin/kill -USR1 $MAINPID
 


### PR DESCRIPTION
Hi.

According to [systemd documentation](http://www.freedesktop.org/software/systemd/man/systemd.unit.html), `ConditionPathExists` must in the `[unit]` section, not in the `[service]` section.

This is the log systemd generate: `[/lib/systemd/system/exabgp.service:9] Unknown lvalue 'ConditionPathExists' in section 'Service'`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/352)
<!-- Reviewable:end -->
