### PR TITLE
a link to ExaZK

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Please let us know if you use it.
  * [exabgp-voipbl](https://github.com/GeertHauwaerts/exabgp-voipbl) advertises local or/and voipbl.org blacklist using unicast or flow route.
  * [ExaBGPmon](https://github.com/thepacketgeek/ExaBGPmon) web interface to ExaBGP
  * [ERCO](https://erco.xyz/) web interface to ExaBGP
+ * [ExaZK](https://github.com/shtouff/exazk) a plugin to interface ExaBGP & ZooKeeper
 
 ## Self Promotion
 


### PR DESCRIPTION
Hello,

Here at BlaBlaCar, we use ZooKeeper as a directory for our services. We also are used to run ExaBGP with healthcheck to announce our VIPs on our BGP infrastructure, on our load-balancers.

We created a script: exazk, to directly connect exabgp to ZK, and this way control what exabgp will announce, directly from ZK.

We were greatly inspired by healthcheck, off course, and I though it could be of some interest for the community of ExaBGP users.

Regards,

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/363)
<!-- Reviewable:end -->
