### PR TITLE
fix #690: Add L2VPN/EVPN to next-hop sizing check

### DIFF
--- a/lib/exabgp/protocol/family.py
+++ b/lib/exabgp/protocol/family.py
@@ -264,6 +264,7 @@ class Family (object):
 		(AFI.ipv6,SAFI.flow_ip):   ((0,16,32), 0),
 		(AFI.ipv6,SAFI.flow_vpn):  ((0,16,32), 0),
 		(AFI.l2vpn,SAFI.vpls):     ((4,),      0),
+		(AFI.l2vpn,SAFI.evpn):     ((4,),      0),
 		(AFI.bgpls,SAFI.bgp_ls):   ((4,),      0),
 	}
 


### PR DESCRIPTION
Credits to jsynack who provided the solution in the bug report.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/692)
<!-- Reviewable:end -->
