### PR TITLE
Add 'show neighbor status' command

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -29,6 +29,8 @@ Version 3.4.17
     patch by: Dhammika Pathirana
  * Fix: Possible race conditions in api handling
     patch by: Brian Johnson
+ * Feature: Add 'show neighbor status' api
+    patch by: Brian Johnson
 
 Version 3.4.16
  * Feature: allow users to decide if processes must be run before or after we drop privileges

--- a/lib/exabgp/reactor/api/command.py
+++ b/lib/exabgp/reactor/api/command.py
@@ -114,6 +114,24 @@ def show_neighbors (self, reactor, service, command):
 	return True
 
 
+def show_neighbor_status (self, reactor, service, command):
+	def callback ():
+		for peer_name in reactor.peers.keys():
+			peer = reactor.peers.get(peer_name, None)
+			if not peer:
+				continue
+			detailed_status = peer.detailed_link_status()
+			families = peer.negotiated_families()
+			if families:
+				families = "negotiated %s" % families
+			reactor.answer(service, "%s %s state %s" % (peer_name, families, detailed_status))
+			yield True
+		reactor.answer(service,"done")
+
+	reactor.plan(callback())
+	return True
+
+
 def show_routes (self, reactor, service, command):
 	def callback ():
 		last = command.split()[-1]

--- a/lib/exabgp/reactor/api/decoder/__init__.py
+++ b/lib/exabgp/reactor/api/decoder/__init__.py
@@ -48,6 +48,7 @@ FUNCTION = {
 	'teardown':               'teardown',
 	'show neighbor':          'show_neighbor',
 	'show neighbors':         'show_neighbors',
+	'show neighbor status':   'show_neighbor_status',
 	'show routes':            'show_routes',
 	'show routes extensive':  'show_routes_extensive',
 	'announce watchdog':      'announce_watchdog',

--- a/lib/exabgp/reactor/peer.py
+++ b/lib/exabgp/reactor/peer.py
@@ -273,6 +273,29 @@ class Peer (object):
 	def established (self):
 		return self._['in']['state'] == STATE.ESTABLISHED or self._['out']['state'] == STATE.ESTABLISHED
 
+	def detailed_link_status (self):
+		state_tbl = {
+			STATE.IDLE : "Idle",
+			STATE.ACTIVE : "Active",
+			STATE.CONNECT : "Connect",
+			STATE.OPENSENT : "OpenSent",
+			STATE.OPENCONFIRM : "OpenConfirm",
+			STATE.ESTABLISHED : "Established" }
+		return state_tbl[max(self._["in"]["state"], self._["out"]["state"])]
+
+	def negotiated_families(self):
+		if self._['out']['proto']:
+			families = ["%s/%s" % (x[0], x[1]) for x in self._['out']['proto'].negotiated.families]
+		else:
+			families = ["%s/%s" % (x[0], x[1]) for x in self.neighbor.families()]
+
+		if len(families) > 1:
+			return "[ %s ]" % " ".join(families)
+		elif len(families) == 1:
+			return families[0]
+
+		return ''
+
 	def _accept (self):
 		# we can do this as Protocol is a mutable object
 		proto = self._['in']['proto']


### PR DESCRIPTION
Adds support for a 'show neighbor status' api, which will return the state of each peer connection along with a list of negotiated address families.

This patch addresses issue #427

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/475)
<!-- Reviewable:end -->
