### PR TITLE
Fix `MD5` calling `bytes_ascii` with a bytes argument

### DIFF
--- a/lib/exabgp/reactor/network/tcp.py
+++ b/lib/exabgp/reactor/network/tcp.py
@@ -127,16 +127,17 @@ def MD5 (io, ip, port, md5, md5_base64):
 	elif platform_os == 'Linux':
 		try:
 			if md5:
+				md5_bytes = None
 				if md5_base64 is True:
 					try:
-						md5 = base64.b64decode(md5)
+						md5_bytes = base64.b64decode(md5)
 					except TypeError:
 						raise MD5Error("Failed to decode base 64 encoded PSK")
 				elif md5_base64 is None:  # auto
 					options = [md5+'==', md5+'=', md5]
 					for md5 in options:
 						try:
-							md5 = base64.b64decode(md5)
+							md5_bytes = base64.b64decode(md5)
 							break
 						except TypeError:
 							pass
@@ -162,7 +163,8 @@ def MD5 (io, ip, port, md5, md5_base64):
 
 			TCP_MD5SIG_MAXKEYLEN = 80
 			if md5:
-				md5_bytes = bytes_ascii(md5)
+				if md5_bytes is None:
+					md5_bytes = bytes_ascii(md5)
 				key = pack('2xH4x%ds' % TCP_MD5SIG_MAXKEYLEN, len(md5_bytes), md5_bytes)
 			else:
 				key = pack('2xH4x%ds' % TCP_MD5SIG_MAXKEYLEN, 0, b'')


### PR DESCRIPTION
Running python 3 with an `md5-password` set and `md5-base64` unset (`None`) would cause a condition where `bytes_ascii()` was called with a bytestring which caused the traceback below.  This condition is possible if `md5-base64` is `True`, but only if the `md5-password` value is a valid base64 string.

I added a check to `MD5()` to ensure this case didn't happen.

```pytb
20:20:35 | 19885  | reactor       | ExaBGP version : 4.0.5-67a808ae                                                                                    
20:20:35 | 19885  | reactor       | Python version : 3.6.4 (default, Dec 23 2017, 19:07:07)  [GCC 7.2.1 20171128]                  
20:20:35 | 19885  | reactor       | System Uname   : #1 SMP PREEMPT Thu Nov 2 10:25:56 CET 2017                                                                                           
20:20:35 | 19885  | reactor       | System MaxInt  : 9223372036854775807                                                                                                                  
20:20:35 | 19885  | reactor       |                                                                                                                                                       
20:20:35 | 19885  | reactor       |                                                                                                                                                        
20:20:35 | 19885  | reactor       |                                                                                                                                                        
20:20:35 | 19885  | reactor       |                                                                                                                                                        
20:20:35 | 19885  | reactor       | <class 'TypeError'>                                                                                                                                    
20:20:35 | 19885  | reactor       | encoding without a string argument                                                                                            
20:20:35 | 19885  | reactor       | Traceback (most recent call last):                                                                                                                
20:20:35 | 19885  | reactor       |   File "/home/kbirkela/exabgp/lib/exabgp/reactor/peer.py", line 521, in _run                                                   
20:20:35 | 19885  | reactor       |     for action in self._establish():                                                                                                                  
20:20:35 | 19885  | reactor       |   File "/home/kbirkela/exabgp/lib/exabgp/reactor/peer.py", line 312, in _establish                              
20:20:35 | 19885  | reactor       |     for action in self._connect():                                                                                                                    
20:20:35 | 19885  | reactor       |   File "/home/kbirkela/exabgp/lib/exabgp/reactor/peer.py", line 259, in _connect                                               
20:20:35 | 19885  | reactor       |     connected = six.next(generator)                                                                                                                    
20:20:35 | 19885  | reactor       |   File "/home/kbirkela/exabgp/lib/exabgp/reactor/protocol.py", line 103, in connect                                             
20:20:35 | 19885  | reactor       |     self.connection = Outgoing(afi,peer,local,self.port,md5,md5_base64,ttl_out)                                                                        
20:20:35 | 19885  | reactor       |   File "/home/kbirkela/exabgp/lib/exabgp/reactor/network/outgoing.py", line 31, in __init__                                    
20:20:35 | 19885  | reactor       |     MD5(self.io,self.peer,port,md5,md5_base64)                                                                                                        
20:20:35 | 19885  | reactor       |   File "/home/kbirkela/exabgp/lib/exabgp/reactor/network/tcp.py", line 166, in MD5                                              
20:20:35 | 19885  | reactor       |     md5_bytes = bytes_ascii(md5)                                                                                                                      
20:20:35 | 19885  | reactor       |   File "/home/kbirkela/exabgp/lib/exabgp/util/__init__.py", line 91, in bytes_ascii                                            
20:20:35 | 19885  | reactor       |     return bytes(bytestring, 'ascii')                                                                                                                  
20:20:35 | 19885  | reactor       | TypeError: encoding without a string argument 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/780)
<!-- Reviewable:end -->
