### PR TITLE
Fix flag comparison operator in BGP-LS SPRING extensions

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/bgpls/link/sradj.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/link/sradj.py
@@ -56,11 +56,12 @@ class SrAdjacency(object):
 		while data:
 			# Range Size: 3 octet value indicating the number of labels in
 			# the range.
-			if flags.flags['V'] and flags.flags['L']:
+			if int(flags.flags['V']) and int(flags.flags['L']):
 				b = BitArray(bytes=data[:3])
 				sid = b.unpack('uintbe:24')[0]
 				data = data[3:]
-			elif (not flags.flags['V']) and (not flags.flags['L']):
+			elif (not int(flags.flags['V'])) and \
+				(not int(flags.flags['L'])):
 				sid = unpack('!I',data[:4])[0]
 				data = data[4:]
 			sids.append(sid)

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/link/sradjlan.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/link/sradjlan.py
@@ -67,11 +67,12 @@ class SrAdjacencyLan(object):
 		while data:
 			# Range Size: 3 octet value indicating the number of labels in
 			# the range.
-			if flags.flags['V'] and flags.flags['L']:
+			if int(flags.flags['V']) and int(flags.flags['L']):
 				b = BitArray(bytes=data[:3])
 				sid = b.unpack('uintbe:24')[0]
 				data = data[3:]
-			elif (not flags.flags['V']) and (not flags.flags['L']):
+			elif (not int(flags.flags['V'])) and \
+				(not int(flags.flags['L'])):
 				sid = unpack('!I',data[:4])[0]
 				data = data[4:]
 			sids.append(sid)

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/srprefix.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/srprefix.py
@@ -55,11 +55,12 @@ class SrPrefix(object):
 		#  	 Section 3.1.  In this case V and L flags MUST be unset.
 		sids = []
 		while data:
-			if flags.flags['V'] and flags.flags['L']:
+			if int(flags.flags['V']) and int(flags.flags['L']):
 				b = BitArray(bytes=data[:3])
 				sid = b.unpack('uintbe:24')[0]
 				data = data[3:]
-			elif (not flags.flags['V']) and (not flags.flags['L']):
+			elif (not int(flags.flags['V'])) and \
+				(not int(flags.flags['L'])):
 				sid = unpack('!I',data[:4])[0]
 				data = data[4:]
 			sids.append(sid)


### PR DESCRIPTION
This patch fixes issue #653.

Flags are produced as strings by LsGenericFlags.unpack(). We convert to int() while comparing them.

`exabgp config.ini --decode "0000 0056 4001 0100 4002 0040 0504 0000 0064 801D 0C04 8600 0840 0000 0000 0000 8C90 0E00 3540 0447 04C0 0002 0100 0003 0028 0200 0000 0000 0000 0001 0000 1202 0000 0400 00FD E802 0300 0610 0000 0000 0401 0900 0520 C000 0204"`

```
Sun
, 11 Jun 2017 19:00:40 | error    | 29933  | ExaBGP        | 
Sun, 11 Jun 2017 19:00:40 | error    | 29933  | version       | 4.0.0-0478a014
Sun, 11 Jun 2017 19:00:40 | error    | 29933  | interpreter   | 2.7.10 (default, Feb  7 2017, 00:08:15)  [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
Sun, 11 Jun 2017 19:00:40 | error    | 29933  | os            | Darwin tw-mbp-evila 16.6.0 Darwin Kernel Version 16.6.0: Fri Apr 14 16:21:16 PDT 2017; root:xnu-3789.60.24~6/RELEASE_X86_64 x86_64
Sun, 11 Jun 2017 19:00:40 | error    | 29933  | ExaBGP        | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | environment file missing
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | generate it using "exabgp --fi > /Users/evila/workspace/moi/exabgp/moi/etc/exabgp/exabgp.env"
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | reactor       | performing reload of exabgp 4.0.0-0478a014
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | > process          | 'parsed-route-backend'
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | . run              | '/Users/evila/workspace/moi/exa-local/etc/exabgp/processes/syslog-1.py'
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | . encoder          | 'json'
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | < process          | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | > neighbor         | '10.30.4.3'
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | . local-address    | '10.30.4.2'
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | . local-as         | '65050'
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | . peer-as          | '65000'
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | > family           | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | . ipv4             | 'nlri-mpls'
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | . bgpls            | 'bgp-ls'
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | < family           | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | > api              | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | . processes        | '[' 'parsed-route-backend' ']'
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | > receive          | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | . parsed           | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | . update           | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | < receive          | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | < api              | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | configuration | < neighbor         | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | decoding routes in configuration
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | header missing, assuming this message is ONE update
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | parsing UPDATE (  90) 0000 0056 4001 0100 4002 0040 0504 0000 0064 801D 0C04 8600 0840 0000 0000 0000 8C90 0E00 3540 0447 04C0 0002 0100 0003 0028 0200 0000 0000 0000 0001 0000 1202 0000 0400 00FD E802 0300 0610 0000 0000 0401 0900 0520 C000 0204
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | withdrawn NLRI none
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | attribute origin             flag 0x40 type 0x01 len 0x01 payload 00
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | attribute as-path            flag 0x40 type 0x02 len 0x00
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | attribute local-preference   flag 0x40 type 0x05 len 0x04 payload 0000 0064
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | attribute bgp-ls             flag 0x80 type 0x1d len 0x0c payload 0486 0008 4000 0000 0000 008C
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | attribute mp-reach-nlri      flag 0x90 type 0x0e len 0x35 payload 4004 4704 C000 0201 0000 0300 2802 0000 0000 0000 0000 0100 0012 0200 0004 0000 FDE8 0203 0006 1000 0000 0004 0109 0005 20C0 0002 04
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | NLRI      16388 71           without path-information     payload 0003 0028 0200 0000 0000 0000 0001 0000 1202 0000 0400 00FD E802 0300 0610 0000 0000 0401 0900 0520 C000 0204
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | announced NLRI none
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | 
Sun, 11 Jun 2017 19:00:40 | INFO     | 29933  | parser        | decoded update 1 { "ls-nlri-type": 3, "l3-routing-topology": 0, "protocol-id": 2, "node-descriptors": { "autonomous-system": "65000", "router-id": "100000000004" }, "ip-reachability-tlv": "192.0.2.4", "nexthop": "192.0.2.1" } origin igp local-preference 100 bgp-ls prefix_flags: {'E': '0', 'L': '0', 'N': '1', 'P': '0', 'R': '0', 'V': '0', 'RSV': '0'}, sids: [140]

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/654)
<!-- Reviewable:end -->
