### PR TITLE
Remove b from string

### DIFF
--- a/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/ipreach.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/ipreach.py
@@ -60,7 +60,7 @@ class IpReach(object):
 		# a 4 octet IP prefix
 		prefix_list = prefix_list + ["0"]*(4 - len(prefix_list))
 		prefix = '.'.join(prefix_list)
-		return cls(prefix=prefix.encode('ascii'))
+		return cls(prefix=prefix)
 
 	def json (self, compact=None):
 		return '"ip-reachability-tlv": "%s"' % str(self.prefix)


### PR DESCRIPTION
Tested with both Py3 and Py2

```{
	"exabgp": "4.0.1",
	"time": 1512020885.38,
	"host": "ruissalo",
	"pid": 22777,
	"ppid": 23307,
	"counter": 1,
	"type": "update",
	"neighbor": {
		"address": {
			"local": "172.24.182.21",
			"peer": "10.113.63.241"
		},
		"asn": {
			"local": 4804,
			"peer": 65533
		},
		"direction": "in",
		"message": {
			"update": {
				"attribute": {
					"origin": "igp",
					"as-path": [65533],
					"confederation-path": [],
					"med": 0,
					"bgp-ls": {
						"igp-route-tags": [65534],
						"prefix-metric": 20
					}
				},
				"announce": {
					"bgp-ls bgp-ls": {
						"10.113.63.241": [{
							"ls-nlri-type": 3,
							"l3-routing-topology": 0,
							"protocol-id": 3,
							"node-descriptors": {
								"autonomous-system": 65533,
								"bgp-ls-identifier": "0",
								"router-id": "10.113.63.240"
							},
							"ip-reachability-tlv": "10.0.0.0",
							"nexthop": "10.113.63.241",
							"ospf-route-type": 4
						}]
					}
				}
			}
		}
	}
}
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/749)
<!-- Reviewable:end -->
