### PR TITLE
Fixed exiting AS_SET parsing on ']' instead of just ')'

### DIFF
--- a/lib/exabgp/configuration/static/parser.py
+++ b/lib/exabgp/configuration/static/parser.py
@@ -213,7 +213,7 @@ def as_path (tokeniser):
 					inset = True
 					while True:
 						value = tokeniser()
-						if value == ')':
+						if value in (')',']'):
 							break
 						as_set.append(ASN.from_string(value))
 				if value == ')':


### PR DESCRIPTION
This fixes a bug where AS_SET parsing began with either '(' or '[' but only exited the while loop with ')'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/778)
<!-- Reviewable:end -->
