### PR TITLE
qa: fix command to execute to replicate parsing error

### DIFF
--- a/qa/bin/parsing
+++ b/qa/bin/parsing
@@ -42,7 +42,7 @@ do
 	else
 		printf "failed\n"
 		printf "\n"
-		printf "env exabgp.debug.configuration=true exabgp.tcp.bind='' exabgp.debug.selfcheck=true $path/sbin/exabgp -d -p $path/etc/exabgp/$conf 2>&1"
+		printf "env exabgp_debug_configuration=true exabgp_tcp_bind='' exabgp_debug_selfcheck=true $path/sbin/exabgp -d -p $path/etc/exabgp/$conf 2>&1"
 		printf "\n\n"
 		printf "$result"
 		printf "\n\n"


### PR DESCRIPTION
Environment variables should use "_" instead of ".". We keep "-p" and
"-d" to get more results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/806)
<!-- Reviewable:end -->
