### PR TITLE
Fix a bunch of encoding errors in prefix-sid attribute

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/srprefix.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/srprefix.py
@@ -68,5 +68,5 @@ class SrPrefix(object):
 		return cls(flags=flags.flags, sids=sids, sr_algo=sr_algo)
 
 	def json (self,compact=None):
-		return '"sr-adj-flags": "%s", "sids": "%s", "sr-algorithm": "%s"' % (self.flags,
+		return '"sr-prefix-flags": "%s", "sids": "%s", "sr-algorithm": "%s"' % (self.flags,
 				self.sids, self.sr_algo)

--- a/lib/exabgp/bgp/message/update/attribute/sr/labelindex.py
+++ b/lib/exabgp/bgp/message/update/attribute/sr/labelindex.py
@@ -33,7 +33,7 @@ class SrLabelIndex(object):
 		self.packed = self.pack()
 
 	def __repr__ (self):
-		return "sr-label-index %s" % (self.labelindex)
+		return "%s" % (self.labelindex)
 
 	def pack (self):
 		t = pack('!B', self.TLV)
@@ -60,4 +60,4 @@ class SrLabelIndex(object):
 		return cls(labelindex=labelindex,packed=data)
 
 	def json (self,compact=None):
-		return '"sr-label-index": "%s"' % (self.labelindex)
+		return '"sr-label-index": %d' % (self.labelindex)

--- a/lib/exabgp/bgp/message/update/attribute/sr/prefixsid.py
+++ b/lib/exabgp/bgp/message/update/attribute/sr/prefixsid.py
@@ -66,7 +66,12 @@ class PrefixSid (Attribute):
 		return '{ %s }' % (content)
 
 	def __str__(self):
-		return ', '.join(str(d) for d in self.sr_attrs)
+		label_index = next((i for i in self.sr_attrs if i.TLV == 1), None)
+		srgb = next((i for i in self.sr_attrs if i.TLV == 3), None)
+		if srgb:
+			return "[ {}, {} ]".format(str(label_index), str(srgb))
+		else:
+			return "[ {} ]".format(str(label_index))
 
 	def pack (self, negotiated=None):
 		return self._packed

--- a/lib/exabgp/bgp/message/update/attribute/sr/srgb.py
+++ b/lib/exabgp/bgp/message/update/attribute/sr/srgb.py
@@ -48,8 +48,8 @@ class SrGb(object):
 
 	def __repr__ (self):
 		items = []
-		for base, range in self.srgbs:
-			items.append("( {},{} )".format(base,range))
+		for base, srange in self.srgbs:
+			items.append("( {},{} )".format(base, srange))
 		return '[ {} ]'.format(', '.join(items))
 
 	def pack (self):

--- a/lib/exabgp/bgp/message/update/attribute/sr/srgb.py
+++ b/lib/exabgp/bgp/message/update/attribute/sr/srgb.py
@@ -5,6 +5,7 @@ sr/srgb.py
 Created by Evelio Vila 2017-02-16
 Copyright (c) 2009-2017 Exa Networks. All rights reserved.
 """
+import json
 from struct import pack, unpack
 
 from exabgp.util import concat_bytes
@@ -42,11 +43,14 @@ class SrGb(object):
 	LENGTH = -1
 
 	def __init__ (self, srgbs, packed=None):
-		self.srgbs = sorted(srgbs)
+		self.srgbs = srgbs
 		self.packed = self.pack()
 
 	def __repr__ (self):
-		return "sr-srgbs %s" % (self.srgbs)
+		items = []
+		for base, range in self.srgbs:
+			items.append("( {},{} )".format(base,range))
+		return '[ {} ]'.format(', '.join(items))
 
 	def pack (self):
 		t = pack('!B', self.TLV)
@@ -80,4 +84,4 @@ class SrGb(object):
 		return cls(srgbs=srgbs)
 
 	def json (self,compact=None):
-		return '"sr-srgbs": "%s"' % (self.srgbs)
+		return '"sr-srgbs": {}'.format((json.dumps(self.srgbs)))


### PR DESCRIPTION
this should fix #640 .

For #662 I removed a sorted() statement, hopefully, that would be enough?

Apologies for the long delay.

Decoded output now looks like
```
Thu, 22 Jun 2017 22:57:21 | INFO     | 54515  | parser        | decoded update 1 198.51.100.101/32 label [ 800002 ] next-hop 198.51.100.2 origin igp local-preference 100 bgp-prefix-sid [ 300, [ ( 1000000,5000 ), ( 800000,4096 ) ] ]
```
```
Thu, 22 Jun 2017 22:57:21 | INFO     | 54515  | parser        | update json { "exabgp": "4.0.1", "time": 1498197441.72, "host" : "tw-mbp-evila", "pid" : 54515, "ppid" : 40830, "counter": 1, "type": "update", "neighbor": { "address": { "local": "10.30.4.2", "peer": "10.30.4.3" }, "asn": { "local": "65050", "peer": "65000" }, "direction": "in", "message": { "update": { "attribute": { "origin": "igp", "local-preference": 100, "bgp-prefix-sid": { "sr-label-index": 300, "sr-srgbs": [[1000000, 5000], [800000, 4096]] } }, "announce": { "ipv4 nlri-mpls": { "198.51.100.2": [ { "nlri": "198.51.100.101/32", "label": [ 800002 ] } ] } } } } } }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/665)
<!-- Reviewable:end -->
