### PR TITLE
Fixed invalid FSM constant in state table

### DIFF
--- a/lib/exabgp/reactor/peer.py
+++ b/lib/exabgp/reactor/peer.py
@@ -299,7 +299,7 @@ class Peer (object):
 	def detailed_link_status (self):
 		state_tbl = {
 			FSM.IDLE : "Idle",
-			FSN.ACTIVE : "Active",
+			FSM.ACTIVE : "Active",
 			FSM.CONNECT : "Connect",
 			FSM.OPENSENT : "OpenSent",
 			FSM.OPENCONFIRM : "OpenConfirm",


### PR DESCRIPTION
Noticed a typo in exabgp/lib/reactor/peer.py:detailed_link_status

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/552)
<!-- Reviewable:end -->
