### PR TITLE
Issue:661 Preserving the order in which the routes are added

### DIFF
--- a/lib/exabgp/rib/store.py
+++ b/lib/exabgp/rib/store.py
@@ -6,6 +6,8 @@ Created by Thomas Mangin on 2009-11-05.
 Copyright (c) 2009-2015 Exa Networks. All rights reserved.
 """
 
+from collections import OrderedDict
+
 from exabgp.bgp.message import IN
 from exabgp.bgp.message import OUT
 from exabgp.bgp.message.update import Update
@@ -189,7 +191,7 @@ class Store (object):
 						return
 
 		# add the route to the list to be announced
-		dict_sorted.setdefault(change_attr_index,{})[change_nlri_index] = change
+		dict_sorted.setdefault(change_attr_index,OrderedDict())[change_nlri_index] = change
 		dict_nlri[change_nlri_index] = change
 
 		if change_attr_index not in dict_attr:


### PR DESCRIPTION
Preserving the order in which the routes are added by using collections.OrderedDict instead of Dictionary. When the order is not preserved as the Dictionary returns the values in any order, Exabgp results in announcing the route that may not be the latest.

This fixes the issue: https://github.com/Exa-Networks/exabgp/issues/661

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/671)
<!-- Reviewable:end -->
