### PR TITLE
Add support base64 encoding the md5 password

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -176,6 +176,8 @@ Version 4.0.0
     patch by: Brian Johnson
  * Fix: Remove a peer's RIB cache when it is deleted from the config file
     patch by: Brian Johnson
+ * Feature: Allow md5 password to be base64 encoded
+    patch by: Brian Johnson
 
 Version 3.4.10
  * Fix: Fix parsing attributes with PARTIAL flag set

--- a/lib/exabgp/bgp/neighbor.py
+++ b/lib/exabgp/bgp/neighbor.py
@@ -43,6 +43,7 @@ class Neighbor (object):
 		self.asn4 = None
 		self.add_path = None
 		self.md5_password = None
+		self.md5_base64 = False
 		self.md5_ip = None
 		self.ttl_in = None
 		self.ttl_out = None
@@ -234,7 +235,7 @@ class Neighbor (object):
 			'\tpeer-as %s;\n' \
 			'\thold-time %s;\n' \
 			'\tmanual-eor %s;\n' \
-			'%s%s%s%s%s%s%s%s%s%s\n' \
+			'%s%s%s%s%s%s%s%s%s%s%s\n' \
 			'\tcapability {\n' \
 			'%s%s%s%s%s%s%s\t}\n' \
 			'\tfamily {%s\n' \
@@ -259,6 +260,7 @@ class Neighbor (object):
 				'\tauto-flush %s;\n' % ('true' if self.flush else 'false'),
 				'\tadj-rib-out %s;\n' % ('true' if self.adjribout else 'false'),
 				'\tmd5-password "%s";\n' % self.md5_password if self.md5_password else '',
+				'\tmd5-base64 %s;\n' % ('true' if self.md5_base64 else 'false'),
 				'\tmd5-ip "%s";\n' % self.md5_ip if not self.auto_discovery else '',
 				'\toutgoing-ttl %s;\n' % self.ttl_out if self.ttl_out else '',
 				'\tincoming-ttl %s;\n' % self.ttl_in if self.ttl_in else '',

--- a/lib/exabgp/configuration/neighbor/parser.py
+++ b/lib/exabgp/configuration/neighbor/parser.py
@@ -66,8 +66,6 @@ def description (tokeniser):
 
 def md5 (tokeniser):
 	value = tokeniser()
-	if len(value) > 80:
-		raise ValueError('MD5 password must be no larger than 80 characters')
 	if not value:
 		raise ValueError('value requires the value password as an argument (quoted or unquoted).  FreeBSD users should use "kernel" as the argument.')
 	return value

--- a/lib/exabgp/reactor/listener.py
+++ b/lib/exabgp/reactor/listener.py
@@ -44,7 +44,7 @@ class Listener (object):
 			return socket.socket(socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP)
 		raise NetworkError('Can not create socket for listening, family of IP %s is unknown' % ip)
 
-	def listen (self, local_ip, peer_ip, local_port, md5, ttl_in):
+	def listen (self, local_ip, peer_ip, local_port, md5, md5_base64, ttl_in):
 		self.serving = True
 
 		for sock,(local,port,peer,md) in self._sockets.items():
@@ -53,7 +53,7 @@ class Listener (object):
 			if local_port != port:
 				continue
 			if md5:
-				MD5(sock,peer_ip.top(),0,md5)
+				MD5(sock,peer_ip.top(),0,md5,md5_base64)
 			if ttl_in:
 				MIN_TTL(sock,ttl_in)
 			return
@@ -62,7 +62,7 @@ class Listener (object):
 			sock = self._new_socket(local_ip)
 			if md5:
 				# MD5 must match the peer side of the TCP, not the local one
-				MD5(sock,peer_ip.top(),0,md5)
+				MD5(sock,peer_ip.top(),0,md5,md5_base64)
 			try:
 				sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 			except (socket.error,AttributeError):

--- a/lib/exabgp/reactor/loop.py
+++ b/lib/exabgp/reactor/loop.py
@@ -141,12 +141,12 @@ class Reactor (object):
 			self.listener = Listener()
 
 			if self.ip:
-				self.listener.listen(IP.create(self.ip),IP.create('0.0.0.0'),self.port,None,None)
+				self.listener.listen(IP.create(self.ip),IP.create('0.0.0.0'),self.port,None,False,None)
 				self.logger.reactor('Listening for BGP session(s) on %s:%d' % (self.ip,self.port))
 
 			for neighbor in self.configuration.neighbors.values():
 				if neighbor.listen:
-					self.listener.listen(neighbor.md5_ip,neighbor.peer_address,neighbor.listen,neighbor.md5_password,neighbor.ttl_in)
+					self.listener.listen(neighbor.md5_ip,neighbor.peer_address,neighbor.listen,neighbor.md5_password,neighbor.md5_base64,neighbor.ttl_in)
 					self.logger.reactor('Listening for BGP session(s) on %s:%d%s' % (neighbor.md5_ip,neighbor.listen,' with MD5' if neighbor.md5_password else ''))
 		except NetworkError as exc:
 			self.listener = None

--- a/lib/exabgp/reactor/network/outgoing.py
+++ b/lib/exabgp/reactor/network/outgoing.py
@@ -16,7 +16,7 @@ from .error import NetworkError
 class Outgoing (Connection):
 	direction = 'outgoing'
 
-	def __init__ (self, afi, peer, local, port=179,md5='',ttl=None):
+	def __init__ (self, afi, peer, local, port=179,md5='',md5_base64=False, ttl=None):
 		Connection.__init__(self,afi,peer,local)
 
 		self.logger.wire("attempting connection to %s:%d" % (self.peer,port))
@@ -28,7 +28,7 @@ class Outgoing (Connection):
 
 		try:
 			self.io = create(afi)
-			MD5(self.io,self.peer,port,md5)
+			MD5(self.io,self.peer,port,md5,md5_base64)
 			if afi == AFI.ipv4:
 				TTL(self.io, self.peer, self.ttl)
 			elif afi == AFI.ipv6:

--- a/lib/exabgp/reactor/network/tcp.py
+++ b/lib/exabgp/reactor/network/tcp.py
@@ -6,6 +6,7 @@ Created by Thomas Mangin on 2013-07-13.
 Copyright (c) 2013-2015 Exa Networks. All rights reserved.
 """
 
+import base64
 import time
 import socket
 import select
@@ -100,7 +101,7 @@ def connect (io, ip, port, afi, md5):
 # 	/* _SS_MAXSIZE value minus size of ss_family */
 # } __attribute__ ((aligned(_K_SS_ALIGNSIZE)));   /* force desired alignment */
 
-def MD5 (io, ip, port, md5):
+def MD5 (io, ip, port, md5, md5_base64):
 	if md5:
 		os = platform.system()
 		if os == 'FreeBSD':
@@ -123,6 +124,12 @@ def MD5 (io, ip, port, md5):
 				)
 		elif os == 'Linux':
 			try:
+				if md5_base64:
+					try:
+						md5 = base64.b64decode(md5)
+					except TypeError:
+						raise MD5Error("Failed to decode base 64 encoded PSK")
+
 				# __kernel_sockaddr_storage
 				n_af   = IP.toaf(ip)
 				n_addr = IP.pton(ip)

--- a/lib/exabgp/reactor/protocol.py
+++ b/lib/exabgp/reactor/protocol.py
@@ -99,8 +99,9 @@ class Protocol (object):
 			peer = self.neighbor.peer_address.top()
 			afi = self.neighbor.peer_address.afi
 			md5 = self.neighbor.md5_password
+			md5_base64 = self.neighbor.md5_base64
 			ttl_out = self.neighbor.ttl_out
-			self.connection = Outgoing(afi,peer,local,self.port,md5,ttl_out)
+			self.connection = Outgoing(afi,peer,local,self.port,md5,md5_base64,ttl_out)
 			if not local and self.connection.init:
 				self.neighbor.local_address = IP.create(self.connection.local)
 				if self.neighbor.router_id is None and self.neighbor.local_address.afi == AFI.ipv4:


### PR DESCRIPTION
This patch adds an option to support using base64 encoding for the md5 password. 

We use this to prevent issues with md5 passwords that might contain characters, like ;,  {, } or ". Even if we quote the md5 password in the config file there will still be issues if someone passes in a string containing quote marks.

By being able to set a base64 encoded version of the password we no longer have to worry about having exabgp crash if someone sets a password containing such characters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/602)
<!-- Reviewable:end -->
