### PR TITLE
Update parser.py

### DIFF
--- a/lib/exabgp/configuration/neighbor/parser.py
+++ b/lib/exabgp/configuration/neighbor/parser.py
@@ -114,7 +114,7 @@ def hold_time (tokeniser):
 		holdtime = HoldTime(int(value))
 	except ValueError:
 		raise ValueError ('"%s" is an invalid hold-time' % value)
-	if holdtime < 3 and hold_time != 0:
+	if holdtime < 3 and holdtime != 0:
 		raise ValueError('holdtime must be zero or at least three seconds')
 	if holdtime > HoldTime.MAX:
 		raise ValueError('holdtime must be smaller or equal to %d' % HoldTime.MAX)


### PR DESCRIPTION
ExaBGP does not allow you to set "hold-time" value to 0.

AADAMAVI-M-209Q:~ aadamavi$ ./exabgp/sbin/exabgp -d ./exabgp/etc/exabgp/conf.conf
09:46:12 | 14980 | welcome | Thank you for using ExaBGP
09:46:12 | 14980 | version | 4.0.2-1c737d99
09:46:12 | 14980 | interpreter | 3.6.1 (v3.6.1:69c0db5050, Mar 21 2017, 01:21:04) [GCC 4.2.1 (Apple Inc. build 5666) (dot 3)]
09:46:12 | 14980 | os | Darwin AADAMAVI-M-209Q 16.7.0 Darwin Kernel Version 16.7.0: Thu Jun 15 17:36:27 PDT 2017; root:xnu-3789.70.16~2/RELEASE_X86_64 x86_64
09:46:12 | 14980 | installation | /Users/aadamavi/exabgp
09:46:12 | 14980 | advice | environment file missing
09:46:12 | 14980 | advice | generate it using "exabgp --fi > /Users/aadamavi/exabgp/etc/exabgp/exabgp.env"
09:46:12 | 14980 | cli | could not find the named pipes (exabgp.in and exabgp.out) required for the cli
09:46:12 | 14980 | cli | we scanned the following folders (the number is your PID):
09:46:12 | 14980 | cli control | - /run/exabgp/
09:46:12 | 14980 | cli control | - /run/501/
09:46:12 | 14980 | cli control | - /run/
09:46:12 | 14980 | cli control | - /var/run/exabgp/
09:46:12 | 14980 | cli control | - /var/run/501/
09:46:12 | 14980 | cli control | - /var/run/
09:46:12 | 14980 | cli control | - /Users/aadamavi/exabgp/run/exabgp/
09:46:12 | 14980 | cli control | - /Users/aadamavi/exabgp/run/501/
09:46:12 | 14980 | cli control | - /Users/aadamavi/exabgp/run/
09:46:12 | 14980 | cli control | - /Users/aadamavi/exabgp/var/run/exabgp/
09:46:12 | 14980 | cli control | - /Users/aadamavi/exabgp/var/run/501/
09:46:12 | 14980 | cli control | - /Users/aadamavi/exabgp/var/run/
09:46:12 | 14980 | cli control | please make them in one of the folder with the following commands:
09:46:12 | 14980 | cli control | > mkfifo /Users/aadamavi/run/exabgp.{in,out}
09:46:12 | 14980 | cli control | > chmod 600 /Users/aadamavi/run/exabgp.{in,out}
09:46:12 | 14980 | cli control | > chown 501:20 /Users/aadamavi/run/exabgp.{in,out}
09:46:12 | 14980 | configuration | performing reload of exabgp 4.0.2-1c737d99
09:46:12 | 14980 | configuration | > neighbor | '192.168.86.100'
09:46:12 | 14980 | configuration | . description | 'a simple test for the new configuration format name'
09:46:12 | 14980 | configuration | . inherit | 'a-few-routes'
09:46:12 | 14980 | configuration | . router-id | '192.168.86.1'
09:46:12 | 14980 | configuration | . local-address | '192.168.86.1'
09:46:12 | 14980 | configuration | . local-as | '65531'
09:46:12 | 14980 | configuration | . peer-as | '65533'
09:46:12 | 14980 | configuration | . hold-time | '0'
09:46:12 | 14980 | configuration | problem with the configuration file, no change done
09:46:12 | 14980 | configuration |
09:46:12 | 14980 | configuration | syntax error in section neighbor
09:46:12 | 14980 | configuration | line 8: hold-time 0 ;
09:46:12 | 14980 | configuration |
09:46:12 | 14980 | configuration | holdtime must be zero or at least three seconds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/696)
<!-- Reviewable:end -->
