### PR TITLE
The md5-ip config options should be an IP address not a RouterID

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -164,6 +164,8 @@ Version 4.0.0
     patch by: Brian Johnson
  * Fix: Off by one error when getting message type for send-* api
     patch by: Brian Johnson
+ * Fix: md5-ip config option is an ip address not a router_id
+    patch by: Brian Johnson
 
 Version 3.4.10
  * Fix: Fix parsing attributes with PARTIAL flag set

--- a/lib/exabgp/configuration/neighbor/__init__.py
+++ b/lib/exabgp/configuration/neighbor/__init__.py
@@ -76,7 +76,7 @@ class ParseNeighbor (Section):
 		'outgoing-ttl':  ttl,
 		'incoming-ttl':  ttl,
 		'md5-password':  md5,
-		'md5-ip':        router_id,
+		'md5-ip':        ip,
 		'group-updates': boolean,
 		'auto-flush':    boolean,
 		'adj-rib-out':   boolean,


### PR DESCRIPTION
When this is defined as a router_id a parse error will be generated if an IPv6 address is specified.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/563)
<!-- Reviewable:end -->
