### PR TITLE
Allow show routes commands to yield less often then every line

### DIFF
--- a/lib/exabgp/configuration/setup.py
+++ b/lib/exabgp/configuration/setup.py
@@ -230,6 +230,12 @@ environment.configuration = {
 		},
 	},
 	'api':  {
+		'chunk': {
+			'read': environment.integer,
+			'write': environment.nop,
+			'value': '1',
+			'help': 'maximum lines to print before yielding in show routes api',
+		},
 		'encoder':  {
 			'read':  environment.api,
 			'write': environment.lower,


### PR DESCRIPTION
We were running into performance issues when sending exabgp a show routes command via the API.  The current code was yielding after printing each route. This works fine for smaller numbers of routes, but when you have multiple peers with a large number of routes stored in their RIB it was taking longer then desired to query the current set of routes.

This patch allows the setting of an environment variable that can configure how many lines will be printed before yielding back to the main loop, with the default being 1.

@thomas-mangin Feel free to suggest a better name for the environment variable; Naming is hard :-)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/599)
<!-- Reviewable:end -->
