### PR TITLE
Correct typo in usage.py

### DIFF
--- a/lib/exabgp/configuration/usage.py
+++ b/lib/exabgp/configuration/usage.py
@@ -88,7 +88,7 @@ For example :
       exabgp.log.destination=host:127.0.0.1 \\
       exabgp.daemon.user=wheel \\
       exabgp.daemon.daemonize=true \\
-      exabgp.daemon.pid=/var/run/exabpg.pid \\
+      exabgp.daemon.pid=/var/run/exabgp.pid \\
  > ./bin/exabgp ./etc/bgp/configuration.txt
 
 The program configuration can be controlled using signals:


### PR DESCRIPTION
exabgp.daemon.pid=/var/run/exabpg.pid -> exabgp.daemon.pid=/var/run/exabgp.pid

License: BSD-3-Clause
Signed-off-by: Frank Petrilli <frank@petril.li>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/578)
<!-- Reviewable:end -->
