### PR TITLE
Read and discard command confirmation from exabgp

### DIFF
--- a/lib/exabgp/application/healthcheck.py
+++ b/lib/exabgp/application/healthcheck.py
@@ -455,8 +455,10 @@ def loop(options):
                         options.as_path)
             logger.debug("exabgp: %s %s", command, announce)
             print("{0} {1}".format(command, announce))
+            # Flush command and wait for confirmation from ExaBGP
+            sys.stdout.flush()
+            sys.stdin.readline()
             metric += options.increase
-        sys.stdout.flush()
 
     def trigger(target):
         """Trigger a state change and execute the appropriate commands"""


### PR DESCRIPTION
Now that ExaBGP responds to commands with `done\n`, it's possible for ExaBGP + healthcheck.py to get stuck unless healthcheck.py reads the response to announces / withdrawls from ExaBGP.

This simply reads the contents of stdin on the healthcheck process after sending commands to ExaBGP to make sure ExaBGP doesn't get stuck trying to write output to healthcheck which it isn't accepting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/539)
<!-- Reviewable:end -->
