### PR TITLE
Allow parsing a text string in Configuration class

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -154,6 +154,8 @@ Version 4.0.0
    patch by: Stacey Sheldon (Corsa)
  * Fix: Update RIB cache families on configuration reload
     patch by: Brian Johnson
+ * Feature: Allow configuration parsing of a string or a file
+    patch by: Brian Johnson
 
 Version 3.4.10
  * Fix: Fix parsing attributes with PARTIAL flag set

--- a/lib/exabgp/configuration/configuration.py
+++ b/lib/exabgp/configuration/configuration.py
@@ -88,11 +88,12 @@ class _Configuration (object):
 
 class Configuration (_Configuration):
 
-	def __init__ (self, configurations):
+	def __init__ (self, configurations, text=False):
 		_Configuration.__init__(self)
 		self.api_encoder = environment.settings().api.encoder
 
 		self._configurations = configurations
+		self._text = text
 
 		self.error  = Error  ()
 		self.scope  = Scope  ()
@@ -335,8 +336,12 @@ class Configuration (_Configuration):
 		# clearing the current configuration to be able to re-parse it
 		self._clear()
 
-		if not self.tokeniser.set_file(fname):
-			return False
+		if self._text:
+			if not self.tokeniser.set_text(fname):
+				return False
+		else:
+			if not self.tokeniser.set_file(fname):
+				return False
 
 		if self.section('root') is not True:
 			# XXX: Should it be in neighbor ?


### PR DESCRIPTION

Version 3.4.x supported configuration parsing using a string instead of a file. This adds support in the 4.x branch for the same. This is useful to parse the output of show neighbors command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/556)
<!-- Reviewable:end -->
