### PR TITLE
Fix typo in Segment Routing ADJ LAN link attribute flags

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/bgpls/link/sradjlan.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/link/sradjlan.py
@@ -49,7 +49,7 @@ class SrAdjacencyLan(object):
 	@classmethod
 	def unpack (cls,data,length):
 		# We only support IS-IS flags for now.
-		flags = LsGenericFlags.unpack(data[0:1],LsGenericFlags.ISIS_ADJ_SR_FLAGS)
+		flags = LsGenericFlags.unpack(data[0:1],LsGenericFlags.ISIS_SR_ADJ_FLAGS)
 		# Parse adj weight
 		weight = six.indexbytes(data,1)
 		# Move pointer 4 bytes: Flags(1) + Weight(1) + Reserved(2)


### PR DESCRIPTION
Fixing https://github.com/Exa-Networks/exabgp/issues/729

exabgp -d config.ini --decode "0000 00D5 4001 0100 4002 0040 0504 0000 0064 801D 6D04 4000 0400 0000 0004 4100 044E 9502 F904 4200 0400 0000 0004 4300 2000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0004 4400 0400 0000 0A04 4700 0300 000A 044C 000D 7000 0000 1971 5509 4120 00F1 D304 4C00 0D30 0000 0019 7155 0941 2000 F1E8 900E 0053 4004 4704 293C E123 0000 0200 4602 0000 0000 0000 0000 0100 0012 0200 0004 0000 787C 0203 0006 1971 5509 4102 0101 0013 0200 0004 0000 787C 0203 0007 1971 5509 4102 0701 0300 04C5 9B5E FE01 0400 04C5 9B5E FE"
08:50:23 | 87965  | welcome       | Thank you for using ExaBGP
08:50:23 | 87965  | version       | 4.0.2-1c737d99
08:50:23 | 87965  | interpreter   | 2.7.10 (default, Feb  7 2017, 00:08:15)  [GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.34)]
08:50:23 | 87965  | os            | Darwin ruissalo 16.7.0 Darwin Kernel Version 16.7.0: Thu Jun 15 17:36:27 PDT 2017; root:xnu-3789.70.16~2/RELEASE_X86_64 x86_64
08:50:23 | 87965  | installation  | /home/evila/moi/exabgp/exa
08:50:23 | 87965  | advice        | environment file missing
08:50:23 | 87965  | advice        | generate it using "exabgp --fi > /home/evila/moi/exabgp/exa/etc/exabgp/exabgp.env"
08:50:23 | 87965  | cli           | could not find the named pipes (exabgp.in and exabgp.out) required for the cli
08:50:23 | 87965  | cli           | we scanned the following folders (the number is your PID):
08:50:23 | 87965  | cli control   |  - /run/exabgp/
08:50:23 | 87965  | cli control   |  - /run/501/
08:50:23 | 87965  | cli control   |  - /run/
08:50:23 | 87965  | cli control   |  - /var/run/exabgp/
08:50:23 | 87965  | cli control   |  - /var/run/501/
08:50:23 | 87965  | cli control   |  - /var/run/
08:50:23 | 87965  | cli control   |  - /home/evila/moi/exabgp/exa/run/exabgp/
08:50:23 | 87965  | cli control   |  - /home/evila/moi/exabgp/exa/run/501/
08:50:23 | 87965  | cli control   |  - /home/evila/moi/exabgp/exa/run/
08:50:23 | 87965  | cli control   |  - /home/evila/moi/exabgp/exa/var/run/exabgp/
08:50:23 | 87965  | cli control   |  - /home/evila/moi/exabgp/exa/var/run/501/
08:50:23 | 87965  | cli control   |  - /home/evila/moi/exabgp/exa/var/run/
08:50:23 | 87965  | cli control   | please make them in one of the folder with the following commands:
08:50:23 | 87965  | cli control   | > mkfifo /home/evila/moi/exabgp/run/exabgp.{in,out}
08:50:23 | 87965  | cli control   | > chmod 600 /home/evila/moi/exabgp/run/exabgp.{in,out}
08:50:23 | 87965  | cli control   | > chown 501:20 /home/evila/moi/exabgp/run/exabgp.{in,out}
08:50:23 | 87965  | configuration | performing reload of exabgp 4.0.2-1c737d99
08:50:23 | 87965  | configuration | > process          | 'parsed-route-backend'
08:50:23 | 87965  | configuration | . run              | '/home/evila/moi/exabgp/etc/exabgp/run/syslog-1.py'
08:50:23 | 87965  | configuration | . encoder          | 'json'
08:50:23 | 87965  | configuration | < process          | 
08:50:23 | 87965  | configuration | > neighbor         | '10.30.4.3'
08:50:23 | 87965  | configuration | . local-address    | '10.30.4.2'
08:50:23 | 87965  | configuration | . local-as         | '65050'
08:50:23 | 87965  | configuration | . peer-as          | '65000'
08:50:23 | 87965  | configuration | > family           | 
08:50:23 | 87965  | configuration | . ipv4             | 'nlri-mpls'
08:50:23 | 87965  | configuration | . bgp-ls           | 'bgp-ls'
08:50:23 | 87965  | configuration | < family           | 
08:50:23 | 87965  | configuration | > api              | 
08:50:23 | 87965  | configuration | . processes        | '[' 'parsed-route-backend' ']'
08:50:23 | 87965  | configuration | > receive          | 
08:50:23 | 87965  | configuration | . parsed           | 
08:50:23 | 87965  | configuration | . update           | 
08:50:23 | 87965  | configuration | < receive          | 
08:50:23 | 87965  | configuration | < api              | 
08:50:23 | 87965  | configuration | < neighbor         | 
08:50:23 | 87965  | parser        |         
08:50:23 | 87965  | parser        | decoding routes in configuration
08:50:23 | 87965  | parser        | header missing, assuming this message is ONE update
08:50:23 | 87965  | parser        | parsing UPDATE ( 217) 0000 00D5 4001 0100 4002 0040 0504 0000 0064 801D 6D04 4000 0400 0000 0004 4100 044E 9502 F904 4200 0400 0000 0004 4300 2000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0004 4400 0400 0000 0A04 4700 0300 000A 044C 000D 7000 0000 1971 5509 4120 00F1 D304 4C00 0D30 0000 0019 7155 0941 2000 F1E8 900E 0053 4004 4704 293C E123 0000 0200 4602 0000 0000 0000 0000 0100 0012 0200 0004 0000 787C 0203 0006 1971 5509 4102 0101 0013 0200 0004 0000 787C 0203 0007 1971 5509 4102 0701 0300 04C5 9B5E FE01 0400 04C5 9B5E FE
08:50:23 | 87965  | parser        | withdrawn NLRI none
08:50:23 | 87965  | parser        | attribute origin             flag 0x40 type 0x01 len 0x01 payload 00
08:50:23 | 87965  | parser        | attribute as-path            flag 0x40 type 0x02 len 0x00
08:50:23 | 87965  | parser        | attribute local-preference   flag 0x40 type 0x05 len 0x04 payload 0000 0064
08:50:23 | 87965  | parser        | attribute bgp-ls             flag 0x80 type 0x1d len 0x6d payload 0440 0004 0000 0000 0441 0004 4E95 02F9 0442 0004 0000 0000 0443 0020 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0000 0444 0004 0000 000A 0447 0003 0000 0A04 4C00 0D70 0000 0019 7155 0941 2000 F1D3 044C 000D 3000 0000 1971 5509 4120 00F1 E8
08:50:23 | 87965  | parser        | attribute mp-reach-nlri      flag 0x90 type 0x0e len 0x53 payload 4004 4704 293C E123 0000 0200 4602 0000 0000 0000 0000 0100 0012 0200 0004 0000 787C 0203 0006 1971 5509 4102 0101 0013 0200 0004 0000 787C 0203 0007 1971 5509 4102 0701 0300 04C5 9B5E FE01 0400 04C5 9B5E FE
08:50:23 | 87965  | parser        | NLRI      bgp-ls bgp-ls      without path-information     payload 0002 0046 0200 0000 0000 0000 0001 0000 1202 0000 0400 0078 7C02 0300 0619 7155 0941 0201 0100 1302 0000 0400 0078 7C02 0300 0719 7155 0941 0207 0103 0004 C59B 5EFE 0104 0004 C59B 5EFE
08:50:23 | 87965  | parser        | announced NLRI none
08:50:23 | 87965  | parser        |         
08:50:23 | 87965  | parser        | decoded update 1 { "ls-nlri-type": 2, "l3-routing-topology": 0, "protocol-id": 2, "local-node-descriptors": { "autonomous-system": 30844, "router-id": "197155094102" }, "remote-node-descriptors": { "autonomous-system": 30844, "psn": "7", "router-id": "197155094102" }, "interface-address": { "interface-address": "197.155.94.254" }, "neighbor-address": { "neighbor-address": "197.155.94.254" } } origin igp local-preference 100 bgp-ls Admin Group mask: [0], Maximum link bandwidth: 1250000000.0, Maximum reservable link bandwidth: 0.0, Maximum link bandwidth: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], TE Default Metric: 10, IGP Metric: [10], sr_adj_lan_flags: {'B': 1, 'F': 0, 'L': 1, 'P': 0, 'S': 0, 'V': 1, 'RSV': 0}, sids: [1667413, 606496, 61907], sr_adj_lan_flags: {'B': 0, 'F': 0, 'L': 1, 'P': 0, 'S': 0, 'V': 1, 'RSV': 0}, sids: [1667413, 606496, 61928]
08:50:23 | 87965  | parser        | update json { "exabgp": "4.0.1", "time": 1508687423.46, "host" : "ruissalo", "pid" : 87965, "ppid" : 1244, "counter": 1, "type": "update", "neighbor": { "address": { "local": "10.30.4.2", "peer": "10.30.4.3" }, "asn": { "local": 65050, "peer": 65000 } , "direction": "in", "message": { "update": { "attribute": { "origin": "igp", "local-preference": 100, "bgp-ls": { "admin-group-mask": [0], "maximum-link-bandwidth": 1250000000.0, "maximum-reservable-link-bandwidth": 0.0, "unreserved-bandwidth": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0], "te-metric": 10, "igp-metric": 10, "sr-adj-lan-flags": {"B": 1, "F": 0, "L": 1, "P": 0, "S": 0, "V": 1, "RSV": 0}, "sids": [1667413, 606496, 61907], "sr-adj-lan-weight": 0, "sr-adj-lan-flags": {"B": 0, "F": 0, "L": 1, "P": 0, "S": 0, "V": 1, "RSV": 0}, "sids": [1667413, 606496, 61928], "sr-adj-lan-weight": 0 } }, "announce": { "bgp-ls bgp-ls": { "41.60.225.35": [ { "ls-nlri-type": 2, "l3-routing-topology": 0, "protocol-id": 2, "local-node-descriptors": { "autonomous-system": 30844, "router-id": "197155094102" }, "remote-node-descriptors": { "autonomous-system": 30844, "psn": "7", "router-id": "197155094102" }, "interface-address": { "interface-address": "197.155.94.254" }, "neighbor-address": { "neighbor-address": "197.155.94.254" } } ] } } } } } }

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/738)
<!-- Reviewable:end -->
