### PR TITLE
Change references to BGP Large Communities

### DIFF
--- a/doc/man/exabgp.1
+++ b/doc/man/exabgp.1
@@ -360,8 +360,8 @@ implemented is:
 .Bl -hang -width 10m -compact
 .It RFC 1997
 BGP Communities Attribute
-.It draft-heitz-idr-large-community-03
-Large BGP Communities Attribute
+.It RFC 8092
+BGP Large Communities Attribute
 .It RFC 2385
 Protection of BGP Sessions via the TCP MD5 Signature
 .It RFC 2545

--- a/lib/exabgp/bgp/message/update/attribute/community/large/community.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/large/community.py
@@ -1,7 +1,7 @@
 # encoding: utf-8
 """
 
-Support for draft-heitz-idr-large-community-03
+Support for RFC 8092
 
 Copyright (c) 2016 Job Snijders <job@ntt.net>
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.


### PR DESCRIPTION
Since the RFC has now been published as RFC 8092, these should probably
be updated.

Signed-off-by: Mandar Gokhale <mandarg@mandarg.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/576)
<!-- Reviewable:end -->
