### PR TITLE
When group-updates is enabled, send one UPDATE per address family

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,8 @@ Version 3.4.18
     reported by: Ben Agricola
  * Fix: Update RIB cache families on configuration reload
     patch by: Brian Johnson
+ * Fix: When group-updates is enabled, send one UPDATE per address family
+    patch by: Brian Johnson
 
 Version 3.4.17
  * Fix: does not accept IPv6 as router-id

--- a/lib/exabgp/rib/store.py
+++ b/lib/exabgp/rib/store.py
@@ -241,19 +241,17 @@ class Store (object):
 			# we NEED the copy provided by list() here as insert_announced can be called while we iterate
 			changed = list(dict_change.itervalues())
 
-			for family in self._seen:
-				if family != (AFI.ipv4,SAFI.unicast):
-					grouped = False
-
 			if grouped:
-				update = Update([dict_nlri[nlri_index].nlri for nlri_index in dict_change],attributes)
+				updates = {}
 				for change in changed:
+					updates.setdefault(change.nlri.family(), []).append(change.nlri)
 					nlri_index = change.index()
 					del dict_sorted[attr_index][nlri_index]
 					del dict_nlri[nlri_index]
 				# only yield once we have a consistent state, otherwise it will go wrong
 				# as we will try to modify things we are using
-				yield update
+				for nlris in updates.itervalues():
+					yield Update(nlris, attributes)
 			else:
 				updates = []
 				for change in changed:


### PR DESCRIPTION
Currently exabgp is disabling group-updates when sending non ipv4/unicast families to prevent more then one MP_REACH/MP_UNREACH attribute from appearing in the UPDATE message. 

With this fix instead of creating a separate UPDATE message for each NLRI when we have group-updates enabled, we will instead create a single UPDATE for each family in our list of NLRIs.  This should still prevent duplicate path attributes, but also allow  grouping of announcements and withdrawals were possible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/535)
<!-- Reviewable:end -->
