### PR TITLE
not to terminate never created processes

### DIFF
--- a/lib/exabgp/reactor/api/processes.py
+++ b/lib/exabgp/reactor/api/processes.py
@@ -141,7 +141,7 @@ class Processes (object):
 
 	def start (self, restart=False):
 		for process in self.reactor.configuration.processes:
-			if restart:
+			if restart and process in list(self._process):
 				self._terminate(process)
 			self._start(process)
 		for process in list(self._process):


### PR DESCRIPTION
When USR2 is sent after configuration file which has been updated with additional process(es) causes exabgp to cause because _terminate() to throw a 'KeyError' exception

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/569)
<!-- Reviewable:end -->
