### PR TITLE
Missing combinations of flowspec Op flags

### DIFF
--- a/lib/exabgp/bgp/message/update/nlri/flow.py
+++ b/lib/exabgp/bgp/message/update/nlri/flow.py
@@ -243,6 +243,7 @@ class NumericString (object):
 		NumericOperator.EQ: '=',
 		NumericOperator.LT | NumericOperator.EQ: '<=',
 		NumericOperator.GT | NumericOperator.EQ: '>=',
+		NumericOperator.LT | NumericOperator.GT: '!=',
 		NumericOperator.FALSE: 'false',
 
 		NumericOperator.AND: '&true',
@@ -251,6 +252,7 @@ class NumericString (object):
 		NumericOperator.AND | NumericOperator.EQ: '&=',
 		NumericOperator.AND | NumericOperator.LT | NumericOperator.EQ: '&<=',
 		NumericOperator.AND | NumericOperator.GT | NumericOperator.EQ: '&>=',
+		NumericOperator.AND | NumericOperator.LT | NumericOperator.GT: '&!=',
 		NumericOperator.AND | NumericOperator.FALSE: '&false',
 	}
 
@@ -267,8 +269,12 @@ class BinaryString (object):
 		BinaryOperator.INCLUDE: '',
 		BinaryOperator.NOT:     '!',
 		BinaryOperator.MATCH:   '=',
-		BinaryOperator.AND | BinaryOperator.NOT:   '&!',
-		BinaryOperator.AND | BinaryOperator.MATCH: '&=',
+		BinaryOperator.NOT | BinaryOperator.MATCH:   '!=',
+		BinaryOperator.AND | BinaryOperator.INCLUDE: '&',
+		BinaryOperator.AND | BinaryOperator.NOT:     '&!',
+		BinaryOperator.AND | BinaryOperator.MATCH:   '&=',
+		BinaryOperator.AND | BinaryOperator.NOT | BinaryOperator.MATCH: '&!=',
+
 	}
 
 	def __str__ (self):

--- a/lib/exabgp/bgp/message/update/nlri/flow.py
+++ b/lib/exabgp/bgp/message/update/nlri/flow.py
@@ -257,7 +257,10 @@ class NumericString (object):
 	}
 
 	def __str__ (self):
-		return "%s%s" % (self._string[self.operations & (CommonOperator.EOL ^ 0xFF)], self.value)
+		op = self.operations & (CommonOperator.EOL ^ 0xFF)
+		if op in [NumericOperator.TRUE, NumericOperator.FALSE]:
+			return self._string[op]
+		return "%s%s" % (self._string.get(op, "%02X" % op), self.value)
 
 
 class BinaryString (object):
@@ -278,7 +281,8 @@ class BinaryString (object):
 	}
 
 	def __str__ (self):
-		return "%s%s" % (self._string[self.operations & (CommonOperator.EOL ^ 0xFF)], self.value)
+		op = self.operations & (CommonOperator.EOL ^ 0xFF)
+		return "%s%s" % (self._string.get(op, "%02X" % op), self.value)
 
 
 # Components ..............................


### PR DESCRIPTION
Related to https://github.com/Exa-Networks/exabgp/issues/752

---

According to ["draft-ietf-idr-rfc5575bis"](https://tools.ietf.org/html/draft-ietf-idr-rfc5575bis-06#section-4.2.3), some more combinations of the flowspec operator/operand flags are required (e.g., "not equal" for the numeric operator).

```text
            +----+----+----+----------------------------------+
            | lt | gt | eq | Resulting operation              |
            +----+----+----+----------------------------------+
            | 0  | 0  | 0  | true (independent of the value)  |
            | 0  | 0  | 1  | == (equal)                       |
            | 0  | 1  | 0  | > (greater than)                 |
            | 0  | 1  | 1  | >= (greater than or equal)       |
            | 1  | 0  | 0  | < (less than)                    |
            | 1  | 0  | 1  | <= (less than or equal)          |
            | 1  | 1  | 0  | != (not equal value)             |
            | 1  | 1  | 1  | false (independent of the value) |
            +----+----+----+----------------------------------+

                Table 1: Comparison operation combinations
```

Also, this PR avoids to raise exceptions when unknown Op flags received.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/761)
<!-- Reviewable:end -->
