### PR TITLE
Fix python-exabgp.spec.git so it creates an RPM which can be installed

### DIFF
--- a/redhat/python-exabgp.spec.git
+++ b/redhat/python-exabgp.spec.git
@@ -56,7 +56,7 @@ mv ${RPM_BUILD_ROOT}%{_bindir} ${RPM_BUILD_ROOT}%{_sbindir}
 mv ${RPM_BUILD_ROOT}%{_sbindir}/healthcheck ${RPM_BUILD_ROOT}/%{_sbindir}/exabgp-healthcheck
 install -d -m 744 ${RPM_BUILD_ROOT}/%{_sysconfdir}/
 install -d -m 755 ${RPM_BUILD_ROOT}/%{_sysconfdir}/exabgp/examples
-mv ${RPM_BUILD_ROOT}/usr/share/exabgp/etc/* ${RPM_BUILD_ROOT}/%{_sysconfdir}/exabgp/examples
+install etc/exabgp/*.conf ${RPM_BUILD_ROOT}/%{_sysconfdir}/exabgp/examples
 
 install -d %{buildroot}/%{_unitdir}
 install etc/systemd/exabgp.service %{buildroot}/%{_unitdir}/
@@ -88,6 +88,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %files -n exabgp
 %defattr(-,root,root,-)
 %attr(755, root, root) %{_sbindir}/exabgp
+%attr(755, root, root) %{_sbindir}/exabgpcli
 %attr(755, root, root) %{_sbindir}/exabgp-healthcheck
 %dir %{_sysconfdir}/exabgp
 %{_sysconfdir}/exabgp/exabgp.conf
@@ -95,6 +96,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %attr(744, root, root) %{_prefix}/share/exabgp/*
 %attr(744, root, root) %{_sysconfdir}/exabgp/examples/*
 %{_unitdir}/exabgp.service
+%{_unitdir}/exabgp@.service
 %doc COPYRIGHT CHANGELOG README.md
 %{_mandir}/man1/*
 %{_mandir}/man5/*


### PR DESCRIPTION
Apply a couple of minor fixes so that `git build-rpm redhat/python-exabgp.spec.git` works.