### PR TITLE
3.4

### DIFF
--- a/lib/exabgp/reactor/network/outgoing.py
+++ b/lib/exabgp/reactor/network/outgoing.py
@@ -32,7 +32,7 @@ class Outgoing (Connection):
 			async(self.io,peer)
 			if afi == AFI.ipv4:
 				TTL(self.io,peer,ttl)
-			else if afi == AFI.ipv6:
+			elif afi == AFI.ipv6:
 				TTLv6(self.io,peer,ttl)
 			connect(self.io,peer,port,afi,md5)
 			self.init = True

--- a/lib/exabgp/reactor/network/outgoing.py
+++ b/lib/exabgp/reactor/network/outgoing.py
@@ -1,9 +1,11 @@
+from exabgp.protocol.family import AFI
 from .connection import Connection
 from .tcp import create,bind
 from .tcp import connect
 from .tcp import MD5
 from .tcp import nagle
 from .tcp import TTL
+from .tcp import TTLv6
 from .tcp import async
 from .tcp import ready
 from .error import NetworkError
@@ -28,7 +30,10 @@ class Outgoing (Connection):
 			MD5(self.io,peer,port,md5)
 			bind(self.io,local,afi)
 			async(self.io,peer)
-			TTL(self.io,peer,ttl)
+			if afi == AFI.ipv4:
+				TTL(self.io,peer,ttl)
+			else if afi == AFI.ipv6:
+				TTLv6(self.io,peer,ttl)
 			connect(self.io,peer,port,afi,md5)
 			self.init = True
 		except NetworkError,exc:

--- a/lib/exabgp/reactor/network/tcp.py
+++ b/lib/exabgp/reactor/network/tcp.py
@@ -169,6 +169,12 @@ def TTL (io, ip, ttl):
 		except socket.error,exc:
 			raise TTLError('This OS does not support IP_TTL (ttl-security) for %s (%s)' % (ip,errstr(exc)))
 
+def TTLv6 (io, ip, ttl):
+	if ttl:
+		try:
+			io.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_UNICAST_HOPS, ttl)
+		except socket.error,exc:
+			raise TTLError('This OS does not support unicast_hops (ttl-security) for %s (%s)' % (pi,errstr(exc)))
 
 def async (io, ip):
 	try:


### PR DESCRIPTION
Fixed ttl-security option for IPv6.

The previous fix only worked on IPv4 and the program aborted if the ttl-security option was used on IPv6.

Now it uses the correct option for setsockopt() on IPv6, IPV6_UNICAST_HOPS rather than IP_TTL, which is only valid for IPv4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/517)
<!-- Reviewable:end -->
