### PR TITLE
Fix the broken flush route api

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,8 @@ Version 3.4.17
     patch by: Brian Johnson
  * Feature: Add 'show neighbor status' api
     patch by: Brian Johnson
+ * Fix: flush route api
+    patch by: Brian Johnson
 
 Version 3.4.16
  * Feature: allow users to decide if processes must be run before or after we drop privileges

--- a/lib/exabgp/reactor/api/command.py
+++ b/lib/exabgp/reactor/api/command.py
@@ -209,8 +209,12 @@ def withdraw_watchdog (self, reactor, service, command):
 def flush_route (self, reactor, service, command):
 	def callback (self, peers):
 		self.logger.reactor("Flushing routes for %s" % ', '.join(peers if peers else []) if peers is not None else 'all peers')
-		yield True
-		reactor.route_update = True
+		for peer_name in peers:
+			peer = reactor.peers.get(peer_name, None)
+			if not peer:
+				continue
+			peer.send_new(update=True)
+			yield False
 
 	try:
 		descriptions,command = _extract_neighbors(command)

--- a/lib/exabgp/reactor/loop.py
+++ b/lib/exabgp/reactor/loop.py
@@ -422,12 +422,6 @@ class Reactor (object):
 			self.peers[key].send_new()
 		self.logger.reactor("Updated peers dynamic routes successfully")
 
-	def route_flush (self):
-		"""we just want to flush any unflushed routes"""
-		self.logger.reactor("Performing route flush")
-		for key in self.configuration.neighbor.keys():
-			self.peers[key].send_new(update=True)
-
 	def restart (self):
 		"""kill the BGP session and restart it"""
 		self.logger.reactor("Performing restart of exabgp %s" % version)


### PR DESCRIPTION
This fixes the flush route api so it will actually flush any unsent routes when auto-flush is disabled. 

Thomas, let me know if you would like me to  prepare a PR request for this against master as well. Same for the previous show neighbor status api PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/481)
<!-- Reviewable:end -->
