### PR TITLE
Don't always add ipv4/unicast family

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -154,6 +154,8 @@ Version 4.0.0
    patch by: Stacey Sheldon (Corsa)
  * Fix: Update RIB cache families on configuration reload
     patch by: Brian Johnson
+ * Fix: Do not add IPv4/unicast family unless specifically configured
+    patch by: Brian Johnson
 
 Version 3.4.10
  * Fix: Fix parsing attributes with PARTIAL flag set

--- a/lib/exabgp/configuration/neighbor/__init__.py
+++ b/lib/exabgp/configuration/neighbor/__init__.py
@@ -178,9 +178,6 @@ class ParseNeighbor (Section):
 
 		families = families or NLRI.known_families()
 
-		if (AFI.ipv4,SAFI.unicast) not in families:
-			families.append((AFI(AFI.ipv4),SAFI(SAFI.unicast)))
-
 		for family in families:
 			neighbor.add_family(family)
 


### PR DESCRIPTION
Currently ExaBGP seems to be adding the IPv4/unicast family even when not requested to the list of supported families.  There does not seem to be a good reason for this and it can cause unexpected results, so this removed the lines of code responsible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/558)
<!-- Reviewable:end -->
