### PR TITLE
python-setuptools is a runtime requirement

### DIFF
--- a/redhat/python-exabgp.spec.git
+++ b/redhat/python-exabgp.spec.git
@@ -18,12 +18,12 @@ Source0:	exabgp-%{version}.tar.gz
 BuildArch:      noarch
 Provides:       exabgp-libs
 
-BuildRequires:  python-setuptools
 BuildRequires:  sed
 BuildRequires:  git
 BuildRequires:  git-extras
 Requires:       python2 >= 2.6
 Requires:	python-ipaddr
+Requires:       python-setuptools
 
 %description
 ExaBGP python module


### PR DESCRIPTION
Without python-setuptools the exabgp software built from python-exabgp.spec.git refuse to run with the error:

ImportError: No module named pkg_resources

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/735)
<!-- Reviewable:end -->
