### PR TITLE
AIGP: Add missing concat import

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/aigp.py
+++ b/lib/exabgp/bgp/message/update/attribute/aigp.py
@@ -11,7 +11,7 @@ from struct import unpack
 
 from exabgp.util import ordinal
 from exabgp.util import character
-from exabgp.util import concat_bytes
+from exabgp.util import concat_bytes_i, concat_bytes
 from exabgp.bgp.message.update.attribute.attribute import Attribute
 
 


### PR DESCRIPTION
I came across this missing import. Looks like it's from this change
9eb878be (Thomas Morin  2017-05-10 00:13:41 -0400  55)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/637)
<!-- Reviewable:end -->
