### PR TITLE
Fix more Json encoding issues

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/bgpls/link/igpmetric.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/link/igpmetric.py
@@ -58,4 +58,4 @@ class IgpMetric(object):
 			raise Notify(3,5, "Incorrect IGP Metric Size")
 
 	def json (self,compact=None):
-		return '"igp-metric": "%s"' % self.igpmetric[0]
+		return '"igp-metric": %d' % int(self.igpmetric[0])

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/link/mplsmask.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/link/mplsmask.py
@@ -42,7 +42,7 @@ class MplsMask(object):
 			raise Notify(3,5, "LINK TLV length too large")
 		else:
 			mpls_mask = LsGenericFlags.unpack(data[0],LsGenericFlags.LS_MPLS_MASK)
-			return cls(mplsflags=mpls_mask.flags)
+			return cls(mplsflags=mpls_mask)
 
 	def json (self,compact=None):
-		return '"mpls-mask": "%s"' % self.mplsflags
+		return '"mpls-mask": {}'.format(self.mplsflags.json())

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/link/protection.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/link/protection.py
@@ -42,7 +42,7 @@ class LinkProtectionType(object):
 			# We only care about the first octect
 			protection_mask = LsGenericFlags.unpack(data[0],
 				LsGenericFlags.LS_PROTECTION_MASK)
-		return cls(protectionflags=protection_mask.flags)
+		return cls(protectionflags=protection_mask)
 
 	def json (self,compact=None):
-		return '"link-protection-flags": "%s"' % str(self.protectionflags)
+		return '"link-protection-flags": {}'.format(self.protectionflags.json())

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/link/sradj.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/link/sradj.py
@@ -5,6 +5,8 @@ sradj.py
 Created by Evelio Vila
 Copyright (c) 2014-2017 Exa Networks. All rights reserved.
 """
+
+import json
 from struct import unpack
 from exabgp.vendoring import six
 
@@ -60,13 +62,14 @@ class SrAdjacency(object):
 				b = BitArray(bytes=data[:3])
 				sid = b.unpack('uintbe:24')[0]
 				data = data[3:]
-			elif (not int(flags.flags['V'])) and \
-				(not int(flags.flags['L'])):
+			elif (not flags.flags['V']) and \
+				(not flags.flags['L']):
 				sid = unpack('!I',data[:4])[0]
 				data = data[4:]
 			sids.append(sid)
-		return cls(flags=flags.flags, sids=sids, weight=weight)
+		return cls(flags=flags, sids=sids, weight=weight)
 
 	def json (self,compact=None):
-		return '"sr-adj-flags": "%s", "sids": "%s", "sr-adj-weight": "%s"' % (self.flags,
-				self.sids, self.weight)
+		return ', '.join(['"sr-adj-flags": {}'.format(self.flags.json()),
+			'"sids": {}'.format(json.dumps(self.sids)),
+			'"sr-adj-weight": {}'.format(json.dumps(self.weight))])

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/link/sradjlan.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/link/sradjlan.py
@@ -6,6 +6,7 @@ Created by Evelio Vila
 Copyright (c) 2014-2017 Exa Networks. All rights reserved.
 """
 
+import json
 from struct import unpack
 from exabgp.vendoring import six
 
@@ -71,13 +72,14 @@ class SrAdjacencyLan(object):
 				b = BitArray(bytes=data[:3])
 				sid = b.unpack('uintbe:24')[0]
 				data = data[3:]
-			elif (not int(flags.flags['V'])) and \
-				(not int(flags.flags['L'])):
+			elif (not flags.flags['V']) and \
+				(not flags.flags['L']):
 				sid = unpack('!I',data[:4])[0]
 				data = data[4:]
 			sids.append(sid)
-		return cls(flags=flags.flags, sids=sids, weight=weight)
+		return cls(flags=flags, sids=sids, weight=weight)
 
 	def json (self,compact=None):
-		return '"sr-adj-lan-flags": "%s", "sids": "%s", "sr-adj-weight": "%s"' % (self.flags,
-				self.sids, self.weight)
+		return ', '.join(['"sr-adj-lan-flags": {}'.format(self.flags.json()),
+			'"sids": {}'.format(json.dumps(self.sids)),
+			'"sr-adj-lan-weight": {}'.format(json.dumps(self.weight))])

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/link/temetric.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/link/temetric.py
@@ -40,4 +40,4 @@ class TeMetric(object):
 			return cls(temetric=temetric)
 
 	def json (self,compact=None):
-		return '"te-metric": "%s"' % str(self.temetric)
+		return '"te-metric": %d' % int(str(self.temetric))

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
@@ -125,7 +125,6 @@ class LsGenericFlags(object):
 		valid_flags.append('0000')
 		if bit_array.bin in valid_flags:
 			flags = dict(zip(pattern, bit_array.bin))
-			print(flags)
 			flags = {k:int(v) for k, v in flags.items()}
 		else:
 			raise Notify(3,5, "Invalid SR flags mask")

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
@@ -5,6 +5,7 @@ Copyright (c) 2009-2017 Exa Networks. All rights reserved.
 License: 3-clause BSD. (See the COPYRIGHT file)
 """
 
+import json
 import binascii
 import itertools
 from struct import unpack
@@ -124,7 +125,14 @@ class LsGenericFlags(object):
 		valid_flags.append('0000')
 		if bit_array.bin in valid_flags:
 			flags = dict(zip(pattern, bit_array.bin))
+			print(flags)
+			flags = {k:int(v) for k, v in flags.items()}
 		else:
 			raise Notify(3,5, "Invalid SR flags mask")
 		return cls(flags=flags)
 
+	def json (self,compact=None):
+    		return json.dumps(self.flags)
+
+	def __repr__ (self):
+		return str(self.flags)

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/node/nodeflags.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/node/nodeflags.py
@@ -46,7 +46,7 @@ class NodeFlags(object):
 			raise Notify(3,5, "Node Flags TLV length too large")
 		else:
 			flags = LsGenericFlags.unpack(data[0],LsGenericFlags.LS_NODE_FLAGS)
-		return cls(nodeflags=flags.flags)
+		return cls(nodeflags=flags)
 
 	def json (self,compact=None):
-		return '"node-flags": "%s"' % str(self.nodeflags)
+		return '"node-flags": {}'.format(self.nodeflags.json())

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/node/sralgo.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/node/sralgo.py
@@ -6,6 +6,7 @@ Created by Evelio Vila
 Copyright (c) 2014-2017 Exa Networks. All rights reserved.
 """
 
+import json
 from struct import unpack
 from exabgp.vendoring import six
 
@@ -46,4 +47,4 @@ class SrAlgorithm(object):
 		return cls(sr_algos=sr_algos)
 
 	def json (self,compact=None):
-		return '"sr-algorithms": "%s"' % (self.sr_algos)
+		return '"sr-algorithms": {}'.format(json.dumps(self.sr_algos))

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/node/srcap.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/node/srcap.py
@@ -6,6 +6,7 @@ Created by Evelio Vila
 Copyright (c) 2014-2017 Exa Networks. All rights reserved.
 """
 
+import json
 from struct import unpack
 
 from exabgp.vendoring.bitstring import BitArray
@@ -74,9 +75,9 @@ class SrCapabilities(object):
 			sids.append((range_size, sid))
 			data = data[l+7:]
 
-		return cls(sr_flags=flags.flags, sids=sids)
+		return cls(sr_flags=flags, sids=sids)
 
 	def json (self,compact=None):
-		return '"sr-capability-flags": "%s", "sids": "%s"' % (self.sr_flags,
-				self.sids)
+		return ', '.join(['"sr-capability-flags": {}'.format(self.sr_flags.json()),
+			'"sids": {}'.format(json.dumps(self.sids))])
 

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/igpflags.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/igpflags.py
@@ -44,7 +44,7 @@ class IgpFlags(object):
 			raise Notify(3,5, "IGP Flags TLV length too large")
 		else:
 			flags = LsGenericFlags.unpack(data[0],LsGenericFlags.LS_IGP_FLAGS)
-			return cls(igpflags=flags.flags)
+			return cls(igpflags=flags)
 
 	def json (self,compact=None):
-		return '"igp-flags": "%s"' % str(self.igpflags)
+		return '"igp-flags": {}'.format(self.igpflags.json())

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/prefixmetric.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/prefixmetric.py
@@ -43,4 +43,4 @@ class PrefixMetric(object):
 			return cls(prefixmetric=metric)
 
 	def json (self,compact=None):
-		return '"prefix-metric": %d' % self.prefixmetric
+		return '"prefix-metric": %d' % int(self.prefixmetric)

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/prefixmetric.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/prefixmetric.py
@@ -43,4 +43,4 @@ class PrefixMetric(object):
 			return cls(prefixmetric=metric)
 
 	def json (self,compact=None):
-		return '"prefix-metric": "%s"' % str(self.prefixmetric)
+		return '"prefix-metric": %d' % self.prefixmetric

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/srigpprefixattr.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/srigpprefixattr.py
@@ -6,6 +6,8 @@ Created by Evelio Vila
 Copyright (c) 2014-2017 Exa Networks. All rights reserved.
 """
 
+import json
+
 from exabgp.bgp.message.update.attribute.bgpls.linkstate import LINKSTATE, LsGenericFlags
 
 #    draft-gredler-idr-bgp-ls-segment-routing-ext-03
@@ -31,7 +33,7 @@ class SrIgpPrefixAttr(object):
 	def unpack (cls,data,length):
 		# We only support IS-IS for now.
 		flags = LsGenericFlags.unpack(data[0],LsGenericFlags.ISIS_SR_ATTR_FLAGS)
-		return cls(flags=flags.flags)
+		return cls(flags=flags)
 
 	def json (self,compact=None):
-		return '"sr-prefix-attribute-flags": "%s"' % (self.flags)
+		return '"sr-prefix-attribute-flags": {}'.format(self.flags.json())

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/srprefix.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/srprefix.py
@@ -11,6 +11,7 @@ from struct import unpack
 from exabgp.vendoring import six
 
 from exabgp.vendoring.bitstring import BitArray
+from exabgp.bgp.message.notification import Notify
 from exabgp.bgp.message.update.attribute.bgpls.linkstate import LINKSTATE, LsGenericFlags
 
 #    draft-gredler-idr-bgp-ls-segment-routing-ext-03
@@ -62,10 +63,13 @@ class SrPrefix(object):
 				data = data[3:]
 			elif (not flags.flags['V']) and \
 				(not flags.flags['L']):
+				if len(data) != 4:
+    				# Cisco IOS XR Software, Version 6.1.1.19I is not
+					# correctly setting the flags
+					raise Notify(3,5, "SID/Label size doesn't match V and L flag state")
 				sid = unpack('!I', data[:4])[0]
 				data = data[4:]
 			sids.append(sid)
-
 		return cls(flags=flags, sids=sids, sr_algo=sr_algo)
 
 	def json (self,compact=None):

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/srprefix.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/prefix/srprefix.py
@@ -6,6 +6,7 @@ Created by Evelio Vila
 Copyright (c) 2014-2017 Exa Networks. All rights reserved.
 """
 
+import json
 from struct import unpack
 from exabgp.vendoring import six
 
@@ -41,7 +42,7 @@ class SrPrefix(object):
 		flags = LsGenericFlags.unpack(data[0],LsGenericFlags.ISIS_SR_FLAGS)
 		#
 		# Parse Algorithm
-		sr_algo = six.indexbytes(data,1)
+		sr_algo = six.indexbytes(data, 1)
 		# Move pointer 4 bytes: Flags(1) + Algorithm(1) + Reserved(2)
 		data = data[4:]
      	# SID/Index/Label: according to the V and L flags, it contains
@@ -55,18 +56,19 @@ class SrPrefix(object):
 		#  	 Section 3.1.  In this case V and L flags MUST be unset.
 		sids = []
 		while data:
-			if int(flags.flags['V']) and int(flags.flags['L']):
+			if flags.flags['V'] and flags.flags['L']:
 				b = BitArray(bytes=data[:3])
 				sid = b.unpack('uintbe:24')[0]
 				data = data[3:]
-			elif (not int(flags.flags['V'])) and \
-				(not int(flags.flags['L'])):
-				sid = unpack('!I',data[:4])[0]
+			elif (not flags.flags['V']) and \
+				(not flags.flags['L']):
+				sid = unpack('!I', data[:4])[0]
 				data = data[4:]
 			sids.append(sid)
 
-		return cls(flags=flags.flags, sids=sids, sr_algo=sr_algo)
+		return cls(flags=flags, sids=sids, sr_algo=sr_algo)
 
 	def json (self,compact=None):
-		return '"sr-prefix-flags": "%s", "sids": "%s", "sr-algorithm": "%s"' % (self.flags,
-				self.sids, self.sr_algo)
+		return ', '.join(['"sr-prefix-flags": {}'.format(self.flags.json()),
+			'"sids": {}'.format(json.dumps(self.sids)),
+			'"sr-algorithm": {}'.format(json.dumps(self.sr_algo))])

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/link.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/link.py
@@ -169,8 +169,8 @@ class LINK(BGPLS):
 		interface_addrs = ', '.join(d.json() for d in self.iface_addrs)
 		neighbor_addrs = ', '.join(d.json() for d in self.neigh_addrs)
 		content = '"ls-nlri-type": 2, '
-		content += '"l3-routing-topology": "%s", ' % self.domain
-		content += '"protocol-id": %d, ' % self.proto_id
+		content += '"l3-routing-topology": %d, ' % int(self.domain)
+		content += '"protocol-id": %d, ' % int(self.proto_id)
 		content += '"local-node-descriptors": { %s }, ' % local
 		content += '"remote-node-descriptors": { %s }, ' % remote
 		content += '"interface-address": { %s }, ' % interface_addrs

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/node.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/node.py
@@ -56,8 +56,8 @@ class NODE(BGPLS):
 		nodes = ', '.join(d.json() for d in self.node_ids)
 		content = ', '.join([
 			'"ls-nlri-type": 1',
-			'"l3-routing-topology": %s' % self.domain,
-			'"protocol-id": %s' % self.proto_id,
+			'"l3-routing-topology": %d' % int(self.domain),
+			'"protocol-id": %d' % int(self.proto_id),
 			'"node-descriptors": { %s }' % nodes,
 			'"nexthop": "%s"' % self.nexthop,
 		])

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv4.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv4.py
@@ -115,8 +115,8 @@ class PREFIXv4(BGPLS):
 		nodes = ', '.join(d.json() for d in self.local_node)
 		content = ', '.join([
 			'"ls-nlri-type": 3',
-			'"l3-routing-topology": %s' % self.domain,
-			'"protocol-id": %s' % self.proto_id,
+			'"l3-routing-topology": %d' % int(self.domain),
+			'"protocol-id": %d' % int(self.proto_id),
 			'"node-descriptors": { %s }' % nodes,
 			self.prefix.json(),
 			'"nexthop": "%s"' % self.nexthop,

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/node.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/node.py
@@ -131,7 +131,7 @@ class NodeDescriptor (object):
 		if self.dtype == 515:
 			router_id = '"router-id": "%s"' % self.node_id
 		if self.dtype == 512:
-			asn = '"autonomous-system": "%d"' % self.node_id
+			asn = '"autonomous-system": %d' % self.node_id
 		if self.dtype == 513:
 			bgpls_id = '"bgp-ls-identifier": "%d"' % self.node_id
 		content = ', '.join(d for d in [ospf,designated,psn,router_id,asn,bgpls_id] if d)


### PR DESCRIPTION
This PR makes sure that all JSON BPG-LS extensions are correctly formatted, in particular cases where integers should be present but instead we were showing strings.

Node NLRI format:

```
 exabgp config.ini.test --decode ffffffffffffffffffffffffffffffff0165020000014e4001010040020602010000fde8801d560440000400000000044100044cee6b28044200044cee6b28044300204cee6b284cee6b284cee6b284cee6b284cee6b284cee6b284cee6b284cee6b28044400040000000a0447000300000a044b000730000000049320900e00e440044704ac18f834000002004502000000000000000001000012020000040000fde80203000617200016000201010012020000040000fde802030006172000160001010300040a000019010400040a0000180002004502000000000000000001000012020000040000fde80203000617200016000101010012020000040000fde802030006172000160002010300040a000018010400040a0000190002004502000000000000000001000012020000040000fde80203000617200016003301010012020000040000fde802030006172000160001010300040a000009010400040a000008

```
decoded as:
```
update json { "exabgp": "4.0.1", "time": 1498266775.73, "host" : "ruissalo", "pid" : 85382, "ppid" : 60690, "counter": 1, "type": "update", "neighbor": { "address": { "local": "172.24.248.5", "peer": "172.24.248.79" }, "asn": { "local": "65000", "peer": "65000" }, "direction": "in", "message": { "update": { "attribute": { "origin": "igp", "as-path": [ 65000 ], "confederation-path": [], "bgp-ls": { "admin-group-mask": [0], "maximum-link-bandwidth": 125000000.0, "maximum-reservable-link-bandwidth": 125000000.0, "unreserved-bandwidth": [125000000.0, 125000000.0, 125000000.0, 125000000.0, 125000000.0, 125000000.0, 125000000.0, 125000000.0], "te-metric": 10, "igp-metric": 10, "sr-adj-flags": {"B": 0, "F": 0, "L": 1, "P": 0, "S": 0, "V": 1, "RSV": 0}, "sids": [299808], "sr-adj-weight": 0 } }, "announce": { "bgpls bgp-ls": { "172.24.248.52": [ { "ls-nlri-type": 2, "l3-routing-topology": 0, "protocol-id": 2, "local-node-descriptors": { "autonomous-system": 65000, "router-id": "172000160002" }, "remote-node-descriptors": { "autonomous-system": 65000, "router-id": "172000160001" }, "interface-address": { "interface-address": "10.0.0.25" }, "neighbor-address": { "neighbor-address": "10.0.0.24" } }, { "ls-nlri-type": 2, "l3-routing-topology": 0, "protocol-id": 2, "local-node-descriptors": { "autonomous-system": 65000, "router-id": "172000160001" }, "remote-node-descriptors": { "autonomous-system": 65000, "router-id": "172000160002" }, "interface-address": { "interface-address": "10.0.0.24" }, "neighbor-address": { "neighbor-address": "10.0.0.25" } }, { "ls-nlri-type": 2, "l3-routing-topology": 0, "protocol-id": 2, "local-node-descriptors": { "autonomous-system": 65000, "router-id": "172000160033" }, "remote-node-descriptors": { "autonomous-system": 65000, "router-id": "172000160001" }, "interface-address": { "interface-address": "10.0.0.9" }, "neighbor-address": { "neighbor-address": "10.0.0.8" } } ] } } } } } }
```

Link NLRI
```
 exabgp config.ini.test --decode ffffffffffffffffffffffffffffffff007b02000000644001010040020602010000fde8801d2404000001000403000349000204040004ac100058040a000c80000001f5048900030f4240900e002c40044704ac18f834000001001f02000000000000000001000012020000040000fde802030006172000160088
```


decoded as

```
update json { "exabgp": "4.0.1", "time": 1498266875.11, "host" : "ruissalo", "pid" : 85393, "ppid" : 60690, "counter": 1, "type": "update", "neighbor": { "address": { "local": "172.24.248.5", "peer": "172.24.248.79" }, "asn": { "local": "65000", "peer": "65000" }, "direction": "in", "message": { "update": { "attribute": { "origin": "igp", "as-path": [ 65000 ], "confederation-path": [], "bgp-ls": { "node-flags": {"B": 0, "E": 0, "T": 0, "O": 0}, "area-id": "490002", "local-te-router-id": "172.16.0.88", "sr-capability-flags": {"I": 1, "RSV": 0, "V": 0}, "sids": [[501, 1000000]] } }, "announce": { "bgpls bgp-ls": { "172.24.248.52": [ { "ls-nlri-type": 1, "l3-routing-topology": 0, "protocol-id": 2, "node-descriptors": { "autonomous-system": 65000, "router-id": "172000160088" }, "nexthop": "172.24.248.52" } ] } } } } } }
```

Prefix NLRI
```
exabgp config.ini --decode "0000 0056 4001 0100 4002 0040 0504 0000 0064 801D 0C04 8600 0840 0000 0000 0000 8C90 0E00 3540 0447 04C0 0002 0100 0003 0028 0200 0000 0000 0000 0001 0000 1202 0000 0400 00FD E802 0300 0610 0000 0000 0401 0900 0520 C000 0204"
```

```
update json { "exabgp": "4.0.1", "time": 1498267031.93, "host" : "ruissalo", "pid" : 85407, "ppid" : 60690, "counter": 1, "type": "update", "neighbor": { "address": { "local": "172.24.248.5", "peer": "172.24.248.79" }, "asn": { "local": "65000", "peer": "65000" }, "direction": "in", "message": { "update": { "attribute": { "origin": "igp", "local-preference": 100, "bgp-ls": { "sr-prefix-flags": {"E": 0, "L": 0, "N": 1, "P": 0, "R": 0, "V": 0, "RSV": 0}, "sids": [140], "sr-algorithm": 0 } }, "announce": { "bgpls bgp-ls": { "192.0.2.1": [ { "ls-nlri-type": 3, "l3-routing-topology": 0, "protocol-id": 2, "node-descriptors": { "autonomous-system": 65000, "router-id": "100000000004" }, "ip-reachability-tlv": "192.0.2.4", "nexthop": "192.0.2.1" } ] } } } } } }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/667)
<!-- Reviewable:end -->
