### PR TITLE
fix wildcard RTC route len encoding + unit tests

### DIFF
--- a/lib/exabgp/bgp/message/update/nlri/rtc.py
+++ b/lib/exabgp/bgp/message/update/nlri/rtc.py
@@ -78,7 +78,7 @@ class RTC (NLRI):
 		if self.rt:
 			packedRT = self.rt.pack()
 			return pack("!BLB", len(self), self.origin, ord(RTC.resetFlags(packedRT[0]))) + packedRT[1:]
-		return pack("!B",1)
+		return pack("!B",0)
 
 	@classmethod
 	def unpack_nlri (cls, afi, safi, bgp, action, addpath):
@@ -87,6 +87,9 @@ class RTC (NLRI):
 
 		if length == 0:
 			return cls(afi,safi,action,ASN(0),None),bgp[1:]
+
+		if length < 8*4:
+			raise Exception("incorrect RT lenght: %d (should be >=32,<=96)" % length)
 
 		# We are reseting the flags on the RouteTarget extended
 		# community, because they do not make sense for an RTC route

--- a/qa/tests/nlri_tests.py
+++ b/qa/tests/nlri_tests.py
@@ -279,6 +279,28 @@ class TestNLRIs(unittest.TestCase):
         self.assertEqual(64577, unpacked.rt.asn)
         self.assertEqual(123, unpacked.rt.number)
 
+    def test98_RTCWildcardPackUnpack(self):
+        '''Test pack/unpack for RTC routes'''
+
+        nlri = RTC.new(AFI(AFI.ipv4), SAFI(SAFI.rtc),
+                       0, None)
+
+        packed = nlri.pack()
+        unpacked,leftover = RTC.unpack_nlri(AFI(AFI.ipv4), SAFI(SAFI.mpls_vpn),
+                                            packed, OUT.UNSET, None)
+
+        self.assertEqual(0, len(leftover))
+
+        # TODO: compare packed with a reference encoding verified 
+        # as conformant with RFC4684
+
+        self.assertTrue(isinstance(unpacked, RTC))
+
+        self.assertEqual(0, unpacked.origin)
+
+        self.assertIsNone(unpacked.rt)
+
+
     # tests on attributes
 
     def test4_DistinctAttributes(self):


### PR DESCRIPTION
- len should be zero and not one for wildcard RTC routes
- add unit tests for wildcard RTC routes

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/375)
<!-- Reviewable:end -->
