### PR TITLE
Added support for draft-ietf-idr-flowspec-interfaceset

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Version explained:
  bug   : increase on bug or incremental changes
 
 Version 4.0.0
+ * Feature: add support for interface-set for BGP flowspec routes
  * Change: the configuration format is not compatible with ExaBGP 3.x
  * Change: BMP support is deprecated for BGP-LS
  * Change: move and install healthcheck in bin

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/__init__.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/__init__.py
@@ -29,3 +29,4 @@ from exabgp.bgp.message.update.attribute.community.extended.traffic import Traff
 from exabgp.bgp.message.update.attribute.community.extended.encapsulation import Encapsulation
 from exabgp.bgp.message.update.attribute.community.extended.chso import ConsistentHashSortOrder
 from exabgp.bgp.message.update.attribute.community.extended.rt_record import RTRecord
+from exabgp.bgp.message.update.attribute.community.extended.flowspec_scope import InterfaceSet

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/flowspec_scope.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/flowspec_scope.py
@@ -1,0 +1,57 @@
+# encoding: utf-8
+"""
+flowspec_scope.py
+
+Created by Stephane Litkowski on 2017-02-24.
+"""
+
+from struct import pack
+from struct import unpack
+
+from exabgp.bgp.message.open.asn import ASN
+from exabgp.bgp.message.update.attribute.community.extended import ExtendedCommunity
+
+
+# ============================================================== InterfaceSet
+# draft-ietf-idr-flowspsec-interfaceset 
+
+
+@ExtendedCommunity.register
+class InterfaceSet(ExtendedCommunity):
+	COMMUNITY_TYPE = 0x07
+	COMMUNITY_SUBTYPE = 0x02
+
+	__slots__ = ['trans', 'asn','target','direction']
+
+	names = {
+		1:	'input',
+		2:	'output',
+		3:	'input-output',
+	}
+
+	def __init__ (self, trans, asn, target, direction, community=None):
+		self.asn = asn
+		self.target = target
+		self.direction = direction
+		self.transitive = trans	
+		new_target =  (direction << 14) + target
+		ExtendedCommunity.__init__(
+			self,
+			community if community is not None else pack(
+				"!2sLH",
+				self._subtype(self.transitive),
+				asn,new_target
+			)
+		)
+
+	def __repr__ (self):
+		str_direction = self.names.get(self.direction, str(self.direction)) 
+		return "interface-set:%s:%s:%s" % (\
+			str_direction,str(self.asn),str(self.target))
+
+	@staticmethod
+	def unpack (data):
+		asn,target = unpack('!LH',data[2:8])
+		direction = target >> 14
+		target = target & 0x1FFF
+		return InterfaceSet(False,ASN(asn),target,direction,data[:8])

--- a/lib/exabgp/configuration/configuration.py
+++ b/lib/exabgp/configuration/configuration.py
@@ -30,6 +30,7 @@ from exabgp.configuration.flow import ParseFlow
 from exabgp.configuration.flow import ParseFlowRoute
 from exabgp.configuration.flow import ParseFlowThen
 from exabgp.configuration.flow import ParseFlowMatch
+from exabgp.configuration.flow import ParseFlowScope
 from exabgp.configuration.l2vpn import ParseL2VPN
 from exabgp.configuration.l2vpn import ParseVPLS
 from exabgp.configuration.operational import ParseOperational
@@ -122,6 +123,7 @@ class Configuration (_Configuration):
 		self.flow_route          = ParseFlowRoute        (*params)
 		self.flow_match          = ParseFlowMatch        (*params)
 		self.flow_then           = ParseFlowThen         (*params)
+		self.flow_scope		 = ParseFlowScope	 (*params)	
 		self.l2vpn               = ParseL2VPN            (*params)
 		self.vpls                = ParseVPLS             (*params)
 		self.operational         = ParseOperational      (*params)
@@ -234,6 +236,7 @@ class Configuration (_Configuration):
 				'sections': {
 					'match': self.flow_match.name,
 					'then':  self.flow_then.name,
+					'scope': self.flow_scope.name,
 				},
 			},
 			self.flow_match.name: {
@@ -247,6 +250,12 @@ class Configuration (_Configuration):
 				'commands': self.flow_then.known.keys(),
 				'sections': {
 				},
+			},
+			self.flow_scope.name: {
+				'class':    self.flow_scope,
+				'commands': self.flow_scope.known.keys(),
+				'sections': {
+				}
 			},
 			self.l2vpn.name: {
 				'class':    self.l2vpn,
@@ -298,6 +307,7 @@ class Configuration (_Configuration):
 		self.flow_route.clear()
 		self.flow_match.clear()
 		self.flow_then.clear()
+		self.flow_scope.clear()	
 		self.l2vpn.clear()
 		self.vpls.clear()
 		self.operational.clear()

--- a/lib/exabgp/configuration/flow/__init__.py
+++ b/lib/exabgp/configuration/flow/__init__.py
@@ -11,6 +11,7 @@ from exabgp.configuration.core import Section
 from exabgp.configuration.flow.route import ParseFlowRoute
 from exabgp.configuration.flow.route import ParseFlowMatch
 from exabgp.configuration.flow.route import ParseFlowThen
+from exabgp.configuration.flow.route import ParseFlowScope
 
 from exabgp.rib.change import Change
 from exabgp.bgp.message.update.nlri import Flow
@@ -27,9 +28,11 @@ class ParseFlow (Section):
 
 	known = dict(ParseFlowMatch.known)
 	known.update(ParseFlowThen.known)
+	known.update(ParseFlowScope.known)
 
 	action = dict(ParseFlowMatch.action)
 	action.update(ParseFlowThen.action)
+	action.update(ParseFlowScope.action)
 
 	def __init__ (self, tokeniser, scope, error, logger):
 		Section.__init__(self,tokeniser,scope,error,logger)

--- a/lib/exabgp/configuration/flow/parser.py
+++ b/lib/exabgp/configuration/flow/parser.py
@@ -34,6 +34,8 @@ from exabgp.bgp.message.update.attribute.community.extended import TrafficRedire
 from exabgp.bgp.message.update.attribute.community.extended import TrafficMark
 from exabgp.bgp.message.update.attribute.community.extended import TrafficNextHop
 
+from exabgp.bgp.message.update.attribute.community.extended import InterfaceSet
+
 from exabgp.bgp.message.update.attribute.community.extended import ExtendedCommunities
 
 from exabgp.rib.change import Change
@@ -300,3 +302,49 @@ def action (tokeniser):
 		raise ValueError('invalid flow action')
 
 	return ExtendedCommunities().add(TrafficAction(sample,terminal))
+
+def _interface_set (data):
+	if data.count(':') != 3:
+		raise ValueError('not a valid format %s' % data)
+
+	trans,direction,prefix,suffix = data.split(':',3)
+
+	if trans == 'transitive':
+		trans = True
+	elif trans == 'non-transitive':
+		trans = False
+	else:
+		raise ValueError('Bad transitivity type %s, should be transitive or non-transitive' % trans)
+	if prefix.count('.'):
+		raise ValueError('a 32 bits number must be used, invalid value %s' % prefix)
+	if (direction == 'input'):
+		int_direction = 1
+	elif (direction == 'output'):
+		int_direction = 2
+	elif (direction == 'input-output'):
+		int_direction = 3
+	else:
+		raise ValueError('Bad direction %s, should be input, output or input-output' % direction)
+	asn = int(prefix)
+	route_target = int(suffix)
+	if asn >= pow(2,32):
+		raise ValueError('asn can only be 32 bits, value too large %s' % asn)
+	if route_target >= pow(2,14):
+		raise ValueError('group-id is a 14 bits number, value too large %s' % route_target)
+	return InterfaceSet(trans,asn,route_target,int_direction)
+
+def interface_set (tokeniser):
+	communities = ExtendedCommunities()
+
+	value = tokeniser()
+	if value == '[':
+		while True:
+			value = tokeniser()
+			if value == ']':
+				break
+			communities.add(_interface_set(value))
+	else:
+		communities.add(_interface_set(value))
+
+	return communities
+

--- a/lib/exabgp/configuration/flow/route.py
+++ b/lib/exabgp/configuration/flow/route.py
@@ -13,6 +13,7 @@ from exabgp.configuration.core import Section
 
 from exabgp.configuration.flow.match import ParseFlowMatch
 from exabgp.configuration.flow.then import ParseFlowThen
+from exabgp.configuration.flow.scope import ParseFlowScope
 
 from exabgp.configuration.static.mpls import route_distinguisher
 
@@ -27,8 +28,10 @@ class ParseFlowRoute (Section):
 		'  next-hop 1.2.3.4; (to use with redirect-to-nexthop)\n' \
 		'  %s\n' \
 		'  %s\n' \
+		'  %s\n' \
 		'}\n' % (
 			'\n  '.join(ParseFlowMatch.syntax.split('\n')),
+			'\n  '.join(ParseFlowScope.syntax.split('\n')),			
 			'\n  '.join(ParseFlowThen.syntax.split('\n'))
 		)
 

--- a/lib/exabgp/configuration/flow/scope.py
+++ b/lib/exabgp/configuration/flow/scope.py
@@ -1,0 +1,47 @@
+# encoding: utf-8
+"""
+scope.py
+
+Created by Stephane Litkowski on 2017-02-24.
+"""
+
+from exabgp.configuration.core import Section
+
+from exabgp.configuration.flow.parser import interface_set
+
+
+class ParseFlowScope (Section):
+	definition = [
+		'interface-set transitive:input:1234:1234'
+	]
+
+	syntax = \
+		'scope {\n' \
+		'  %s;\n' \
+		'}' % ';\n  '.join(definition)
+
+	known = {
+		'interface-set':	interface_set,
+	}
+
+	# 'community','extended-community'
+
+	action = {
+		'interface-set':       'attribute-add',
+	}
+
+	name = 'flow/scope'
+
+	def __init__ (self, tokeniser, scope, error, logger):
+		Section.__init__(self,tokeniser,scope,error,logger)
+
+	def clear (self):
+		pass
+
+	def pre (self):
+		self.scope.set(self.name,self.scope.get('flow/route'))
+		return True
+
+	def post (self):
+		self.scope.pop(self.name)
+		return True


### PR DESCRIPTION
Added the configuration stanza for interface-set
Both transitive and non transitive instance of the community are supported
```
flow {
        route MYROUTE {
                match {
                        source 1.1.1.1/32;
                        destination 2.2.2.2/32;
                }
                scope {
                        interface-set [  transitive:input:3000:3 non-transitive:output:12:1 transitive:input-output:1:1   ];
                }
                then {
                        accept;
                }
        }
}
```

Signed-off-by: Stephane Litkowski <stephane.litkowski@orange.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/592)
<!-- Reviewable:end -->
