### PR TITLE
An asn4 capable peer should be able to speak with an asn2 peer.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -37,6 +37,8 @@ Version 3.4.17
     patch by: doddt
  * Change: syslog format changed to be in line with other application
     patch by: Brian Johnson
+ * Fix: Allow asn4 peer to speak with asn2 only peer
+    patch by: Brian Johnson
 
 Version 3.4.16
  * Feature: allow users to decide if processes must be run before or after we drop privileges

--- a/lib/exabgp/bgp/message/open/capability/negotiated.py
+++ b/lib/exabgp/bgp/message/open/capability/negotiated.py
@@ -109,14 +109,6 @@ class Negotiated (object):
 		# 		self.received_open_size = self.peer.bgp.received_open_size - 19
 
 	def validate (self, neighbor):
-		if not self.asn4:
-			if neighbor.local_as.asn4():
-				return (2,0,'peer does not speak ASN4, we are stuck')
-			else:
-				# we will use RFC 4893 to convey new ASN to the peer
-				# XXX: FIXME
-				pass
-
 		if self.peer_as != neighbor.peer_as:
 			return (2,2,'ASN in OPEN (%d) did not match ASN expected (%d)' % (self.received_open.asn,neighbor.peer_as))
 


### PR DESCRIPTION
This section of code is breaking the ability of an asn4 capable peer talking with an asn2 only peer.  When removed things seem to work as expected per the rfcs, the OPEN message sets AS_TRANS as its two byte asn and UPDATE messages contain the AS4_PATH attribute containing the asn4 value.

Is there a reason this code is here that I am overlooking?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/492)
<!-- Reviewable:end -->
