### PR TITLE
Fix ipv4 unicast eor json encoding

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -153,6 +153,8 @@ Version 4.0.0
    - encoding is now valid JSON
    - dropped auto-generated name for flowspec updates
    - format for flowspec updates is now a list of dicts where each dict contains a single flowspec rule
+ * Fix: API encoding of IPv4 Unicast EOR messages were being encoded as NLRI updates
+   patch by: Stacey Sheldon (Corsa)
 
 Version 3.4.10
  * Fix: Fix parsing attributes with PARTIAL flag set

--- a/lib/exabgp/bgp/message/update/__init__.py
+++ b/lib/exabgp/bgp/message/update/__init__.py
@@ -257,7 +257,7 @@ class Update (Message):
 
 		# This could be speed up massively by changing the order of the IF
 		if length == 4 and data == '\x00\x00\x00\x00':
-			return EOR(AFI.ipv4,SAFI.unicast,IN.ANNOUNCED)  # pylint: disable=E1101
+			return EOR(AFI.ipv4,SAFI.unicast)  # pylint: disable=E1101
 		if length == 11 and data.startswith(EOR.NLRI.PREFIX):
 			return EOR.unpack_message(data,negotiated)
 

--- a/lib/exabgp/bgp/message/update/__init__.py
+++ b/lib/exabgp/bgp/message/update/__init__.py
@@ -257,7 +257,7 @@ class Update (Message):
 
 		# This could be speed up massively by changing the order of the IF
 		if length == 4 and data == '\x00\x00\x00\x00':
-			return EOR(AFI.ipv4,SAFI.unicast)  # pylint: disable=E1101
+			return EOR(AFI(AFI.ipv4),SAFI(SAFI.unicast))  # pylint: disable=E1101
 		if length == 11 and data.startswith(EOR.NLRI.PREFIX):
 			return EOR.unpack_message(data,negotiated)
 


### PR DESCRIPTION
The IPv4 Unicast EOR messages were being serialized into invalid JSON across the API.  They were also being incorrectly serialized as an NLRI within an announce which differs from the encoding of EOR in all other AFIs/SAFIs so this embedding seems unintentional.

This patch set fixes the structure of the IPv4 unicast EOR to match the other families.  It also ensures that the string encoding of these EORs is provided over the API.  AFI/SAFI was being encoded as ints.

Old IPv4 EOR (invalid json, ints for AFI/SAFI)
```
...
		"message": {
			"update": {
				"announce": {
					"1 1": {
						"null": ["eor": {
							"afi": "1",
							"safi": "1"
						}]
					}
				}
			}
		}
...
```

New IPv4 EOR (valid json, strings for AFI/SAFI)
```
...
        "message": {
            "eor": {
                "afi": "ipv4", 
                "safi": "unicast"
            }
        }
...
```

IPv6 EOR for reference (unchanged in this patch set)
```
...
        "message": {
            "eor": {
                "afi": "ipv6", 
                "safi": "unicast"
            }
        }
...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/506)
<!-- Reviewable:end -->
