### PR TITLE
Use default mask /128 if IP address is IPv6 family (master)

### DIFF
--- a/lib/exabgp/configuration/static/parser.py
+++ b/lib/exabgp/configuration/static/parser.py
@@ -66,6 +66,8 @@ def prefix (tokeniser):
 		ip,mask = ip.split('/')
 	except ValueError:
 		mask = '32'
+		if ':' in ip:
+			mask = '128'
 
 	tokeniser.afi = IP.toafi(ip)
 	return IPRange.create(ip,mask)


### PR DESCRIPTION
related: https://github.com/Exa-Networks/exabgp/pull/775

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/776)
<!-- Reviewable:end -->
