### PR TITLE
Added ttl-security (now called outgoing-ttl) feature to IPv6.

### DIFF
--- a/lib/exabgp/reactor/network/outgoing.py
+++ b/lib/exabgp/reactor/network/outgoing.py
@@ -1,9 +1,11 @@
+from exabgp.protocol.family import AFI
 from .connection import Connection
 from .tcp import create,bind
 from .tcp import connect
 from .tcp import MD5
 from .tcp import nagle
 from .tcp import TTL
+from .tcp import TTLv6
 from .tcp import async
 from .tcp import ready
 from .error import NetworkError
@@ -26,7 +28,10 @@ class Outgoing (Connection):
 		try:
 			self.io = create(afi)
 			MD5(self.io,peer,port,md5)
-			TTL(self.io, peer, self.ttl)
+			if afi == AFI.ipv4:
+				TTL(self.io, peer, self.ttl)
+			elif afi == AFI.ipv6:
+				TTLv6(self.io, peer, self.ttl)
 			bind(self.io,local,afi)
 			async(self.io,peer)
 			connect(self.io,peer,port,afi,md5)

--- a/lib/exabgp/reactor/network/tcp.py
+++ b/lib/exabgp/reactor/network/tcp.py
@@ -170,6 +170,14 @@ def TTL (io, ip, ttl):
 			raise TTLError('This OS does not support IP_TTL (ttl-security) for %s (%s)' % (ip,errstr(exc)))
 
 
+def TTLv6 (io, ip, ttl):
+	if ttl:
+		try:
+			io.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_UNICAST_HOPS, ttl)
+		except socket.error,exc:
+			raise TTLError('This OS does not support unicast_hops (ttl-security) for %s (%s)' % (ip,errstr(exc)))
+
+
 def MIN_TTL (io, ip, ttl):
 	# None (ttl-security unset) or zero (maximum TTL) is the same thing
 	if ttl:


### PR DESCRIPTION
Support for outgoing-ttl (previously known as ttl-security).

Should we add some warning for the deprecated "ttl-security" option? Or maybe it would be a good idea to accept ttl-security as an equivalent to outgoing-ttl *and* log a warning about a deprecated option?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/520)
<!-- Reviewable:end -->
