### PR TITLE
Global listening address changes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -19,6 +19,8 @@ Version 4.0.1
  * Feature: added a new API message "signal" which inform of the signals received by ExaBGP
  * Feature: it is now possible to use ip/netmask as notation for neighbor
  * Feature: local-as can be set to "auto", to auto-setup an iBGP session using the OPEN's ASN
+ * Feature: Allow binding to multiple global IP addresses
+ * Fix: Handle MD5 authentication on global IP addresses
 
 Version 4.0.0
  * Feature: add support for interface-set for BGP flowspec routes

--- a/lib/exabgp/configuration/environment.py
+++ b/lib/exabgp/configuration/environment.py
@@ -16,6 +16,7 @@ import sys
 import pwd
 import syslog
 
+from exabgp.protocol.ip import IP
 from exabgp.util.ip import isip
 
 
@@ -135,10 +136,16 @@ class environment (object):
 		raise TypeError('ip %s is invalid' % _)
 
 	@staticmethod
-	def optional_ip (_):
-		if not _ or isip(_):
-			return _
-		raise TypeError('ip %s is invalid' % _)
+	def ip_list (_):
+		ips = []
+		for ip in _.split(' '):
+			if not ip:
+				continue
+			elif isip(ip):
+				ips.append(IP.create(ip))
+			else:
+				raise TypeError('ip %s is invalid' % ip)
+		return ips
 
 	@staticmethod
 	def user (_):

--- a/lib/exabgp/configuration/setup.py
+++ b/lib/exabgp/configuration/setup.py
@@ -189,10 +189,10 @@ environment.configuration = {
 			'help':  'start to announce route when the minutes in the hours is a modulo of this number',
 		},
 		'bind': {
-			'read':  environment.optional_ip,
+			'read':  environment.ip_list,
 			'write': environment.quote,
 			'value': '',
-			'help':  'IP to bind on when listening (no ip to disable)',
+			'help':  'Space separated list of IPs to bind on when listening (no ip to disable)',
 		},
 		'port': {
 			'read':  environment.integer,

--- a/lib/exabgp/reactor/listener.py
+++ b/lib/exabgp/reactor/listener.py
@@ -52,17 +52,15 @@ class Listener (object):
 				continue
 			if local_port != port:
 				continue
-			if md5:
-				MD5(sock,peer_ip.top(),0,md5,md5_base64)
+			MD5(sock,peer_ip.top(),0,md5,md5_base64)
 			if ttl_in:
 				MIN_TTL(sock,peer_ip,ttl_in)
 			return
 
 		try:
 			sock = self._new_socket(local_ip)
-			if md5:
-				# MD5 must match the peer side of the TCP, not the local one
-				MD5(sock,peer_ip.top(),0,md5,md5_base64)
+			# MD5 must match the peer side of the TCP, not the local one
+			MD5(sock,peer_ip.top(),0,md5,md5_base64)
 			if ttl_in:
 				MIN_TTL(sock,peer_ip,ttl_in)
 			try:

--- a/lib/exabgp/reactor/listener.py
+++ b/lib/exabgp/reactor/listener.py
@@ -63,6 +63,8 @@ class Listener (object):
 			if md5:
 				# MD5 must match the peer side of the TCP, not the local one
 				MD5(sock,peer_ip.top(),0,md5,md5_base64)
+			if ttl_in:
+				MIN_TTL(sock,peer_ip,ttl_in)
 			try:
 				sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 			except (socket.error,AttributeError):

--- a/lib/exabgp/reactor/listener.py
+++ b/lib/exabgp/reactor/listener.py
@@ -67,6 +67,8 @@ class Listener (object):
 				MIN_TTL(sock,peer_ip,ttl_in)
 			try:
 				sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+				if local_ip.ipv6():
+					sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_V6ONLY, 1)
 			except (socket.error,AttributeError):
 				pass
 			sock.setblocking(0)

--- a/lib/exabgp/reactor/loop.py
+++ b/lib/exabgp/reactor/loop.py
@@ -44,7 +44,7 @@ class Reactor (object):
 	clear = concat_bytes_i(character(int(c,16)) for c in ['0x1b', '0x5b', '0x48', '0x1b', '0x5b', '0x32', '0x4a'])
 
 	def __init__ (self, configurations):
-		self.ip = environment.settings().tcp.bind
+		self.ips = environment.settings().tcp.bind
 		self.port = environment.settings().tcp.port
 		self.ack = environment.settings().api.ack
 
@@ -149,15 +149,13 @@ class Reactor (object):
 
 	def _setup_listener (self):
 		try:
-			if self.ip:
-				self.listener = Listener()
-				self.listener.listen(IP.create(self.ip),IP.create('0.0.0.0'),self.port,None,False,None)
-				self.logger.reactor('Listening for BGP session(s) on %s:%d' % (self.ip,self.port))
+			self.listener = Listener()
+			for ip in self.ips:
+				self.listener.listen(ip,IP.create('0.0.0.0'),self.port,None,False,None)
+				self.logger.reactor('Listening for BGP session(s) on %s:%d' % (ip,self.port))
 
 			for neighbor in self.configuration.neighbors.values():
 				if neighbor.listen:
-					if not self.listener:
-						self.listener = Listener()
 					self.listener.listen(neighbor.md5_ip,neighbor.peer_address,neighbor.listen,neighbor.md5_password,neighbor.md5_base64,neighbor.ttl_in)
 					self.logger.reactor('Listening for BGP session(s) on %s:%d%s' % (neighbor.md5_ip,neighbor.listen,' with MD5' if neighbor.md5_password else ''))
 			return True


### PR DESCRIPTION
This adds support for configuring multiple bind address in the environment file for global listeners. Particularly we use this so we are able to setup for an IPv6 listener on :: and an IPv4 listener on 0.0.0.0. It also adds support for adding and removing the correct md5 key mappings to any configured global listeners when the configuration file changes so that incoming md5 connections will work.

This patch should only affect the global listeners defined in the environment file and not the per neighbor ones that can be created by the listen directive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/646)
<!-- Reviewable:end -->
