### PR TITLE
RTRecord support

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/community/extended/rt.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/rt.py
@@ -23,6 +23,8 @@ class RouteTarget (ExtendedCommunity):
 	COMMUNITY_SUBTYPE = 0x02
 	LIMIT = 0
 
+	DESC = 'target'
+
 	@property
 	def la (self):
 		return self.community[2:self.LIMIT]
@@ -66,12 +68,12 @@ class RouteTargetASN2Number (RouteTarget):
 		return hash((self.asn,self.number))
 
 	def __repr__ (self):
-		return "target:%d:%d" % (self.asn,self.number)
+		return "%s:%d:%d" % (self.DESC,self.asn,self.number)
 
-	@staticmethod
-	def unpack (data):
+	@classmethod
+	def unpack (cls, data):
 		asn,number = unpack('!HL',data[2:8])
-		return RouteTargetASN2Number(ASN(asn),number,False,data[:8])
+		return cls(ASN(asn),number,False,data[:8])
 
 
 # ============================================================= RouteTargetIPNumber
@@ -102,12 +104,12 @@ class RouteTargetIPNumber (RouteTarget):
 		return hash((self.ip,self.number))
 
 	def __repr__ (self):
-		return "target:%s:%d" % (self.ip, self.number)
+		return "%s:%d:%d" % (self.DESC,self.ip,self.number)
 
-	@staticmethod
-	def unpack (data):
+	@classmethod
+	def unpack (cls, data):
 		ip,number = unpack('!4sH',data[2:8])
-		return RouteTargetIPNumber(IPv4.ntop(ip),number,False,data[:8])
+		return cls(IPv4.ntop(ip),number,False,data[:8])
 
 
 # ======================================================== RouteTargetASN4Number
@@ -138,9 +140,9 @@ class RouteTargetASN4Number (RouteTarget):
 		return hash((self.asn,self.number))
 
 	def __repr__ (self):
-		return "target:%dL:%d" % (self.asn, self.number)
+		return "%s:%dL:%d" % (self.DESC,self.asn, self.number)
 
-	@staticmethod
-	def unpack (data):
+	@classmethod
+	def unpack (cls, data):
 		asn,number = unpack('!LH',data[2:8])
-		return RouteTargetASN4Number(ASN(asn),number,False,data[:8])
+		return cls(ASN(asn),number,False,data[:8])

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/rt_record.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/rt_record.py
@@ -1,0 +1,33 @@
+from exabgp.bgp.message.update.attribute.community.extended import ExtendedCommunity
+from exabgp.bgp.message.update.attribute.community.extended import rt
+
+import logging
+log = logging.getLogger(__name__)
+
+# draft-fm-bess-service-chaining
+
+
+class RTRecord(rt.RouteTarget):
+    COMMUNITY_SUBTYPE = 0x13
+
+    DESC = "rtrecord"
+
+    @classmethod
+    def from_rt(cls, rt):
+        packed = rt.pack()
+        return cls.unpack(packed[0] + chr(cls.COMMUNITY_SUBTYPE) + packed[2:])
+
+
+@ExtendedCommunity.register
+class RTRecordASN2Number(RTRecord, rt.RouteTargetASN2Number):
+    pass
+
+
+@ExtendedCommunity.register
+class RTRecordIPNumber(RTRecord, rt.RouteTargetIPNumber):
+    pass
+
+
+@ExtendedCommunity.register
+class RTRecordASN4Number(RTRecord, rt.RouteTargetASN4Number):
+    pass


### PR DESCRIPTION
These two commits add support for RTRecord (as specified in draft-fm-bess-service-chaining).

The first commit simply make RouteTarget easily extensible (does not change any behavior in ExaBGP).

The second commit adds support for RTRecord based on the first commit.
If preferred, because the spec still is an individual draft and the subtype not IANA-registered, the second commit can be left apart (we can add/register it from bagpipe-bgp).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/368)
<!-- Reviewable:end -->
