### PR TITLE
Misc filename header fixes and typos

### DIFF
--- a/lib/exabgp/__main__.py
+++ b/lib/exabgp/__main__.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-__init__.py
+__main__.py
 
 Created by Thomas Mangin on 2010-01-15.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/application/bgp.py
+++ b/lib/exabgp/application/bgp.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-exabgp.py
+bgp.py
 
 Created by Thomas Mangin on 2009-08-30.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.
@@ -296,9 +296,9 @@ def run (env, comment, configurations, pid=0):
 
 	notice = ''
 	if os.path.isdir(profile_name):
-		notice = 'profile can not use this filename as outpout, it is not a directory (%s)' % profile_name
+		notice = 'profile can not use this filename as output, it is not a directory (%s)' % profile_name
 	if os.path.exists(profile_name):
-		notice = 'profile can not use this filename as outpout, it already exists (%s)' % profile_name
+		notice = 'profile can not use this filename as output, it already exists (%s)' % profile_name
 
 	if not notice:
 		logger.reactor('profiling ....')

--- a/lib/exabgp/application/bmp.py
+++ b/lib/exabgp/application/bmp.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 """
-peer.py
+bmp.py
 
 Created by Thomas Mangin on 2013-02-20.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/application/tojson.py
+++ b/lib/exabgp/application/tojson.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # encoding: utf-8
 """
-parser.py
+tojson.py
 
 Created by Thomas Mangin on 2014-12-22.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/direction.py
+++ b/lib/exabgp/bgp/message/direction.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-state.py
+direction.py
 
 Created by Thomas Mangin on 2010-01-15.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/message.py
+++ b/lib/exabgp/bgp/message/message.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-update/__init__.py
+message.py
 
 Created by Thomas Mangin on 2010-01-15.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/open/__init__.py
+++ b/lib/exabgp/bgp/message/open/__init__.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-open.py
+__init__.py
 
 Created by Thomas Mangin on 2009-11-05.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/operational.py
+++ b/lib/exabgp/bgp/message/operational.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-operational/__init__.py
+operational.py
 
 Created by Thomas Mangin on 2013-09-01.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/__init__.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/__init__.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-community.py
+__init__.py
 
 Created by Thomas Mangin on 2009-11-05.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/communities.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/communities.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-community.py
+communities.py
 
 Created by Thomas Mangin on 2009-11-05.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/l2info.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/l2info.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-encapsulation.py
+l2info.py
 
 Created by Thomas Mangin on 2014-06-20.
 Copyright (c) 2014-2015 Orange. All rights reserved.

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/traffic.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/traffic.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-encapsulation.py
+traffic.py
 
 Created by Thomas Mangin on 2014-06-21.
 Copyright (c) 2014-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/update/attribute/localpref.py
+++ b/lib/exabgp/bgp/message/update/attribute/localpref.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-attributes.py
+localpref.py
 
 Created by Thomas Mangin on 2009-11-05.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/update/attribute/origin.py
+++ b/lib/exabgp/bgp/message/update/attribute/origin.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-attributes.py
+origin.py
 
 Created by Thomas Mangin on 2009-11-05.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/update/attribute/pmsi.py
+++ b/lib/exabgp/bgp/message/update/attribute/pmsi.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-pmsi_tunnel.py
+pmsi.py
 
 Created by Thomas Morin on 2014-06-10.
 Copyright (c) 2014-2015 Orange. All rights reserved.

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/link.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/link.py
@@ -1,5 +1,5 @@
 """
-node.py
+link.py
 
 Created by Evelio Vila on 2016-11-26. eveliovila@gmail.com
 Copyright (c) 2009-2016 Exa Networks. All rights reserved.
@@ -167,7 +167,7 @@ class LINK(BGPLS):
 		interface_addrs = ', '.join(d.json() for d in self.iface_addrs)
 		neighbor_addrs = ', '.join(d.json() for d in self.neigh_addrs)
 		content = '"ls-nlri-type": 2, '
-		content += '"l3-routing-toplogy": "%s", ' % self.domain
+		content += '"l3-routing-topology": "%s", ' % self.domain
 		content += '"protocol-id": %d, ' % self.proto_id
 		content += '"local-node-descriptors": { %s }, ' % local
 		content += '"remote-node-descriptors": { %s }, ' % remote

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/node.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/node.py
@@ -56,7 +56,7 @@ class NODE(BGPLS):
 		nodes = ', '.join(d.json() for d in self.node_ids)
 		content = ', '.join([
 			'"ls-nlri-type": 1',
-			'"l3-routing-toplogy": %s' % self.domain,
+			'"l3-routing-topology": %s' % self.domain,
 			'"protocol-id": %s' % self.proto_id,
 			'"node-descriptors": { %s }' % nodes,
 			'"nexthop": "%s"' % self.nexthop,

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv4.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv4.py
@@ -1,5 +1,5 @@
 """
-node.py
+prefixv4.py
 
 Created by Evelio Vila on 2016-11-26. eveliovila@gmail.com
 Copyright (c) 2009-2016 Exa Networks. All rights reserved.
@@ -115,7 +115,7 @@ class PREFIXv4(BGPLS):
 		nodes = ', '.join(d.json() for d in self.local_node)
 		content = ', '.join([
 			'"ls-nlri-type": 3',
-			'"l3-routing-toplogy": %s' % self.domain,
+			'"l3-routing-topology": %s' % self.domain,
 			'"protocol-id": %s' % self.proto_id,
 			'"node-descriptors": { %s }' % nodes,
 			self.prefix.json(),

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/ifaceaddr.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/ifaceaddr.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-node.py
+ifaceaddr.py
 
 Created by Evelio Vila on 2016-11-26. eveliovila@gmail.com
 Copyright (c) 2009-2016 Exa Networks. All rights reserved.
@@ -74,5 +74,3 @@ class IfaceAddr (object):
 
 	def pack (self):
 		return self._packed
-
-

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/ipreach.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/ipreach.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-node.py
+ipreach.py
 
 Created by Evelio Vila on 2016-11-26. eveliovila@gmail.com
 Copyright (c) 2009-2016 Exa Networks. All rights reserved.
@@ -96,5 +96,3 @@ class IpReach(object):
 
 	def pack (self):
 		return self._packed
-
-

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/linkid.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/linkid.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-node.py
+linkid.py
 
 Created by Evelio Vila on 2016-11-26. eveliovila@gmail.com
 Copyright (c) 2009-2016 Exa Networks. All rights reserved.
@@ -76,5 +76,3 @@ class LinkIdentifier (object):
 
 	def pack (self):
 		return self._packed
-
-

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/neighaddr.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/neighaddr.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-node.py
+neighaddr.py
 
 Created by Evelio Vila on 2016-11-26. eveliovila@gmail.com
 Copyright (c) 2009-2016 Exa Networks. All rights reserved.
@@ -21,7 +21,7 @@ from exabgp.util import ord_
 #   into their routing or forwarding table because this can lead to
 #   forwarding loops when interacting with systems that do not support
 #   this sub-TLV.
-# ================================================================== NeighborAddress 
+# ================================================================== NeighborAddress
 
 class NeighAddr (object):
 
@@ -77,5 +77,3 @@ class NeighAddr (object):
 
 	def pack (self):
 		return self._packed
-
-

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/ospfroute.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/ospfroute.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-node.py
+ospfroute.py
 
 Created by Evelio Vila on 2016-11-26. eveliovila@gmail.com
 Copyright (c) 2009-2016 Exa Networks. All rights reserved.
@@ -92,5 +92,3 @@ class OspfRoute(object):
 
 	def pack (self):
 		return self._packed
-
-

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/prefix.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/prefix.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-node.py
+prefix.py
 
 Created by Evelio Vila on 2016-11-26. eveliovila@gmail.com
 Copyright (c) 2009-2016 Exa Networks. All rights reserved.
@@ -79,5 +79,3 @@ class Prefix (object):
 
 	def pack (self):
 		return self._packed
-
-

--- a/lib/exabgp/bgp/message/update/nlri/cidr.py
+++ b/lib/exabgp/bgp/message/update/nlri/cidr.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-prefix.py
+cidr.py
 
 Created by Thomas Mangin on 2013-08-07.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/update/nlri/evpn/nlri.py
+++ b/lib/exabgp/bgp/message/update/nlri/evpn/nlri.py
@@ -1,5 +1,5 @@
 """
-evpn.py
+nlri.py
 
 Created by Thomas Morin on 2014-06-23.
 Copyright (c) 2014-2015 Orange. All rights reserved.

--- a/lib/exabgp/bgp/message/update/nlri/evpn/segment.py
+++ b/lib/exabgp/bgp/message/update/nlri/evpn/segment.py
@@ -93,7 +93,7 @@ class EthernetSegment (EVPN):
 		iplen = ord_(data[18])
 
 		if iplen not in (32,128):
-			raise Notify(3,5,"IP field length is given as %d in current Segment, expecting 32 (IPv4) or 128 (IPv6) bits" % iplen)
+			raise Notify(3,5,"IP length field is given as %d in current Segment, expecting 32 (IPv4) or 128 (IPv6) bits" % iplen)
 
 		ip = IP.unpack(data[19:19+(iplen/8)])
 

--- a/lib/exabgp/bgp/message/update/nlri/inet.py
+++ b/lib/exabgp/bgp/message/update/nlri/inet.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-path.py
+inet.py
 
 Created by Thomas Mangin on 2014-06-27.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.
@@ -139,7 +139,7 @@ class INET (NLRI):
 		size = CIDR.size(mask)
 
 		if len(bgp) < size:
-			raise Notify(3,10,'could not decode route with AFI %d sand SAFI %d' % (afi,safi))
+			raise Notify(3,10,'could not decode route with AFI %d and SAFI %d' % (afi,safi))
 
 		network,bgp = bgp[:size],bgp[size:]
 

--- a/lib/exabgp/bgp/message/update/nlri/ipvpn.py
+++ b/lib/exabgp/bgp/message/update/nlri/ipvpn.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-bgp.py
+ipvpn.py
 
 Created by Thomas Mangin on 2012-07-08.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/update/nlri/labelled.py
+++ b/lib/exabgp/bgp/message/update/nlri/labelled.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-path.py
+labelled.py
 
 Created by Thomas Mangin on 2014-06-27.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/bgp/message/update/nlri/rtc.py
+++ b/lib/exabgp/bgp/message/update/nlri/rtc.py
@@ -94,7 +94,7 @@ class RTC (NLRI):
 			return cls(afi,safi,action,ASN(0),None),bgp[1:]
 
 		if length < 8*4:
-			raise Exception("incorrect RT lenght: %d (should be >=32,<=96)" % length)
+			raise Exception("incorrect RT length: %d (should be >=32,<=96)" % length)
 
 		# We are reseting the flags on the RouteTarget extended
 		# community, because they do not make sense for an RTC route

--- a/lib/exabgp/configuration/capability.py
+++ b/lib/exabgp/configuration/capability.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-parse_capability.py
+capability.py
 
 Created by Thomas Mangin on 2015-06-04.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.
@@ -33,7 +33,7 @@ def addpath (tokeniser):
 	if ap == 'receive/send':  # was allowed with the previous parser
 		raise ValueError('the option is send/receive')
 
-	raise ValueError('"%s" is an invalid add-path, options are send, receive, send/receive' % ap)
+	raise ValueError('"%s" is an invalid add-path, options are: send, receive, send/receive' % ap)
 
 
 def gracefulrestart (tokeniser, default):

--- a/lib/exabgp/configuration/configuration.py
+++ b/lib/exabgp/configuration/configuration.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-current.py
+configuration.py
 
 Created by Thomas Mangin on 2009-08-25.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/configuration/core/format.py
+++ b/lib/exabgp/configuration/core/format.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-formating.py
+format.py
 
 Created by Thomas Mangin on 2014-06-22.
 Copyright (c) 2014-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/configuration/core/section.py
+++ b/lib/exabgp/configuration/core/section.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-generic/__init__.py
+section.py
 
 Created by Thomas Mangin on 2015-06-04.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/configuration/family.py
+++ b/lib/exabgp/configuration/family.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-parse_family.py
+family.py
 
 Created by Thomas Mangin on 2015-06-04.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/configuration/flow/__init__.py
+++ b/lib/exabgp/configuration/flow/__init__.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-parse_flow.py
+__init__.py
 
 Created by Thomas Mangin on 2015-06-04.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/configuration/flow/match.py
+++ b/lib/exabgp/configuration/flow/match.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-parse_match.py
+match.py
 
 Created by Thomas Mangin on 2015-06-22.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/configuration/flow/route.py
+++ b/lib/exabgp/configuration/flow/route.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-parse_flow.py
+route.py
 
 Created by Thomas Mangin on 2015-06-22.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/configuration/flow/then.py
+++ b/lib/exabgp/configuration/flow/then.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-parse_flow.py
+then.py
 
 Created by Thomas Mangin on 2015-06-22.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/configuration/l2vpn/vpls.py
+++ b/lib/exabgp/configuration/l2vpn/vpls.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-parse_l2vpn.py
+vpls.py
 
 Created by Thomas Mangin on 2015-06-05.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.
@@ -149,7 +149,7 @@ class ParseVPLS (Section):
 		if nlri.nexthop is None:
 			return self.error.set('vpls next-hop missing')
 		if nlri.endpoint is None:
-			return self.error.set('vpls enpoint missing')
+			return self.error.set('vpls endpoint missing')
 		if nlri.base is None:
 			return self.error.set('vpls base missing')
 		if nlri.offset is None:
@@ -157,7 +157,7 @@ class ParseVPLS (Section):
 		if nlri.size is None:
 			return self.error.set('vpls size missing')
 		if nlri.base > (0xFFFFF - nlri.size):  # 20 bits, 3 bytes
-			return self.error.set('vpls size inconsistancy')
+			return self.error.set('vpls size inconsistency')
 		return True
 
 	def check (change):

--- a/lib/exabgp/configuration/neighbor/parser.py
+++ b/lib/exabgp/configuration/neighbor/parser.py
@@ -30,7 +30,7 @@ def hostname (tokeniser):
 	if not value[-1].isalnum() or value[-1].isdigit():
 		raise ValueError('bad host-name (alphanumeric)')
 	if '..' in value:
-		raise ValueError('bad host-name (double colon)')
+		raise ValueError('bad host-name (double period)')
 	if not all(True if c in ascii_letters + digits + '.-' else False for c in value):
 		raise ValueError('bad host-name (charset)')
 	if len(value) > 255:
@@ -112,12 +112,12 @@ def processes (tokeniser):
 	result = []
 	token = tokeniser()
 	if token != '[':
-		raise ValueError('invalid processes, does not starts with [')
+		raise ValueError('invalid processes, does not start with [')
 
 	while True:
 		token = tokeniser()
 		if not token:
-			raise ValueError('invalid processes, does not ends with ]')
+			raise ValueError('invalid processes, does not end with ]')
 		if token == ']':
 			break
 		if token == ',':

--- a/lib/exabgp/configuration/operational/__init__.py
+++ b/lib/exabgp/configuration/operational/__init__.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-parse_operational.py
+operational/__init__.py
 
 Created by Thomas Mangin on 2015-06-05.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/configuration/operational/parser.py
+++ b/lib/exabgp/configuration/operational/parser.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-parse_operational.py
+operational/__init__.py
 
 Created by Thomas Mangin on 2015-06-23.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/configuration/parser.py
+++ b/lib/exabgp/configuration/parser.py
@@ -26,7 +26,7 @@ def boolean (tokeniser, default):
 		return False
 	if status in ('unset',):
 		return None
-	raise ValueError('invalid value for a boolean')
+	raise ValueError('invalid value (%s) for a boolean' % status)
 
 
 def port (tokeniser):
@@ -39,7 +39,7 @@ def port (tokeniser):
 	except ValueError:
 		raise ValueError('"%s" is an invalid port' % value)
 	if value < 0:
-		raise ValueError('the port must positive')
+		raise ValueError('the port must be positive')
 	if value >= pow(2,16):
 		raise ValueError('the port must be smaller than %d' % pow(2,16))
 	return value

--- a/lib/exabgp/configuration/template.py
+++ b/lib/exabgp/configuration/template.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-parse_family.py
+template.py
 
 Created by Thomas Mangin on 2015-06-16.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/logger.py
+++ b/lib/exabgp/logger.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-utils.py
+logger.py
 
 Created by Thomas Mangin on 2009-09-06.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/protocol/__init__.py
+++ b/lib/exabgp/protocol/__init__.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-protocol.py
+__init__.py
 
 Created by Thomas Mangin on 2010-01-15.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/protocol/family.py
+++ b/lib/exabgp/protocol/family.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-address.py
+family.py
 
 Created by Thomas Mangin on 2010-01-19.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/reactor/listener.py
+++ b/lib/exabgp/reactor/listener.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-listen.py
+listener.py
 
 Created by Thomas Mangin on 2013-07-11.
 Copyright (c) 2013-2015 Exa Networks. All rights reserved.
@@ -74,7 +74,7 @@ class Listener (object):
 			self._sockets[sock] = (local_ip.top(),local_port,peer_ip.top(),md5)
 		except socket.error as exc:
 			if exc.args[0] == errno.EADDRINUSE:
-				raise BindingError('could not listen on %s:%d, the port already in use by another application' % (local_ip,local_port))
+				raise BindingError('could not listen on %s:%d, the port may already be in use by another application' % (local_ip,local_port))
 			elif exc.args[0] == errno.EADDRNOTAVAIL:
 				raise BindingError('could not listen on %s:%d, this is an invalid address' % (local_ip,local_port))
 			raise NetworkError(str(exc))

--- a/lib/exabgp/reactor/network/connection.py
+++ b/lib/exabgp/reactor/network/connection.py
@@ -117,7 +117,7 @@ class Connection (object):
 			try:
 				while True:
 					if self.defensive and random.randint(0,2):
-						raise socket.error(errno.EAGAIN,'raising network error in purpose')
+						raise socket.error(errno.EAGAIN,'raising network error on purpose')
 
 					read = self.io.recv(number)
 					if not read:
@@ -173,7 +173,7 @@ class Connection (object):
 			try:
 				while True:
 					if self.defensive and random.randint(0,2):
-						raise socket.error(errno.EAGAIN,'raising network error in purpose')
+						raise socket.error(errno.EAGAIN,'raising network error on purpose')
 
 					# we can not use sendall as in case of network buffer filling
 					# it does raise and does not let you know how much was sent

--- a/lib/exabgp/util/enumeration.py
+++ b/lib/exabgp/util/enumeration.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-Enumeration.py
+enumeration.py
 
 Created by Thomas Mangin on 2013-03-18.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.

--- a/lib/exabgp/util/ip.py
+++ b/lib/exabgp/util/ip.py
@@ -1,6 +1,6 @@
 # encoding: utf-8
 """
-od.py
+ip.py
 
 Created by Thomas Mangin on 2009-09-12.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.


### PR DESCRIPTION
Updated filename headers to be the proper filename.py as encountered.

Updated a few error strings / text messages / comments.

OPERATIONAL NOTE: Corrected typo ('toplogy' -> 'topology') in BGPLS JSON output -
this may break anyone that used the previous token (the typo) in the
JSON.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/585)
<!-- Reviewable:end -->
