### PR TITLE
config: allow 'connect' option also in 'neighbor' scope in config

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,7 +6,9 @@ Version explained:
 Version 3.4.18
  * Fix: Configuration parser does not accept configs without neighbors.
     patch by doddt
-    
+ * Fix: 'connect' keyword is now also allowed in neighbor scope
+    patch by: Stacey Sheldon (Corsa)
+
 Version 3.4.17
  * Fix: does not accept IPv6 as router-id
     reported by: yuriya

--- a/lib/exabgp/configuration/ancient.py
+++ b/lib/exabgp/configuration/ancient.py
@@ -1516,7 +1516,7 @@ class Configuration (object):
 				],
 				[
 					'description','router-id','local-address','local-as','peer-as',
-					'passive','listen','hold-time','add-path','graceful-restart','md5',
+					'passive','listen','connect','hold-time','add-path','graceful-restart','md5',
 					'ttl-security','multi-session','group-updates','asn4','aigp',
 					'auto-flush','adj-rib-out','manual-eor',
 				]


### PR DESCRIPTION
The 'connect' config option is currently only allowed in the 'group' scope even though it is already inherited to be a per-neighbor attribute.  This patch allows it to appear directly in the 'neighbor' scope.

I think this was probably the original intention since (almost) every other attribute is the same between the [group scope](https://github.com/Exa-Networks/exabgp/blob/3.4/lib/exabgp/configuration/ancient.py#L1277) and the [neighbor scope](https://github.com/Exa-Networks/exabgp/blob/3.4/lib/exabgp/configuration/ancient.py#L1518).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/504)
<!-- Reviewable:end -->
