### PR TITLE
Update the families in the rib cache with the currently configured families

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -14,6 +14,8 @@ Version 3.4.18
     reported by: Colin Petrie
  * Change: default to a 0 offset for ipv6 flowspec source/destination match
     patch by: Brian Johnson
+ * Fix: Update RIB cache families on configuration reload
+    patch by: Brian Johnson
 
 Version 3.4.17
  * Fix: does not accept IPv6 as router-id

--- a/lib/exabgp/rib/__init__.py
+++ b/lib/exabgp/rib/__init__.py
@@ -22,6 +22,12 @@ class RIB (object):
 		if name in self._cache:
 			self.incoming = self._cache[name].incoming
 			self.outgoing = self._cache[name].outgoing
+			self.incoming.families = families
+			self.outgoing.families = families
+			for family in self.outgoing._seen.keys():
+				if family not in families:
+					del self.outgoing._seen[family]
+
 			if adjribout:
 				self.outgoing.resend(None,False)
 			else:


### PR DESCRIPTION
When doing a config reload existing neighbors will use their cached RIB instead of creating a new one, however the families associated with that rib are not currently being updated.  

This was causing problems if after the reload the neighbor had added a new family. In our case we went from only supporting ipv4/unicast to supporting ipv4/unicast and ipv6/unicast. Since the cached rib from before the reload only supported ipv4/unicast, we ended up in a situation where we could announce ipv6/unicast routes and they would be sent to the remote router over the wire but when doing using the show routes api exabgp would not list any ipv6 routes since it filters out any families not supported by the rib.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/531)
<!-- Reviewable:end -->
