### PR TITLE
Add ConsistentHashSortOrder extended community

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/community/extended/__init__.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/__init__.py
@@ -12,6 +12,7 @@ Copyright (c) 2009-2015 Exa Networks. All rights reserved.
 from exabgp.bgp.message.update.attribute.community.extended.community import ExtendedCommunity
 from exabgp.bgp.message.update.attribute.community.extended.communities import ExtendedCommunities
 
+from exabgp.bgp.message.update.attribute.community.extended.consistent_hash_sort_order import ConsistentHashSortOrder
 from exabgp.bgp.message.update.attribute.community.extended.encapsulation import Encapsulation
 from exabgp.bgp.message.update.attribute.community.extended.l2info import L2Info
 from exabgp.bgp.message.update.attribute.community.extended.origin import Origin

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/consistent_hash_sort_order.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/consistent_hash_sort_order.py
@@ -1,0 +1,36 @@
+from struct import pack
+from struct import unpack
+
+from exabgp.bgp.message.update.attribute.community.extended import ExtendedCommunity
+
+# draft-fm-bess-service-chaining
+
+
+@ExtendedCommunity.register
+class ConsistentHashSortOrder(ExtendedCommunity):
+	COMMUNITY_TYPE = 0x03
+	COMMUNITY_SUBTYPE = 0x14
+	DESCRIPTION = "consistentHashSortOrder"
+
+	__slots__ = ['order','reserved']
+
+	def __init__ (self, order, reserved=0, community=None):
+		self.order = order
+		self.reserved = reserved
+
+		ExtendedCommunity.__init__(
+			self,
+			community if community is not None else pack(
+				"!2sIH",
+				self._subtype(),
+				order,reserved
+			)
+		)
+
+	def __repr__ (self):
+		return "%s:%d" % (self.DESCRIPTION, self.order)
+
+	@staticmethod
+	def unpack (data):
+		order,reserved = unpack('!IH',data[2:8])
+		return ConsistentHashSortOrder(order, reserved, data[:8])


### PR DESCRIPTION
This extended community is introduced by draft-ietf-bess-service-chaining
and is encoded as an optional Transitive Opaque BGP Extended Community
with sub-type 0x14 (reserved in IANA)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/444)
<!-- Reviewable:end -->
