### PR TITLE
Add a systemd exabgp instance service

### DIFF
--- a/etc/systemd/exabgp@.service
+++ b/etc/systemd/exabgp@.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=ExaBGP for instance %i
+Documentation=man:exabgp(1)
+Documentation=man:exabgp.conf(5)
+Documentation=https://github.com/Exa-Networks/exabgp/wiki
+After=network.target
+ConditionPathExists=/etc/exabgp/exabgp-%i.conf
+
+[Service]
+Environment=exabgp_daemon_daemonize=false
+Environment=EXABGP_INSTANCE=exabgp-%i
+ExecStart=/usr/sbin/exabgp /etc/exabgp/${EXABGP_INSTANCE}.conf
+ExecReload=/bin/kill -USR1 $MAINPID
+
+[Install]
+WantedBy=multi-user.target

--- a/redhat/python-exabgp.spec
+++ b/redhat/python-exabgp.spec
@@ -50,6 +50,7 @@ mv ${RPM_BUILD_ROOT}/usr/etc/exabgp ${RPM_BUILD_ROOT}/%{_sysconfdir}/
 
 install -d %{buildroot}/%{_unitdir}
 install etc/systemd/exabgp.service %{buildroot}/%{_unitdir}/
+install etc/systemd/exabgp@.service %{buildroot}/%{_unitdir}/
 
 install -d %{buildroot}/%{_mandir}/man1
 install doc/man/exabgp.1 %{buildroot}/%{_mandir}/man1

--- a/redhat/python-exabgp.spec.git
+++ b/redhat/python-exabgp.spec.git
@@ -60,6 +60,7 @@ mv ${RPM_BUILD_ROOT}/usr/share/exabgp/etc/* ${RPM_BUILD_ROOT}/%{_sysconfdir}/exa
 
 install -d %{buildroot}/%{_unitdir}
 install etc/systemd/exabgp.service %{buildroot}/%{_unitdir}/
+install etc/systemd/exabgp@.service %{buildroot}/%{_unitdir}/
 
 install -d %{buildroot}/%{_mandir}/man1
 install doc/man/exabgp.1 %{buildroot}/%{_mandir}/man1


### PR DESCRIPTION
Hello,

I was wondering if adding the systemd instance feature could be interesting when using exabgp? So I created the following PR to see if you, guys think this is a good idea or not.

The idea is pretty much the same as the `rsync` in Red Hat, the package delivers both the default rsyncd service and also the socket one, so I though this could be applied to exabgp.

Let me know if this does make sense or not.

Regards,
JM

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/740)
<!-- Reviewable:end -->
