### PR TITLE
Make the output of show neighbors parsable by exabgp

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -154,6 +154,8 @@ Version 4.0.0
    patch by: Stacey Sheldon (Corsa)
  * Fix: Update RIB cache families on configuration reload
     patch by: Brian Johnson
+ * Change: Update show neighbors output to be parseable by configuration parser
+    patch by: Brian Johnson
 
 Version 3.4.10
  * Fix: Fix parsing attributes with PARTIAL flag set

--- a/lib/exabgp/bgp/neighbor.py
+++ b/lib/exabgp/bgp/neighbor.py
@@ -228,12 +228,12 @@ class Neighbor (object):
 			'\tpeer-as %s;\n' \
 			'\thold-time %s;\n' \
 			'\tmanual-eor %s;\n' \
-			'%s%s%s%s%s%s%s%s%s\n' \
+			'%s%s%s%s%s%s%s%s%s%s\n' \
 			'\tcapability {\n' \
-			'%s%s%s%s%s%s%s%s\t}\n' \
+			'%s%s%s%s%s%s%s\t}\n' \
 			'\tfamily {%s\n' \
 			'\t}\n' \
-			'\tprocess {\n' \
+			'\tapi {\n' \
 			'%s%s\t}%s\n' \
 			'}' % (
 				self.peer_address,
@@ -246,16 +246,16 @@ class Neighbor (object):
 				self.peer_as,
 				self.hold_time,
 				'true' if self.manual_eor else 'false',
-				'\n\tpassive;\n' if self.passive else '',
+				'\n\tpassive %s;\n' % ('true' if self.passive else 'false'),
 				'\n\tlisten %d;\n' % self.listen if self.listen else '',
 				'\n\tconnect %d;\n' % self.connect if self.connect else '',
-				'\tgroup-updates %s;\n' % (self.group_updates if self.group_updates else ''),
+				'\tgroup-updates %s;\n' % ('true' if self.group_updates else 'false'),
 				'\tauto-flush %s;\n' % ('true' if self.flush else 'false'),
 				'\tadj-rib-out %s;\n' % ('true' if self.adjribout else 'false'),
 				'\tmd5-password "%s";\n' % self.md5_password if self.md5_password else '',
 				'\tmd5-ip "%s";\n' % self.md5_ip if self.md5_ip else '',
-				'\toutgoing-ttl %s;\n' % (self.ttl_out if self.ttl_out else ''),
-				'\tincoming-ttl %s;\n' % (self.ttl_in if self.ttl_in else ''),
+				'\toutgoing-ttl %s;\n' % self.ttl_out if self.ttl_out else '',
+				'\tincoming-ttl %s;\n' % self.ttl_in if self.ttl_in else '',
 				'\t\tasn4 %s;\n' % ('enable' if self.asn4 else 'disable'),
 				'\t\troute-refresh %s;\n' % ('enable' if self.route_refresh else 'disable'),
 				'\t\tgraceful-restart %s;\n' % (self.graceful_restart if self.graceful_restart else 'disable'),

--- a/lib/exabgp/configuration/neighbor/__init__.py
+++ b/lib/exabgp/configuration/neighbor/__init__.py
@@ -46,10 +46,12 @@ def _hostname ():
 
 
 def _domainname ():
-	value = socket.gethostname()
-	if not value:
+	value = socket.getfqdn()
+	domainname = '.'.join(value.split('.')[1:])
+	if not domainname:
 		return 'localdomain'
-	return ''.join(value.split('.')[1:])
+	return domainname
+
 
 
 class ParseNeighbor (Section):
@@ -60,8 +62,8 @@ class ParseNeighbor (Section):
 	known = {
 		'inherit':       inherit,
 		'description':   description,
-		'hostname':      hostname,
-		'domainname':    domainname,
+		'host-name':     hostname,
+		'domain-name':   domainname,
 		'router-id':     router_id,
 		'hold-time':     hold_time,
 		'local-address': ip,
@@ -84,8 +86,8 @@ class ParseNeighbor (Section):
 	action = {
 		'inherit':       'set-command',
 		'description':   'set-command',
-		'hostname':      'set-command',
-		'domainname':    'set-command',
+		'host-name':     'set-command',
+		'domain-name':   'set-command',
 		'router-id':     'set-command',
 		'hold-time':     'set-command',
 		'local-address': 'set-command',


### PR DESCRIPTION
The current version of the show neighbors api output is  not parsable by ExaBGP's own Configuration class. This patch fixes the issues I was able to find so that it can be parsed correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/557)
<!-- Reviewable:end -->
