### PR TITLE
Use default mask /128 if IP address is IPv6 family

### DIFF
--- a/lib/exabgp/configuration/ancient.py
+++ b/lib/exabgp/configuration/ancient.py
@@ -1745,6 +1745,8 @@ class Configuration (object):
 			mask = int(mask)
 		except ValueError:
 			mask = 32
+			if ':' in ip:
+				mask = 128
 		try:
 			if 'rd' in tokens:
 				safi = SAFI(SAFI.mpls_vpn)


### PR DESCRIPTION
We had an issue where accidentally announced the prefix without `/128` at the end of the route. This led to blackholing the whole DC's traffic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/775)
<!-- Reviewable:end -->
