### PR TITLE
configuration: correctly write ini/environment for tcp.bind

### DIFF
--- a/lib/exabgp/configuration/environment.py
+++ b/lib/exabgp/configuration/environment.py
@@ -104,6 +104,10 @@ class environment (object):
 		return "'%s'" % str(_)
 
 	@staticmethod
+	def quote_list (_):
+		return "'%s'" % ' '.join([str(x) for x in _])
+
+	@staticmethod
 	def nop (_):
 		return _
 

--- a/lib/exabgp/configuration/setup.py
+++ b/lib/exabgp/configuration/setup.py
@@ -191,7 +191,7 @@ environment.configuration = {
 		},
 		'bind': {
 			'read':  environment.ip_list,
-			'write': environment.quote,
+			'write': environment.quote_list,
 			'value': '',
 			'help':  'Space separated list of IPs to bind on when listening (no ip to disable)',
 		},


### PR DESCRIPTION
In 3791aee46667, tcp.bind was changed from an IP to a list. However,
when using `--fi` or `--fe`, the list was written as a
list (`[1.2.3.4]`) instead of a space separated list of IP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/731)
<!-- Reviewable:end -->
