### PR TITLE
RPM spec files need to use 'next' version number rather than 'current'

### DIFF
--- a/redhat/python-exabgp.spec
+++ b/redhat/python-exabgp.spec
@@ -1,6 +1,6 @@
 %{!?__python2:        %global __python2 /usr/bin/python2}
 %{!?python2_sitelib:  %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
-%define version %(echo "$(python setup.py current)")
+%define version %(echo "$(python setup.py next)")
 
 Name:           python-exabgp
 Version:        %{version}

--- a/redhat/python-exabgp.spec.git
+++ b/redhat/python-exabgp.spec.git
@@ -1,6 +1,6 @@
 %{!?__python2:        %global __python2 /usr/bin/python2}
 %{!?python2_sitelib:  %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
-%define version %(echo "$(python setup.py current).git$(git rev-parse --short $(python setup.py current))")
+%define version %(echo "$(python setup.py next).git$(git rev-parse --short $(python setup.py next))")
 
 # Warning: This .spec is meant to be used with https://github.com/iovation/git-build-rpm
 #

--- a/redhat/python-exabgp.spec.git
+++ b/redhat/python-exabgp.spec.git
@@ -1,6 +1,6 @@
 %{!?__python2:        %global __python2 /usr/bin/python2}
 %{!?python2_sitelib:  %global python2_sitelib %(%{__python2} -c "from distutils.sysconfig import get_python_lib; print(get_python_lib())")}
-%define version %(echo "$(python setup.py next).git$(git rev-parse --short $(python setup.py next))")
+%define version %(echo "$(python setup.py next).git$(git rev-parse --short HEAD)")
 
 # Warning: This .spec is meant to be used with https://github.com/iovation/git-build-rpm
 #


### PR DESCRIPTION
This is a follow on from yesterday's PR which followed the previous Git RPM example of using `python setup.py current` to find the current version.

However, testing this morning on tags/4.0.6 shows that this actually gives the wrong version number! 
With the way `setup.py` currently works, `next` is the correct version to use.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/804)
<!-- Reviewable:end -->
