### PR TITLE
Fixes python version requirement in PYPI.rst

### DIFF
--- a/PYPI.rst
+++ b/PYPI.rst
@@ -51,7 +51,7 @@ Installation
 Prerequisites
 -------------
 
-ExaBGP requires python 2.6 or 2.7. It has no external dependencies.
+ExaBGP requires python 2.7 or 3.x. It has no external dependencies.
 
 Using pip
 ---------


### PR DESCRIPTION
We'd need to be more specific about which python 3.x release is specified.
I think we don't need to find the lowest possible one, most recent distro now have 3.5 and this is what we've run the test suite against.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/634)
<!-- Reviewable:end -->
