### PR TITLE
Include the IP prefix length in JSON output and fix error message output

### DIFF
--- a/lib/exabgp/bgp/message/update/nlri/evpn/prefix.py
+++ b/lib/exabgp/bgp/message/update/nlri/evpn/prefix.py
@@ -153,7 +153,7 @@ class Prefix (EVPN):
 			gwip = IP.unpack(data[:16])
 			data = data[16:]
 		else:
-			raise Notify(3,5,"Data field length is given as %d, but EVPN route currently support only IPv4 or IPv6(34 or 58)" % iplen)
+			raise Notify(3,5,"Data field length is given as %d, but EVPN route currently support only IPv4 or IPv6(34 or 58)" % datalen)
 
 		label = Labels.unpack(data[:3])
 

--- a/lib/exabgp/bgp/message/update/nlri/evpn/prefix.py
+++ b/lib/exabgp/bgp/message/update/nlri/evpn/prefix.py
@@ -169,5 +169,6 @@ class Prefix (EVPN):
 		content += '%s, ' % self.etag.json()
 		content += '%s, ' % self.label.json()
 		content += '"ip": "%s", ' % str(self.ip)
+		content += '"iplen": %d, ' % self.iplen
 		content += '"gateway": "%s" ' % str(self.gwip)
 		return '{%s}' % content


### PR DESCRIPTION
The JSON output for IP Prefix Advertisements (type 5) now includes the prefix length (integer)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/579)
<!-- Reviewable:end -->
