### PR TITLE
Update the families in the rib cache with the currently configured families (master)

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -152,6 +152,8 @@ Version 4.0.0
    patch by: Stacey Sheldon (Corsa)
  * Fix: API encoding of IPv4 Unicast EOR messages were being encoded as NLRI updates
    patch by: Stacey Sheldon (Corsa)
+ * Fix: Update RIB cache families on configuration reload
+    patch by: Brian Johnson
 
 Version 3.4.10
  * Fix: Fix parsing attributes with PARTIAL flag set

--- a/lib/exabgp/rib/__init__.py
+++ b/lib/exabgp/rib/__init__.py
@@ -22,6 +22,12 @@ class RIB (object):
 		if name in self._cache:
 			self.incoming = self._cache[name].incoming
 			self.outgoing = self._cache[name].outgoing
+			self.incoming.families = families
+			self.outgoing.families = families
+			for family in self.outgoing._seen.keys():
+				if family not in families:
+					del self.outgoing._seen[family]
+
 			if adjribout:
 				self.outgoing.resend(None,False)
 			else:


### PR DESCRIPTION
This forwards ports #531 to master

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/532)
<!-- Reviewable:end -->
