### PR TITLE
Spelling fix in usage.py

### DIFF
--- a/lib/exabgp/configuration/usage.py
+++ b/lib/exabgp/configuration/usage.py
@@ -46,7 +46,7 @@ debugging:
   --debug, -d           start the python debugger on serious logging and on
                         SIGTERM (shortcut for exabgp.log.all=true
                         exabgp.log.level=DEBUG)
-  --signal TIME         issue a SIGUSR1 to reload the configuraiton after
+  --signal TIME         issue a SIGUSR1 to reload the configuration after
                         <time> seconds, only useful for code debugging
   --once, -1            only perform one attempt to connect to peers (used for
                         debugging)


### PR DESCRIPTION
Quick spelling fix. "configuraiton" -> "configuration".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/582)
<!-- Reviewable:end -->
