### PR TITLE
Fix JSON encoding of updates without NLRIs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -25,6 +25,8 @@ Version 3.4.17
     patch by: Shu Sugimoto and Eiichiro Watanabe
  * Change: Run without even peers configured
     patch by: Jordan Gedney
+ * Fix: JSON encoding of updates without NLRIs
+    patch by: Dhammika Pathirana
 
 Version 3.4.16
  * Feature: allow users to decide if processes must be run before or after we drop privileges

--- a/lib/exabgp/reactor/api/encoding.py
+++ b/lib/exabgp/reactor/api/encoding.py
@@ -319,10 +319,10 @@ class JSON (object):
 			remove.append(s)
 
 		nlri = ''
-		if not add and not remove:  # an EOR
-			if not update.nlris:
-				raise RuntimeError('no update.nlri: %s %s' % (type(update),dir(update)))
-			return update.nlris[0].json()
+
+		if not add and not remove:
+			if update.nlris:
+				return update.nlris[0].json()
 		if add:
 			nlri += '"announce": { %s }' % ', '.join(add)
 		if add and remove:


### PR DESCRIPTION
Actually EOR is set as an announcement, 
{ "update": { "announce": { "ipv4 unicast": { "null": { "eor": { "afi" : "ipv4", "safi" : "unicast" } } } } } }

Not sure if else path of original is dead code, but kept it in place just in case.
This seems to fix the crash that I was seeing earlier, if this looks good I'll fix this in master branch too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/460)
<!-- Reviewable:end -->
