### PR TITLE
Misc updates for 4.0.0 release

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,18 @@
+exabgp (4.0.0-1) UNRELEASED; urgency=medium
+
+  * New upstream release.
+  * Add Python 3 support:
+    - d/control: Add python{3}-exabgp, exabgp-common packages.
+    - d/exabgp-common.install: Install /usr/share/exabgp/*.
+    - d/control,rules: Switch buildsystem to pybuild.
+    - d/rules: Limit unit testing to Python 2 for now.
+    - d/control: Add required BD's for Python 3 support.
+    - d/python{3}-exabgp.{postinst,prerm}: Install exabgp binary
+      using alternatives for Python 2 or Python 3 versions.
+  * d/rules: Tidy etc/exabgp/exabgp.env on clean.
+
+ -- James Page <james.page@ubuntu.com>  Wed, 24 May 2017 16:54:34 +0100
+
 exabgp (3.4.17-3) unstable; urgency=medium
 
   * d/exabgp.postinst: provide complete paths to dpkg-maintscript-helper.

--- a/debian/control
+++ b/debian/control
@@ -23,8 +23,6 @@ Vcs-Git: https://github.com/Exa-Networks/exabgp.git -b debian/sid
 Package: exabgp-common
 Architecture: all
 Depends: ${misc:Depends},
-         ${python3:Depends},
-         ${python:Depends},
 Description: BGP swiss army knife of networking - common files
  ExaBGP allows engineers to control their network from commodity
  servers. Think of it as Software Defined Networking using BGP by
@@ -45,8 +43,8 @@ Section: python
 Depends: exabgp-common (= ${binary:Version}),
          ${misc:Depends},
          ${python:Depends},
-Breaks: exabgp (<< 4.0.0-0ubuntu1~),
-Replaces: exabgp (<< 4.0.0-0ubuntu1~),
+Breaks: exabgp (<< 4.0.0-1~),
+Replaces: exabgp (<< 4.0.0-1~),
 Description: BGP swiss army knife of networking - Python 2 module
  ExaBGP allows engineers to control their network from commodity
  servers. Think of it as Software Defined Networking using BGP by

--- a/debian/control
+++ b/debian/control
@@ -3,26 +3,95 @@ Maintainer: Vincent Bernat <bernat@debian.org>
 Section: net
 Priority: optional
 Build-Depends: debhelper (>= 9),
-               python (>= 2.7),
+               dh-python,
+               python-all (>= 2.7),
                python-setuptools,
-               python-ipaddr,
-               python-psutil,
-               python-nose
+               python3-all,
+               python3-setuptools,
+Build-Depends-Indep: python-ipaddr,
+                     python-nose,
+                     python-psutil,
+                     python-six,
+                     python3-nose,
+                     python3-psutil,
+                     python3-six,
 Standards-Version: 3.9.8
 Homepage: https://github.com/Exa-Networks/exabgp
 Vcs-Browser: https://github.com/Exa-Networks/exabgp/tree/debian/sid
 Vcs-Git: https://github.com/Exa-Networks/exabgp.git -b debian/sid
 
+Package: exabgp-common
+Architecture: all
+Depends: ${misc:Depends},
+         ${python3:Depends},
+         ${python:Depends},
+Description: BGP swiss army knife of networking - common files
+ ExaBGP allows engineers to control their network from commodity
+ servers. Think of it as Software Defined Networking using BGP by
+ transforming BGP messages into friendly plain text or JSON.
+ .
+ Current documented use cases include DDOS mitigation, network
+ visualisation, service high availability, anycast.
+ .
+ It features ASN4 (RFC 4893), IPv6 (RFC 4760), MPLS (RFC 4659), VPLS
+ (RFC 4762), Flow (RFC 5575), Graceful Restart (RFC 4724), Enhanced
+ Route Refresh (RFC 7313), AIGP (RFC 7311) and more.
+ .
+ This package provides files common to all Python modules.
+
+Package: python-exabgp
+Architecture: all
+Section: python
+Depends: exabgp-common (= ${binary:Version}),
+         ${misc:Depends},
+         ${python:Depends},
+Breaks: exabgp (<< 4.0.0-0ubuntu1~),
+Replaces: exabgp (<< 4.0.0-0ubuntu1~),
+Description: BGP swiss army knife of networking - Python 2 module
+ ExaBGP allows engineers to control their network from commodity
+ servers. Think of it as Software Defined Networking using BGP by
+ transforming BGP messages into friendly plain text or JSON.
+ .
+ Current documented use cases include DDOS mitigation, network
+ visualisation, service high availability, anycast.
+ .
+ It features ASN4 (RFC 4893), IPv6 (RFC 4760), MPLS (RFC 4659), VPLS
+ (RFC 4762), Flow (RFC 5575), Graceful Restart (RFC 4724), Enhanced
+ Route Refresh (RFC 7313), AIGP (RFC 7311) and more.
+ .
+ This package provides the Python 2 module of exabgp.
+
+Package: python3-exabgp
+Architecture: all
+Section: python
+Depends: exabgp-common (= ${binary:Version}),
+         ${misc:Depends},
+         ${python3:Depends},
+Description: BGP swiss army knife of networking - Python 3 module
+ ExaBGP allows engineers to control their network from commodity
+ servers. Think of it as Software Defined Networking using BGP by
+ transforming BGP messages into friendly plain text or JSON.
+ .
+ Current documented use cases include DDOS mitigation, network
+ visualisation, service high availability, anycast.
+ .
+ It features ASN4 (RFC 4893), IPv6 (RFC 4760), MPLS (RFC 4659), VPLS
+ (RFC 4762), Flow (RFC 5575), Graceful Restart (RFC 4724), Enhanced
+ Route Refresh (RFC 7313), AIGP (RFC 7311) and more.
+ .
+ This package provides the Python 3 module of exabgp.
+
 Package: exabgp
 Architecture: all
 Pre-Depends: debconf (>= 1.5.34),
-             dpkg (>= 1.15.7.2)
-Depends: ${misc:Depends},
-         ${python:Depends},
+             dpkg (>= 1.15.7.2),
+Depends: adduser,
+         lsb-base (>= 3.2-14),
+         python-exabgp (= ${binary:Version}) | python3-exabgp (= ${binary:Version}),
          python-pkg-resources,
-         adduser,
          ucf,
-         lsb-base (>= 3.2-14)
+         ${misc:Depends},
+         ${python:Depends},
 Description: BGP swiss army knife of networking
  ExaBGP allows engineers to control their network from commodity
  servers. Think of it as Software Defined Networking using BGP by

--- a/debian/exabgp-common.install
+++ b/debian/exabgp-common.install
@@ -1,0 +1,2 @@
+etc/exabgp/* usr/share/exabgp
+qa/conf/* usr/share/exabgp/etc

--- a/debian/python-exabgp.postinst
+++ b/debian/python-exabgp.postinst
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "configure" ] ; then
+	update-alternatives --install /usr/sbin/exabgp exabgp /usr/sbin/python2-exabgp 300
+fi
+
+#DEBHELPER#
+
+exit 0

--- a/debian/python-exabgp.prerm
+++ b/debian/python-exabgp.prerm
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "remove" ] ; then
+	update-alternatives --remove exabgp /usr/sbin/python2-exabgp
+fi
+
+#DEBHELPER#
+
+exit 0

--- a/debian/python3-exabgp.postinst
+++ b/debian/python3-exabgp.postinst
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "configure" ] ; then
+	update-alternatives --install /usr/sbin/exabgp exabgp /usr/sbin/python3-exabgp 200
+fi
+
+#DEBHELPER#
+
+exit 0

--- a/debian/python3-exabgp.prerm
+++ b/debian/python3-exabgp.prerm
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+set -e
+
+if [ "$1" = "remove" ] ; then
+	update-alternatives --remove exabgp /usr/sbin/python3-exabgp
+fi
+
+#DEBHELPER#
+
+exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -1,13 +1,30 @@
 #!/usr/bin/make -f
 
+export PYBUILD_NAME=exabgp
+
+PYTHONS:=$(shell pyversions -vr)
+PYTHON3S:=$(shell py3versions -vr)
+
 %:
-	dh $@ --with python2
+	dh $@ --with python2,python3 --buildsystem=pybuild
 
 override_dh_auto_install:
-	dh_auto_install -- --install-scripts=/usr/sbin
-	rm -rf $(CURDIR)/debian/exabgp/usr/etc
+	dh_auto_install --buildsystem=pybuild
+	rm -rf $(CURDIR)/debian/exabgp/usr/etc $(CURDIR)/debian/python*-exabgp/usr/share/exabgp
+	mkdir -p $(CURDIR)/debian/python-exabgp/usr/sbin $(CURDIR)/debian/python3-exabgp/usr/sbin
+	mv $(CURDIR)/debian/python-exabgp/usr/bin/exabgp $(CURDIR)/debian/python-exabgp/usr/sbin/python2-exabgp
+	mv $(CURDIR)/debian/python3-exabgp/usr/bin/exabgp $(CURDIR)/debian/python3-exabgp/usr/sbin/python3-exabgp
 
 override_dh_auto_test:
-	env INTERPRETER=python sbin/exabgp --fi > etc/exabgp/exabgp.env
-	env INTERPRETER=python ./qa/bin/parsing
-	env INTERPRETER=python ETC=$(CURDIR)/etc/exabgp exabgp_log_enable=false nosetests ./qa/tests/*_test.py
+ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
+	set -e; set -x; for pyvers in $(PYTHONS); do \
+		PYMAJOR=`echo $$pyvers | cut -d '.' -f 1`; \
+		env INTERPRETER=python$$pyvers sbin/exabgp --fi > etc/exabgp/exabgp.env ; \
+		env INTERPRETER=python$$pyvers ./qa/bin/parsing ; \
+		env INTERPRETER=python$$pyvers ETC=$(CURDIR)/etc/exabgp exabgp_log_enable=false python$$pyvers -m nose ./qa/tests/*_test.py ; \
+	done
+endif
+
+override_dh_auto_clean:
+	dh_auto_clean --buildsystem=pybuild
+	rm -f etc/exabgp/exabgp.env


### PR DESCRIPTION
Update to 4.0.0 release.

Add Python 3 support; this involved some restructuring to have Py2 and Py3 binary packages, with a shared -common package with exabgp using Py2 or Py3 based on which is installed.

/usr/sbin/exabgp is managed via alternatives -> python2-exabgp | python3-exabgp.

I also switched the build system to pybuild as this does a few automagic things with regards to multiple python versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/649)
<!-- Reviewable:end -->
