### PR TITLE
Add back in 3.x logic which stores existing routes over reload to fix…

### DIFF
--- a/lib/exabgp/configuration/configuration.py
+++ b/lib/exabgp/configuration/configuration.py
@@ -62,6 +62,7 @@ class _Configuration (object):
 	def __init__ (self):
 		self.processes = {}
 		self.neighbors = {}
+		self.backup_changes = {}
 		self.logger = Logger ()
 
 	def inject_change (self, peers, change):
@@ -340,6 +341,8 @@ class Configuration (_Configuration):
 
 	def _clear (self):
 		self.processes = {}
+		for neighbor in self.neighbors:
+			self.backup_changes[neighbor] = self.neighbors[neighbor].changes
 		self.neighbors = {}
 		self._neighbors = {}
 		self._previous_neighbors = {}
@@ -390,6 +393,9 @@ class Configuration (_Configuration):
 		for neighbor in self.neighbors:
 			if neighbor in self._previous_neighbors:
 				self.neighbors[neighbor].changes = self._previous_neighbors[neighbor].changes
+
+		for neighbor in self.neighbors:
+			self.neighbors[neighbor].backup_changes = self.backup_changes.get(neighbor,[])
 
 		self._previous_neighbors = {}
 		self._cleanup()

--- a/lib/exabgp/configuration/configuration.py
+++ b/lib/exabgp/configuration/configuration.py
@@ -62,7 +62,6 @@ class _Configuration (object):
 	def __init__ (self):
 		self.processes = {}
 		self.neighbors = {}
-		self.backup_changes = {}
 		self.logger = Logger ()
 
 	def inject_change (self, peers, change):
@@ -341,11 +340,9 @@ class Configuration (_Configuration):
 
 	def _clear (self):
 		self.processes = {}
-		for neighbor in self.neighbors:
-			self.backup_changes[neighbor] = self.neighbors[neighbor].changes
+		self._previous_neighbors = self.neighbors
 		self.neighbors = {}
 		self._neighbors = {}
-		self._previous_neighbors = {}
 
 	# clear the parser data (ie: free memory)
 	def _cleanup (self):
@@ -389,13 +386,10 @@ class Configuration (_Configuration):
 		self.processes = self.process.processes
 		self._neighbors = {}
 
-		# installing in the neighbor the API routes
+		# Add the changes prior to the reload to the neighbor to correct handling of deleted routes
 		for neighbor in self.neighbors:
 			if neighbor in self._previous_neighbors:
-				self.neighbors[neighbor].changes = self._previous_neighbors[neighbor].changes
-
-		for neighbor in self.neighbors:
-			self.neighbors[neighbor].backup_changes = self.backup_changes.get(neighbor,[])
+				self.neighbors[neighbor].backup_changes = self._previous_neighbors[neighbor].changes
 
 		self._previous_neighbors = {}
 		self._cleanup()

--- a/lib/exabgp/reactor/peer.py
+++ b/lib/exabgp/reactor/peer.py
@@ -103,7 +103,7 @@ class Peer (object):
 		# The peer was restarted (to know what kind of open to send for graceful restart)
 		self._restarted = FORCE_GRACEFUL
 
-		# We want to remove routes which are not in the configuration anymote afte a signal to reload
+		# We want to remove routes which are not in the configuration anymore after a signal to reload
 		self._reconfigure = True
 		# We want to send all the known routes
 		self._resend_routes = SEND.DONE


### PR DESCRIPTION
I discovered that on 4.x, if I deleted a static route then did a SIGUSR1 or used the exabgpcli reload command, then the static route was not actually removed from the RIB or neighbor.

I tracked this down to the configuration reload refactoring.

A quick solution is to reinstate the old code which copied the changes over reload from 3.x - this doesn't seem the most elegant solution and I'm not clear whether the _previous_neighbors field was intended for something like this (albeit its logic is different).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/802)
<!-- Reviewable:end -->
