### PR TITLE
Allow local_address to be optional

### DIFF
--- a/lib/exabgp/bgp/neighbor.py
+++ b/lib/exabgp/bgp/neighbor.py
@@ -130,7 +130,9 @@ class Neighbor (object):
 			self._families.remove(family)
 
 	def missing (self):
-		if self.local_address is None or (self.listen > 0 and self.auto_discovery):
+		if self.local_address is None and not self.auto_discovery:
+			return 'local-address'
+		if self.listen > 0 and self.auto_discovery:
 			return 'local-address'
 		if self.peer_address is None:
 			return 'peer-address'

--- a/lib/exabgp/configuration/neighbor/__init__.py
+++ b/lib/exabgp/configuration/neighbor/__init__.py
@@ -194,7 +194,10 @@ class ParseNeighbor (Section):
 
 		messages = local.get('operational',{}).get('routes',[])
 
-		neighbor.auto_discovery = True if neighbor.local_address == 'auto' else False
+		if neighbor.local_address == 'auto':
+			neighbor.auto_discovery = True
+			neighbor.local_address = None
+			neighbor.md5_ip = None
 
 		if not neighbor.router_id and not neighbor.auto_discovery:
 			neighbor.router_id = neighbor.local_address

--- a/lib/exabgp/configuration/neighbor/__init__.py
+++ b/lib/exabgp/configuration/neighbor/__init__.py
@@ -199,7 +199,7 @@ class ParseNeighbor (Section):
 			neighbor.local_address = None
 			neighbor.md5_ip = None
 
-		if not neighbor.router_id and not neighbor.auto_discovery:
+		if not neighbor.router_id and neighbor.peer_address.afi == AFI.ipv4 and not neighbor.auto_discovery:
 			neighbor.router_id = neighbor.local_address
 
 		if neighbor.route_refresh:

--- a/lib/exabgp/configuration/neighbor/__init__.py
+++ b/lib/exabgp/configuration/neighbor/__init__.py
@@ -204,7 +204,7 @@ class ParseNeighbor (Section):
 		if missing:
 			return self.error.set('incomplete neighbor, missing %s' % missing)
 
-		if neighbor.local_address.afi != neighbor.peer_address.afi:
+		if neighbor.local_address and neighbor.local_address.afi != neighbor.peer_address.afi:
 			return self.error.set('local-address and peer-address must be of the same family')
 
 		if neighbor.peer_address.top() in self._neighbors:

--- a/lib/exabgp/configuration/neighbor/parser.py
+++ b/lib/exabgp/configuration/neighbor/parser.py
@@ -6,13 +6,14 @@ Created by Thomas Mangin on 2014-07-01.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.
 """
 
+import socket
 from string import ascii_letters
 from string import digits
 
 from exabgp.bgp.message.open.routerid import RouterID
 from exabgp.bgp.message.open.holdtime import HoldTime
-
 from exabgp.configuration.parser import string
+from exabgp.protocol.ip import IP
 
 
 def inherit (tokeniser):
@@ -85,6 +86,19 @@ def ttl (tokeniser):
 	if attl > 255:
 		raise ValueError('ttl must be smaller than 256')
 	return attl
+
+
+def local_address(tokeniser):
+	if not tokeniser.tokens:
+		raise ValueError("an ip address  or 'auto' is required")
+
+	value = tokeniser()
+	if value == 'auto':
+		return value
+	try:
+		return IP.create(value)
+	except (IndexError,ValueError,socket.error):
+		raise ValueError('"%s" is an invalid IP address' % value)
 
 
 def router_id (tokeniser):

--- a/lib/exabgp/protocol/ip/__init__.py
+++ b/lib/exabgp/protocol/ip/__init__.py
@@ -124,10 +124,12 @@ class IP (object):
 		return self._string
 
 	def __eq__ (self, other):
+		if not isinstance(other, IP):
+			return False
 		return self._packed == other._packed
 
-	def __neq__ (self, other):
-		return self._packed != other._packed
+	def __ne__ (self, other):
+		return not self.__eq__(other)
 
 	def __lt__ (self, other):
 		return self._packed < other._packed

--- a/lib/exabgp/reactor/api/command/text.py
+++ b/lib/exabgp/reactor/api/command/text.py
@@ -140,6 +140,7 @@ def show_neighbor_status (self, reactor, service, command):
 			peer = reactor.peers.get(peer_name, None)
 			if not peer:
 				continue
+			peer_name = peer.neighbor.name()
 			detailed_status = peer.detailed_link_status()
 			families = peer.negotiated_families()
 			if families:

--- a/lib/exabgp/reactor/loop.py
+++ b/lib/exabgp/reactor/loop.py
@@ -229,7 +229,7 @@ class Reactor (object):
 							# * later if it should be called again but has no work atm
 							# * close if it is finished and is closing down, or restarting
 							if action == ACTION.CLOSE:
-								self.unschedule(peer)
+								self.unschedule(key)
 								peers.discard(key)
 							# we are loosing this peer, not point to schedule more process work
 							elif action == ACTION.LATER:
@@ -252,7 +252,7 @@ class Reactor (object):
 								peer = self.peers[key]
 								neighbor = peer.neighbor
 								# XXX: FIXME: Inet can only be compared to Inet
-								if connection.local == str(neighbor.peer_address) and connection.peer == str(neighbor.local_address):
+								if connection.local == str(neighbor.peer_address) and (not neighbor.local_address or connection.peer == str(neighbor.local_address)):
 									if peer.incoming(connection):
 										found = True
 										break
@@ -440,9 +440,8 @@ class Reactor (object):
 		self.processes.start()
 
 	def unschedule (self, peer):
-		key = peer.neighbor.name()
-		if key in self.peers:
-			del self.peers[key]
+		if peer in self.peers:
+			del self.peers[peer]
 
 	def answer (self, service, string):
 		self.processes.write(service,string)

--- a/lib/exabgp/reactor/loop.py
+++ b/lib/exabgp/reactor/loop.py
@@ -252,7 +252,7 @@ class Reactor (object):
 								peer = self.peers[key]
 								neighbor = peer.neighbor
 								# XXX: FIXME: Inet can only be compared to Inet
-								if connection.local == str(neighbor.peer_address) and (not neighbor.local_address or connection.peer == str(neighbor.local_address)):
+								if connection.local == str(neighbor.peer_address) and (neighbor.auto_discovery or connection.peer == str(neighbor.local_address)):
 									if peer.incoming(connection):
 										found = True
 										break

--- a/lib/exabgp/reactor/network/incoming.py
+++ b/lib/exabgp/reactor/network/incoming.py
@@ -19,8 +19,8 @@ class Incoming (Connection):
 
 		try:
 			self.io = io
-			async(self.io,peer)
-			nagle(self.io,peer)
+			async(self.io,self.peer)
+			nagle(self.io,self.peer)
 		except NetworkError as exc:
 			self.close()
 			raise NotConnected(errstr(exc))

--- a/lib/exabgp/reactor/network/outgoing.py
+++ b/lib/exabgp/reactor/network/outgoing.py
@@ -21,7 +21,6 @@ class Outgoing (Connection):
 
 		self.logger.wire("attempting connection to %s:%d" % (self.peer,port))
 
-		self.peer = peer
 		self.ttl = ttl
 		self.afi = afi
 		self.md5 = md5
@@ -29,14 +28,17 @@ class Outgoing (Connection):
 
 		try:
 			self.io = create(afi)
-			MD5(self.io,peer,port,md5)
+			MD5(self.io,self.peer,port,md5)
 			if afi == AFI.ipv4:
-				TTL(self.io, peer, self.ttl)
+				TTL(self.io, self.peer, self.ttl)
 			elif afi == AFI.ipv6:
-				TTLv6(self.io, peer, self.ttl)
-			bind(self.io,local,afi)
-			async(self.io,peer)
-			connect(self.io,peer,port,afi,md5)
+				TTLv6(self.io, self.peer, self.ttl)
+			if local:
+				bind(self.io,self.local,afi)
+			async(self.io,self.peer)
+			connect(self.io,self.peer,port,afi,md5)
+			if not self.local:
+				self.local = self.io.getsockname()[0]
 			self.init = True
 		except NetworkError as exc:
 			self.init = False

--- a/lib/exabgp/reactor/protocol.py
+++ b/lib/exabgp/reactor/protocol.py
@@ -94,15 +94,14 @@ class Protocol (object):
 	def connect (self):
 		# allows to test the protocol code using modified StringIO with a extra 'pending' function
 		if not self.connection:
-			local = self.neighbor.md5_ip.top() if self.neighbor.md5_ip else None
+			local = self.neighbor.md5_ip.top() if not self.auto_discovery else None
 			peer = self.neighbor.peer_address.top()
 			afi = self.neighbor.peer_address.afi
 			md5 = self.neighbor.md5_password
 			ttl_out = self.neighbor.ttl_out
-			self.neighbor._client_ip = local
 			self.connection = Outgoing(afi,peer,local,self.port,md5,ttl_out)
 			if not local and self.connection.init:
-				self.neighbor._client_ip = self.connection.io.getsockname()[0]
+				self.neighbor.local_address = self.connection.local
 
 			try:
 				generator = self.connection.establish()

--- a/lib/exabgp/reactor/protocol.py
+++ b/lib/exabgp/reactor/protocol.py
@@ -94,11 +94,15 @@ class Protocol (object):
 	def connect (self):
 		# allows to test the protocol code using modified StringIO with a extra 'pending' function
 		if not self.connection:
-			local = self.neighbor.md5_ip
-			peer = self.neighbor.peer_address
+			local = self.neighbor.md5_ip.top() if self.neighbor.md5_ip else None
+			peer = self.neighbor.peer_address.top()
+			afi = self.neighbor.peer_address.afi
 			md5 = self.neighbor.md5_password
 			ttl_out = self.neighbor.ttl_out
-			self.connection = Outgoing(peer.afi,peer.top(),local.top(),self.port,md5,ttl_out)
+			self.neighbor._client_ip = local
+			self.connection = Outgoing(afi,peer,local,self.port,md5,ttl_out)
+			if not local and self.connection.init:
+				self.neighbor._client_ip = self.connection.io.getsockname()[0]
 
 			try:
 				generator = self.connection.establish()


### PR DESCRIPTION
In one of our use cases we would like to be able to set up a peer without specifying the local ip address to use for that connection.

This patch allows the local_address to be left out in which case the correct local IP will be determined by the OS using its current routing table.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/597)
<!-- Reviewable:end -->
