### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -338,7 +338,7 @@ setup(
 	package_data={'': ['PYPI.rst']},
 	download_url='https://github.com/Exa-Networks/exabgp/archive/%s.tar.gz' % version,
 	data_files=files_definition,
-	install_requires=['setuptools'],
+	setup_requires=['setuptools'],
 	classifiers=[
 		'Development Status :: 5 - Production/Stable',
 		'Environment :: Console',


### PR DESCRIPTION
Installing exabgp from source, or building a tarball or wheel requires setuptools. However, setuptools is NOT required when installing a pre-built wheel of exabgp on a target system. This small patch corrects this mistake in the setup.py script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/546)
<!-- Reviewable:end -->
