### PR TITLE
Allowing a ttl-security of 255

### DIFF
--- a/lib/exabgp/configuration/neighbor/parser.py
+++ b/lib/exabgp/configuration/neighbor/parser.py
@@ -82,7 +82,7 @@ def ttl (tokeniser):
 		raise ValueError('invalid ttl-security "%s"' % value)
 	if attl < 0:
 		raise ValueError('ttl-security can not be negative')
-	if attl >= 255:
+	if attl >= 256:
 		raise ValueError('ttl must be smaller than 256')
 	return attl
 


### PR DESCRIPTION
From related issue: https://github.com/Exa-Networks/exabgp/issues/387

We use a ttl_security value of of 255 in our configuration, which is incompatible with this validation.  This change just allows a value of 255.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Review on Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/388)
<!-- Reviewable:end -->
