### PR TITLE
Fix string representation of te-rid

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/bgpls/link/rterid.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/link/rterid.py
@@ -25,7 +25,7 @@ class RemoteTeRid(object):
 		self.terid = terid
 
 	def __repr__ (self):
-		return "Remote TE Router ID: %s" % (self.terid.string)
+		return "Remote TE Router ID: %s" % (self.terid)
 
 	@classmethod
 	def unpack (cls,data,length):

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/ospfaddr.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/ospfaddr.py
@@ -30,7 +30,7 @@ class OspfForwardingAddress(object):
 		self.addr = addr
 
 	def __repr__ (self):
-		return "Ospf forwarding address: '%s'" % (self.addr.string)
+		return "Ospf forwarding address: '%s'" % (self.addr)
 
 	@classmethod
 	def unpack (cls,data,length):


### PR DESCRIPTION
This commit fixes the string representation of an IP object for IPv4 and TE Router ID objects.


(exabgp)evila@obmp:~/exabgp$ exabgp -d config.ini --decode "0000 0077 900E 0053 4004 4704 AC10 FF0A 0000 0200 4602 0000 0000 0000 0000 0100 001B 0200 0004 0000 FEB0 0201 0004 AC10 FF0A 0203 0007 2232 0204 9003 0101 0100 1A02 0000 0400 00FE B002 0100 04AC 10FF 0A02 0300 0622 3202 0490 0340 0101 0040 0200 4005 0400 0000 6480 1D0F 0406 0004 AC10 FF02 0447 0003 0000 00"
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | environment file missing
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | generate it using "exabgp --fi > /home/evila/exabgp/exabgp/etc/exabgp/exabgp.env"
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | reactor       | performing reload of exabgp 4.0.0
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | > process          | 'parsed-route-backend'
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | . run              | '/home/evila/exabgp/etc/exabgp/processes/file.py'
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | . encoder          | 'json'
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | < process          | 
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | > neighbor         | '172.24.248.52'
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | . local-address    | '172.24.248.5'
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | . local-as         | '65050'
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | . peer-as          | '65000'
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | > family           | 
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | . bgpls            | 'bgp-ls'
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | < family           | 
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | > api              | 
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | . processes        | '[' 'parsed-route-backend' ']'
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | > receive          | 
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | . parsed           | 
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | . update           | 
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | < receive          | 
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | < api              | 
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | configuration | < neighbor         | 
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | 
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | decoding routes in configuration
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | header missing, assuming this message is ONE update
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | parsing UPDATE ( 123) 0000 0077 900E 0053 4004 4704 AC10 FF0A 0000 0200 4602 0000 0000 0000 0000 0100 001B 0200 0004 0000 FEB0 0201 0004 AC10 FF0A 0203 0007 2232 0204 9003 0101 0100 1A02 0000 0400 00FE B002 0100 04AC 10FF 0A02 0300 0622 3202 0490 0340 0101 0040 0200 4005 0400 0000 6480 1D0F 0406 0004 AC10 FF02 0447 0003 0000 00
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | withdrawn NLRI none
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | attribute mp-reach-nlri      flag 0x90 type 0x0e len 0x53 payload 4004 4704 AC10 FF0A 0000 0200 4602 0000 0000 0000 0000 0100 001B 0200 0004 0000 FEB0 0201 0004 AC10 FF0A 0203 0007 2232 0204 9003 0101 0100 1A02 0000 0400 00FE B002 0100 04AC 10FF 0A02 0300 0622 3202 0490 03
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | NLRI      bgpls bgp-ls       without path-information     payload 0002 0046 0200 0000 0000 0000 0001 0000 1B02 0000 0400 00FE B002 0100 04AC 10FF 0A02 0300 0722 3202 0490 0301 0101 001A 0200 0004 0000 FEB0 0201 0004 AC10 FF0A 0203 0006 2232 0204 9003
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | attribute origin             flag 0x40 type 0x01 len 0x01 payload 00
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | attribute as-path            flag 0x40 type 0x02 len 0x00
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | attribute local-preference   flag 0x40 type 0x05 len 0x04 payload 0000 0064
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | attribute bgp-ls             flag 0x80 type 0x1d len 0x0f payload 0406 0004 AC10 FF02 0447 0003 0000 00
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | announced NLRI none
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | 
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | decoded update 1 { "ls-nlri-type": 2, "l3-routing-toplogy": "0", "protocol-id": 2, "local-node-descriptors": { "autonomous-system": "65200", "bgp-ls-identifier": "2886795018", "psn": "1", "router-id": "223202049003" }, "remote-node-descriptors": { "autonomous-system": "65200", "bgp-ls-identifier": "2886795018", "router-id": "223202049003" }, "interface-address": {  }, "neighbor-address": {  } } origin igp local-preference 100 bgp-ls Remote TE Router ID: 172.16.255.2, TE Default Metric: [0]
Thu, 05 Jan 2017 17:14:08 | INFO     | 11407  | parser        | update json { "exabgp": "3.5.0", "time": 1483665248.13, "host" : "obmp", "pid" : 11407, "ppid" : 11086, "counter": 1, "type": "update", "neighbor": { "address": { "local": "172.24.248.5", "peer": "172.24.248.52" }, "asn": { "local": "65050", "peer": "65000" }, "direction": "in", "message": { "update": { "attribute": { "origin": "igp", "local-preference": 100, "bgp-ls": { "remote-te-router-id": "172.16.255.2", "igp-metric": "0" } }, "announce": { "bgpls bgp-ls": { "172.16.255.10": [ { "ls-nlri-type": 2, "l3-routing-toplogy": "0", "protocol-id": 2, "local-node-descriptors": { "autonomous-system": "65200", "bgp-ls-identifier": "2886795018", "psn": "1", "router-id": "223202049003" }, "remote-node-descriptors": { "autonomous-system": "65200", "bgp-ls-identifier": "2886795018", "router-id": "223202049003" }, "interface-address": {  }, "neighbor-address": {  } } ] } } } } } }

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/564)
<!-- Reviewable:end -->
