### PR TITLE
Flowspec api fixes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -144,6 +144,13 @@ Version 4.0.0
    patch by: Brian Johnson
  * Fix: Allow asn4 peer to speak with asn2 only peer
    patch by: Brian Johnson
+ * Fix: ExaBGP was crashing when serializing BGP flowspec updates
+   patch by: Stacey Sheldon (Corsa)
+ * Change: API format for BGP flowspec updates
+   patch by: Stacey Sheldon (Corsa)
+   - encoding is now valid JSON
+   - dropped auto-generated name for flowspec updates
+   - format for flowspec updates is now a list of dicts where each dict contains a single flowspec rule
 
 Version 3.4.10
  * Fix: Fix parsing attributes with PARTIAL flag set

--- a/lib/exabgp/bgp/message/update/nlri/flow.py
+++ b/lib/exabgp/bgp/message/update/nlri/flow.py
@@ -475,16 +475,6 @@ for content in dir():
 
 # ..........................................................
 
-def _unique ():
-	value = 0
-	while True:
-		yield value
-		value += 1
-
-
-unique = _unique()
-
-
 @NLRI.register(AFI.ipv4,SAFI.flow_ip)
 @NLRI.register(AFI.ipv6,SAFI.flow_ip)
 @NLRI.register(AFI.ipv4,SAFI.flow_vpn)
@@ -495,7 +485,6 @@ class Flow (NLRI):
 		self.rules = {}
 		self.nexthop = NoNextHop
 		self.rd = RouteDistinguisher.NORD
-		self.unique = unique.next()
 
 	def __eq__ (self, other):
 		return \
@@ -588,7 +577,7 @@ class Flow (NLRI):
 	def __str__ (self):
 		return self.extensive()
 
-	def _json (self):
+	def json (self, compact=None):
 		string = []
 		for index in sorted(self.rules):
 			rules = self.rules[index]
@@ -606,11 +595,6 @@ class Flow (NLRI):
 		rd = '' if self.rd is RouteDistinguisher.NORD else ', %s' % self.rd.json()
 		compatibility = ', "string": "%s"' % self.extensive()
 		return '{' + ','.join(string) + rd + nexthop + compatibility + ' }'
-
-	def json (self, compact=None):
-		# this is a stop gap so flow route parsing does not crash exabgp
-		# delete unique when this is fixed
-		return '{ "flow-%d": %s }' % (self.unique,self._json())
 
 	def index (self):
 		return NLRI._index(self) + self.pack()

--- a/lib/exabgp/bgp/message/update/nlri/flow.py
+++ b/lib/exabgp/bgp/message/update/nlri/flow.py
@@ -607,7 +607,7 @@ class Flow (NLRI):
 		compatibility = ', "string": "%s"' % self.extensive()
 		return '{' + ','.join(string) + rd + nexthop + compatibility + ' }'
 
-	def json (self):
+	def json (self, compact=None):
 		# this is a stop gap so flow route parsing does not crash exabgp
 		# delete unique when this is fixed
 		return '"flow-%d": %s' % (self.unique,self._json())

--- a/lib/exabgp/bgp/message/update/nlri/flow.py
+++ b/lib/exabgp/bgp/message/update/nlri/flow.py
@@ -610,7 +610,7 @@ class Flow (NLRI):
 	def json (self, compact=None):
 		# this is a stop gap so flow route parsing does not crash exabgp
 		# delete unique when this is fixed
-		return '"flow-%d": %s' % (self.unique,self._json())
+		return '{ "flow-%d": %s }' % (self.unique,self._json())
 
 	def index (self):
 		return NLRI._index(self) + self.pack()


### PR DESCRIPTION
This PR fixes two bugs in the flowspec serialization code.

The first bug is an exabgp crash upon receipt of an ipv4 or ipv6 flow update.  This is due to a missing parameter (compact) in the json() method.
```
ExaBGP version : 4.0.0
Python version : 2.7.6 (default, Jun 22 2015, 17:58:13)  [GCC 4.8.2]
System Uname   : #142-Ubuntu SMP Fri Aug 12 17:00:09 UTC 2016
System MaxInt  : 9223372036854775807


peer 127.0.0.1 ASN 2000    

<type 'exceptions.TypeError'>
json() got an unexpected keyword argument 'compact'
Traceback (most recent call last):
  File "/home/stac/.virtualenvs/exabgp-ryu/src/exabgp/lib/exabgp/reactor/peer.py", line 637, in _run
    for action in self._main(direction):
  File "/home/stac/.virtualenvs/exabgp-ryu/src/exabgp/lib/exabgp/reactor/peer.py", line 501, in _main
    for message in proto.read_message():
  File "/home/stac/.virtualenvs/exabgp-ryu/src/exabgp/lib/exabgp/reactor/protocol.py", line 222, in read_message
    self.peer.reactor.processes.message(msg_id,self.neighbor,'receive',message,'','')
  File "/home/stac/.virtualenvs/exabgp-ryu/src/exabgp/lib/exabgp/reactor/api/processes.py", line 250, in closure
    return function(self,*args)
  File "/home/stac/.virtualenvs/exabgp-ryu/src/exabgp/lib/exabgp/reactor/api/processes.py", line 281, in message
    self._dispatch[message_id](self,neighbor,direction,message,header,*body)
  File "/home/stac/.virtualenvs/exabgp-ryu/src/exabgp/lib/exabgp/reactor/api/processes.py", line 289, in wrap
    function(*args)
  File "/home/stac/.virtualenvs/exabgp-ryu/src/exabgp/lib/exabgp/reactor/api/processes.py", line 304, in _update
    self.write(process,self._encoder[process].update(peer,direction,update,header,body),peer)
  File "/home/stac/.virtualenvs/exabgp-ryu/src/exabgp/lib/exabgp/reactor/api/response/json.py", line 210, in update
    'message': '{ %s }' % self._update(update)
  File "/home/stac/.virtualenvs/exabgp-ryu/src/exabgp/lib/exabgp/reactor/api/response/json.py", line 178, in _update
    m += ', '.join('%s' % nlri.json(compact=self.compact) for nlri in nlris)
  File "/home/stac/.virtualenvs/exabgp-ryu/src/exabgp/lib/exabgp/reactor/api/response/json.py", line 178, in <genexpr>
    m += ', '.join('%s' % nlri.json(compact=self.compact) for nlri in nlris)
TypeError: json() got an unexpected keyword argument 'compact'
```

The second bug is an invalid json encoding of the flow update across the API.
```
Tue, 27 Sep 2016 18:25:31 EXABGP PROCESS 4350   { "exabgp": "3.5.0", "time": 1475015131.21, "host" : "archer", "pid" : 4344, "ppid" : 12836, "counter": 2, "type": "update", "neighbor": { "address": { "local": "127.0.0.2", "peer": "127.0.0.1" }, "asn": { "local": "1000", "peer": "2000" }, "direction": "receive", "message": { "update": { "attribute": { "origin": "igp", "as-path": [ 2000 ], "confederation-path": [], "extended-community": [ 9225060886715039744 ] }, "announce": { "ipv4 flow": { "no-nexthop": [ "flow-1": { "destination-ipv4": [ "10.2.0.0/16" ], "source-ipv4": [ "10.1.0.0/16" ], "protocol": [ "=udp" ], "string": "flow destination-ipv4 10.2.0.0/16 source-ipv4 10.1.0.0/16 protocol =udp" } ] } } } } } }
```
The dictionary contained in the ```"no-nexthop"``` list needs to be wrapped in ```{}```.

Submitting that malformed json snippet to [jsonlint.com](http://jsonlint.com/) results in:
```
Error: Parse error on line 29:
...-nexthop": ["flow-1": {							"destinat
-----------------------^
Expecting 'EOF', '}', ',', ']', got ':'
```

The attached config files for routers "R1" and "R2" are sufficient to reproduce both bugs.
[exabgp.r2.v4.conf.txt](https://github.com/Exa-Networks/exabgp/files/496786/exabgp.r2.v4.conf.txt)
[exabgp.r1.v4.conf.txt](https://github.com/Exa-Networks/exabgp/files/496785/exabgp.r1.v4.conf.txt)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/501)
<!-- Reviewable:end -->
