### PR TITLE
Fix race conditions in apis

### DIFF
--- a/lib/exabgp/reactor/api/command/text.py
+++ b/lib/exabgp/reactor/api/command/text.py
@@ -116,7 +116,9 @@ def show_routes (self, reactor, service, command):
 		else:
 			neighbors = [n for n in reactor.configuration.neighbors.keys() if 'neighbor %s' % last in n]
 		for key in neighbors:
-			neighbor = reactor.configuration.neighbors[key]
+			neighbor = reactor.configuration.neighbors.get(key, None)
+			if not neighbor:
+				continue
 			for change in list(neighbor.rib.outgoing.sent_changes()):
 				reactor.answer(service,'neighbor %s %s' % (neighbor.peer_address,str(change.nlri)))
 				yield True
@@ -135,7 +137,9 @@ def show_routes_extensive (self, reactor, service, command):
 		else:
 			neighbors = [n for n in reactor.configuration.neighbors.keys() if 'neighbor %s' % last in n]
 		for key in neighbors:
-			neighbor = reactor.configuration.neighbors[key]
+			neighbor = reactor.configuration.neighbors.get(key, None)
+			if not neighbor:
+				continue
 			for change in list(neighbor.rib.outgoing.sent_changes()):
 				reactor.answer(service,'neighbor %s %s' % (neighbor.name(),change.extensive()))
 				yield True
@@ -149,8 +153,11 @@ def show_routes_extensive (self, reactor, service, command):
 def announce_watchdog (self, reactor, service, command):
 	def callback (name):
 		# XXX: move into Action
-		for neighbor in reactor.configuration.neighbors:
-			reactor.configuration.neighbors[neighbor].rib.outgoing.announce_watchdog(name)
+		for neighbor_name in reactor.configuration.neighbors.keys():
+			neighbor = reactor.configuration.neighbors.get(neighbor_name, None)
+			if not neighbor:
+				continue
+			neighbor.rib.outgoing.announce_watchdog(name)
 			yield False
 
 		reactor.route_update = True
@@ -168,8 +175,11 @@ def announce_watchdog (self, reactor, service, command):
 def withdraw_watchdog (self, reactor, service, command):
 	def callback (name):
 		# XXX: move into Action
-		for neighbor in reactor.configuration.neighbors:
-			reactor.configuration.neighbors[neighbor].rib.outgoing.withdraw_watchdog(name)
+		for neighbor_name in reactor.configuration.neighbors.keys():
+			neighbor = reactor.configuration.neighbors.get(neighbor_name, None)
+			if not neighbor:
+				continue
+			neighbor.rib.outgoing.withdraw_watchdog(name)
 			yield False
 
 		reactor.route_update = True


### PR DESCRIPTION
This will fix a few issues where it may be possible for neighbors to be removed during a reload while still processing one of the api callbacks. show_neighbors(s) is already doing this, but it appears the other commands that can loop of the list of neighbors don't check to make sure that the key still exists within the neighbor dictionary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/465)
<!-- Reviewable:end -->
