### PR TITLE
EVPN support for VXLAN

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/pmsi.py
+++ b/lib/exabgp/bgp/message/update/attribute/pmsi.py
@@ -54,8 +54,9 @@ class PMSI (Attribute):
 
 	__slots__ = ['label','flags','tunnel']
 
-	def __init__ (self, tunnel, label, flags):
+	def __init__ (self, tunnel, label, flags, raw_label=None):
 		self.label = label    # integer
+		self.raw_label = raw_label # integer
 		self.flags = flags    # integer
 		self.tunnel = tunnel  # tunnel id, packed data
 
@@ -75,12 +76,16 @@ class PMSI (Attribute):
 		return PMSI._name.get(tunnel_type,'unknown')
 
 	def pack (self, negotiated):
+		if self.raw_label:
+			packed_label = pack('!L',self.raw_label)[1:4]
+		else:
+			packed_label = pack('!L',self.label << 4)[1:4]
 		return self._attribute(
 			pack(
 				'!BB3s',
 				self.flags,
 				self.TUNNEL_TYPE,
-				pack('!L',self.label << 4)[1:4]
+				packed_label
 			) + self.tunnel
 		)
 
@@ -92,10 +97,14 @@ class PMSI (Attribute):
 		return "0x" + ''.join('%02X' % ordinal(_) for _ in self.tunnel) if self.tunnel else ''
 
 	def __repr__ (self):
+		if self.raw_label:
+			label_repr = "%d(%d)" % (self.label, self.raw_label)
+		else:
+			label_repr = str(self.label) if self.label else '0'
 		return "pmsi:%s:%s:%s:%s" % (
 			self.name(self.TUNNEL_TYPE).replace(' ','').lower(),
-			str(self.flags) if self.flags else '-',  # why not use zero (0) ?
-			str(self.label) if self.label else '-',  # what noy use zero (0) ?
+			str(self.flags),
+			label_repr,
 			self.prettytunnel()
 		)
 
@@ -107,7 +116,7 @@ class PMSI (Attribute):
 		return klass
 
 	@staticmethod
-	def pmsi_unknown (subtype, tunnel, label, flags):
+	def pmsi_unknown (subtype, tunnel, label, flags, raw_label):
 		pmsi = PMSI(tunnel,label,flags)
 		pmsi.TUNNEL_TYPE = subtype
 		return pmsi
@@ -115,11 +124,12 @@ class PMSI (Attribute):
 	@classmethod
 	def unpack (cls, data, negotiated):
 		flags,subtype = unpack('!BB',data[:2])
-		label = unpack('!L',b'\0'+data[2:5])[0] >> 4
+		raw_label = unpack('!L',b'\0'+data[2:5])[0]
+		label = raw_label >> 4
 		# should we check for bottom of stack before the shift ?
 		if subtype in cls._pmsi_known:
-			return cls._pmsi_known[subtype].unpack(data[5:],label,flags)
-		return cls.pmsi_unknown(subtype,data[5:],label,flags)
+			return cls._pmsi_known[subtype].unpack(data[5:],label,flags,raw_label)
+		return cls.pmsi_unknown(subtype,data[5:],label,flags,raw_label)
 
 
 # ================================================================= PMSINoTunnel
@@ -129,15 +139,15 @@ class PMSI (Attribute):
 class PMSINoTunnel (PMSI):
 	TUNNEL_TYPE = 0
 
-	def __init__ (self, label=0,flags=0):
-		PMSI.__init__(self,b'',label,flags)
+	def __init__ (self, label=0,flags=0,raw_label=None):
+		PMSI.__init__(self,b'',label,flags,raw_label=None)
 
 	def prettytunnel (self):
 		return ''
 
 	@classmethod
-	def unpack (cls, tunnel, label, flags):
-		return cls(label,flags)
+	def unpack (cls, tunnel, label, flags, raw_label=None):
+		return cls(label,flags,raw_label)
 
 
 # ======================================================= PMSIIngressReplication
@@ -147,14 +157,14 @@ class PMSINoTunnel (PMSI):
 class PMSIIngressReplication (PMSI):
 	TUNNEL_TYPE = 6
 
-	def __init__ (self, ip, label=0,flags=0,tunnel=None):
+	def __init__ (self, ip, label=0,flags=0,tunnel=None,raw_label=None):
 		self.ip = ip  # looks like a bad name
-		PMSI.__init__(self,tunnel if tunnel else IPv4.pton(ip),label,flags)
+		PMSI.__init__(self,tunnel if tunnel else IPv4.pton(ip),label,flags,raw_label)
 
 	def prettytunnel (self):
 		return self.ip
 
 	@classmethod
-	def unpack (cls, tunnel, label, flags):
+	def unpack (cls, tunnel, label, flags, raw_label):
 		ip = IPv4.ntop(tunnel)
-		return cls(ip,label,flags,tunnel)
+		return cls(ip,label,flags,tunnel,raw_label)

--- a/lib/exabgp/bgp/message/update/nlri/qualifier/labels.py
+++ b/lib/exabgp/bgp/message/update/nlri/qualifier/labels.py
@@ -20,18 +20,27 @@ from exabgp.util import concat_bytes_i
 class Labels (object):
 	MAX = pow(2,20)-1
 
-	__slots__ = ['labels','packed','_len']
+	__slots__ = ['labels','packed','_len','raw_labels']
 
-	def __init__ (self, labels, bos=True):
+	def __init__ (self, labels, bos=True, raw_labels=None):
 		self.labels = labels
+		self.raw_labels = raw_labels
 		packed = []
-		for label in labels:
-			# shift to 20 bits of the label to be at the top of three bytes and then truncate.
-			packed.append(pack('!L',label << 4)[1:])
-		# Mark the bottom of stack with the bit
-		if packed and bos:
-			packed.pop()
-			packed.append(pack('!L',(label << 4) | 1)[1:])
+		if raw_labels:
+			for label in raw_labels:
+				packed.append(pack('!L',label)[1:])
+			# fill self.labels as well, not for packing, but to allow
+			# consistent string representations
+			if not self.labels:
+				self.labels = [x >> 4 for x in self.raw_labels]
+		else:
+			for label in labels:
+				# shift to 20 bits of the label to be at the top of three bytes and then truncate.
+				packed.append(pack('!L',label << 4)[1:])
+			# Mark the bottom of stack with the bit
+			if packed and bos:
+				packed.pop()
+				packed.append(pack('!L',(label << 4) | 1)[1:])
 		self.packed = concat_bytes_i(packed)
 		self._len = len(self.packed)
 
@@ -60,37 +69,39 @@ class Labels (object):
 		return self._len
 
 	def json (self):
-		if self._len >= 1:
-			return '"label": [ %s ]' % ', '.join([str(_) for _ in self.labels])
+		if len(self.labels) >= 1:
+			return '"label": [ %s ]' % ', '.join(["[%d, %d]" % (l,r) for (l,r) in zip(self.labels, self.raw_labels)])
 		else:
 			return ''
 
 	def __str__ (self):
-		if self._len > 1:
-			return ' label [ %s ]' % ' '.join([str(_) for _ in self.labels])
-		elif self._len == 1:
-			return ' label %s' % self.labels[0]
+		if len(self.labels) > 1:
+			return ' label [ %s ]' % ' '.join(["%d (%d)" % (l,r) for (l,r) in zip(self.labels, self.raw_labels)])
+		elif len(self.labels) == 1:
+			return ' label %s (%d)' % (self.labels[0], self.raw_labels[0])
 		else:
 			return ''
 
 	def __repr__(self):
-		if self._len > 1:
-			return '[ %s ]' % ','.join([str(_) for _ in self.labels])
-		elif self._len == 1:
-			return '%d' % self.labels[0]
+		if len(self.labels) > 1:
+			return '[ %s ]' % ','.join(["%d (%d)" % (l,r) for (l,r) in zip(self.labels, self.raw_labels)])
+		elif len(self.labels) == 1:
+			return '%d (%d)' % (self.labels[0], self.raw_labels[0])
 		else:
 			return '[ ]'
 
 	@classmethod
 	def unpack (cls, data):
 		labels = []
+		raw_labels = []
 		while len(data):
 			label = unpack('!L',character(0)+data[:3])[0]
 			data = data[3:]
 			labels.append(label >> 4)
+			raw_labels.append(label)
 			if label & 0x001:
 				break
-		return cls(labels)
+		return cls(labels, raw_labels=raw_labels)
 
 
 Labels.NOLABEL = Labels([])


### PR DESCRIPTION
In EVPN/VXLAN [1] a VXLAN VNI is stored inside the 3-byte fields used
for MPLS labels in RFC7432. In this case the 4-bit shifting done for
MPLS labels does not apply anymore. This applies to label fields in NLRI
routes and to the label field in the PMSI tunnel attribute.

This change updates corresponding classes to:
- expose both the MPLS 4-bit shifted value, and the raw value, in
  parsed routes
- allow passing a 'raw_label' value in routes to be encoded,
  when provided this value will be used for packing,
  instead of using the 'label' after 4-bit shifting
- update string representation to show both the 4-bit shifted label
  and the raw label

[1] https://tools.ietf.org/html/draft-ietf-bess-evpn-overlay

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/744)
<!-- Reviewable:end -->
