### PR TITLE
FSM state fix

### DIFF
--- a/lib/exabgp/reactor/peer.py
+++ b/lib/exabgp/reactor/peer.py
@@ -358,7 +358,7 @@ class Peer (object):
 	def _connect (self):
 		# try to establish the outgoing connection
 
-		self._outgoing.fsm.change(FSM.ACTIVE)
+		self._outgoing.fsm.change(FSM.CONNECT)
 
 		proto = Protocol(self)
 		generator = proto.connect()
@@ -380,7 +380,6 @@ class Peer (object):
 				yield ACTION.NOW
 				raise Interrupted(self._outgoing)
 
-		self._outgoing.fsm.change(FSM.CONNECT)
 		self._outgoing.proto = proto
 
 		# send OPEN


### PR DESCRIPTION
Transitioning to ACTIVE should only be done if the connection attempt fails.
During the TCP connection attempt, the correct state is CONNECT.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/432)
<!-- Reviewable:end -->
