### PR TITLE
Fix pidfile readline issue and invalid fd on nonrunning process

### DIFF
--- a/lib/exabgp/reactor/daemon.py
+++ b/lib/exabgp/reactor/daemon.py
@@ -65,10 +65,13 @@ class Daemon (object):
 			fd = os.open(self.pid,flags,mode)
 		except OSError:
 			try:
-				pid = open(self.pid,'r').read().readline()
+				pid = open(self.pid,'r').readline()
 				if self.check_pid(int(pid)):
 					self.logger.daemon("PIDfile already exists and program still running %s" % self.pid)
 					return False
+				else:
+					# If pid is not running, reopen file without O_EXCL				
+					fd = os.open(self.pid,flags ^ os.O_EXCL,mode)				
 			except (OSError,IOError,ValueError):
 				pass
 


### PR DESCRIPTION
Hi @thomas-mangin 

This fixes 2 issues with the new pidfile code where:

1) Pidfile exists and we attempt to `.readline()` on an already-read string
2) Pidfile exists but `check_pid` returns false (process not running i.e. stale) - we do nothing, and later code expects `fd` to be set to the pidfile but it isn't.

Quick tests indicate this works effectively to detect stale pidfiles.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/534)
<!-- Reviewable:end -->
