### PR TITLE
Print `neighbor` only once.

### DIFF
--- a/lib/exabgp/reactor/api/command/rib.py
+++ b/lib/exabgp/reactor/api/command/rib.py
@@ -45,7 +45,7 @@ def _show_adjrib_callback(reactor, service, last, route_type, advertised, rib_na
 				for change in changes:
 					if isinstance(change.nlri, route_type):
 						if extensive:
-							reactor.processes.answer(service,'neighbor %s %s %s' % (peer.neighbor.name(),'%s %s' % change.nlri.family(),change.extensive()),force=True)
+							reactor.processes.answer(service,'%s %s %s' % (peer.neighbor.name(),'%s %s' % change.nlri.family(),change.extensive()),force=True)
 						else:
 							reactor.processes.answer(service,'neighbor %s %s %s' % (peer.neighbor.peer_address,'%s %s' % change.nlri.family(),str(change.nlri)),force=True)
 				yield True


### PR DESCRIPTION
When using `show adj-rib out extensive`, `neighbor keyword used to be
printed twice as in:
```
neighbor neighbor 192.168.3.8 local-ip 192.168.3.9 local-as 64400
peer-as 64300 router-id 192.168.3.9 family-allowed in-open ipv4 unicast
192.168.4.0/24 next-hop self
```

This change make it printed only once:
```
neighbor 192.168.3.8 local-ip 192.168.3.9 local-as 64400 peer-as 64300
router-id 192.168.3.9 family-allowed in-open ipv4 unicast 192.168.4.0/24
next-hop self
```

Fixes #700

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/701)
<!-- Reviewable:end -->
