### PR TITLE
Fix busy spin when receiving commands on named pipe

### DIFF
--- a/lib/exabgp/application/control.py
+++ b/lib/exabgp/application/control.py
@@ -134,7 +134,7 @@ class Control (object):
 
 	def loop (self):
 		try:
-			self.r_pipe = os.open(self.recv, os.O_RDONLY | os.O_NONBLOCK | os.O_EXCL)
+			self.r_pipe = os.open(self.recv, os.O_RDWR | os.O_NONBLOCK | os.O_EXCL)
 		except OSError:
 			self.terminate()
 
@@ -217,7 +217,7 @@ class Control (object):
 		}
 
 		def consume (source):
-			if not backlog and b'\n' not in store:
+			if not backlog[source] and b'\n' not in store[source]:
 				store[source] += read[source](1024)
 			else:
 				backlog[source].append(read[source](1024))


### PR DESCRIPTION
When opening the read named pipe in RD_ONLY, the select loop will always
return that something is available to read from self.r_pipe once
something has opened and closed the fifo like `exabgpcli` or `echo "foo" >
/path/to/fifo`. Unfortunately, those are going to be EOF and exabgp will
be spinning trying to read content from the fifo when nothing is
actually available.
To work around that, we can open the reader fifo in RDWR mode, this will
ensure that the pipe will always have a potential writer and no EOF will
be available for select.

Fixes #704

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/705)
<!-- Reviewable:end -->
