### PR TITLE
Fix Update.messages so that it won't generate invalid UPDATEs

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -168,6 +168,8 @@ Version 4.0.0
     patch by: Brian Johnson
  * Feature: Show routes by type (static/flow/l2vpn)
     patch by: Brian Johnson
+ * Fix: Rewrite Update.messages so it will only include one MP_REACH or MP_UNREACH per UPDATE
+    patch by: Brian Johnson
 
 Version 3.4.10
  * Fix: Fix parsing attributes with PARTIAL flag set

--- a/lib/exabgp/bgp/message/update/attribute/mpurnlri.py
+++ b/lib/exabgp/bgp/message/update/attribute/mpurnlri.py
@@ -17,7 +17,7 @@ from exabgp.bgp.message.update.attribute.attribute import Attribute
 from exabgp.bgp.message.update.nlri import NLRI
 
 from exabgp.bgp.message.notification import Notify
-
+from exabgp.bgp.message.open.capability import Negotiated
 
 # ================================================================= MP NLRI (14)
 
@@ -41,29 +41,31 @@ class MPURNLRI (Attribute,Family):
 	def __ne__ (self, other):
 		return not self.__eq__(other)
 
-	def packed_attributes (self, negotiated):
+	def packed_attributes (self, negotiated, maximum=Negotiated.FREE_SIZE):
 		if not self.nlris:
 			return
 
 		# we changed the API to nrli.pack from addpath to negotiated but not pack itself
-		maximum = negotiated.FREE_SIZE
 
-		mpurnlri = {}
+		mpurnlri = []
 		for nlri in self.nlris:
-			mpurnlri.setdefault((nlri.afi.pack(),nlri.safi.pack()),[]).append(nlri.pack(negotiated))
-
-		for (pafi,psafi),nlris in mpurnlri.iteritems():
-			payload = pafi + psafi + ''.join(nlris)
-
-			if self._len(payload) <= maximum:
-				yield self._attribute(payload)
+			if nlri.family() != self.family(): # nlri is not part of specified family
 				continue
+			mpurnlri.append(nlri.pack(negotiated))
 
-			# This will not generate an optimum update size..
-			# we should feedback the maximum on each iteration
-
-			for nlri in nlris:
-				yield self._attribute(pafi + psafi + nlri)
+		payload = ''.join([self.afi.pack(), self.safi.pack()])
+		header_length = len(payload)
+		for nlri in mpurnlri:
+			if self._len(payload + nlri) > maximum:
+				if len(payload) == header_length or len(payload) > maximum:
+					raise Notify(6, 0, 'attributes size is so large we can not even pack on MPURNLRI')
+				yield self._attribute(payload)
+				payload = ''.join([self.afi.pack(), self.safi.pack(), nlri])
+				continue
+			payload = ''.join([payload, nlri])
+		if len(payload) == header_length or len(payload) > maximum:
+			raise Notify(6, 0, 'attributes size is so large we can not even pack on MPURNLRI')
+		yield self._attribute(payload)
 
 	def pack (self, negotiated):
 		return ''.join(self.packed_attributes(negotiated))


### PR DESCRIPTION
This is revisiting the issue with sending an UPDATE message that contains multiple MP_REACH or MP_UNREACH attributes.

During some of our testing we encountered another way in which the current code allows this to happen. If you send enough nlris before sending a route flush (in our case we got this to happen using auto flush while handling a route refresh), the current code will determine that all of the nlris can't fit inside a single UPDATE message and end generating multiple mpreach attributes with a single nlri. These then get packed into one or more UPDATE messages which is invalid.


This code rewrites how UPDATE messages are generated so that it never sticks more then one MP_(UN)REACH attribute in a single UPDATE.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/566)
<!-- Reviewable:end -->
