### PR TITLE
Correct extracting extended community

### DIFF
--- a/lib/exabgp/configuration/static/parser.py
+++ b/lib/exabgp/configuration/static/parser.py
@@ -491,7 +491,7 @@ def _extended_community (value):
 		if command == 'target4':
 			return ExtendedCommunity.unpack(_HEADER['target4']+pack('!LH',iga,ila),None)
 
-		if command == 'orgin4':
+		if command == 'origin4':
 			return ExtendedCommunity.unpack(_HEADER['origin4']+pack('!LH',iga,ila),None)
 
 		if command == 'redirect':


### PR DESCRIPTION
Corrected error (spelling mistake) when extracting extended community.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/677)
<!-- Reviewable:end -->
