### PR TITLE
Fix healthcheck.py to use /var/run/log for syslog on NetBSD

### DIFF
--- a/lib/exabgp/application/healthcheck.py
+++ b/lib/exabgp/application/healthcheck.py
@@ -203,10 +203,12 @@ def setup_logging (debug, silent, name, syslog_facility, syslog):
     """Setup logger"""
 
     def syslog_address():
-        """Return a sensitive syslog address"""
+        """Return a sensible syslog address"""
         if sys.platform == "darwin":
             return "/var/run/syslog"
         if sys.platform.startswith("freebsd"):
+            return "/var/run/log"
+        if sys.platform.startswith("netbsd"):
             return "/var/run/log"
         if sys.platform.startswith("linux"):
             return "/dev/log"


### PR DESCRIPTION
This allows it to work on NetBSD too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/672)
<!-- Reviewable:end -->
