### PR TITLE
[reactor][peer] Do not retry immediately when waiting to read open

### DIFF
--- a/lib/exabgp/reactor/peer.py
+++ b/lib/exabgp/reactor/peer.py
@@ -288,7 +288,10 @@ class Peer (object):
 			# Only yield if we have not the open, otherwise the reactor can run the other connection
 			# which would be bad as we need to do the collission check
 			if ordinal(message.TYPE) == Message.CODE.NOP:
-				yield ACTION.NOW
+				# If a peer does not reply to OPEN message, or not enough bytes
+				# yielding ACTION.NOW can cause ExaBGP to busy spin trying to
+				# read from peer. See GH #723 .
+				yield ACTION.LATER
 		yield message
 
 	def _send_ka (self):


### PR DESCRIPTION
message.

If a peer does not reply to OPEN message, or not enough bytes, the
current implementation will busy spin trying to read from the peer.
This behaviour does not happen on 3.4-stable, where we actually defer
the reading:
https://github.com/Exa-Networks/exabgp/blob/3.4-stable/lib/exabgp/reactor/peer.py#L375

Fixes #723

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/730)
<!-- Reviewable:end -->
