### PR TITLE
healthcheck.py: Fix nonexistent option name - ips_deleted vs. ip_dynamic

### DIFF
--- a/lib/exabgp/application/healthcheck.py
+++ b/lib/exabgp/application/healthcheck.py
@@ -446,7 +446,7 @@ def loop(options):
             logger.info("service down, deleting loopback ips")
             remove_ips(options.ips, options.label, options.sudo)
         # if ips was deleted with dyn ip, re-setup them
-        if target == states.UP and options.ips_deleted and options.ip_setup:
+        if target == states.UP and options.ip_dynamic and options.ip_setup:
             logger.info("service up, restoring loopback ips")
             setup_ips(options.ips, options.label, options.sudo)
 


### PR DESCRIPTION
It seems commit 58fe988dcf64c959b09af997ba40f98f63276f75 introduced a problem in the _healthcheck.py_ application by referencing a nonexistant runtime configuration option:
> ERROR[healthcheck] Uncaught exception: 'Namespace' object has no attribute 'ips_deleted'

This PR corrects "options.ips_deleted" to "options.ip_dynamic" which was introduced by the previously-mentioned commit. This makes _healthcheck.py_ work again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/587)
<!-- Reviewable:end -->
