### PR TITLE
SAFI: add _names to have nice str/repr

### DIFF
--- a/lib/exabgp/protocol/family.py
+++ b/lib/exabgp/protocol/family.py
@@ -226,6 +226,8 @@ class SAFI (Resource):
 		'flow-vpn':  flow_vpn,
 	}.items())
 
+	names = _SAFI._names
+
 	cache = dict([(r,r) for (l,r) in codes.items()])
 
 	@staticmethod


### PR DESCRIPTION
Without this change, repr(SAFI(128)) gives "unknown  type 128"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/777)
<!-- Reviewable:end -->
