### PR TITLE
qa: fix BGP FlowSpec parsing tests

### DIFF
--- a/lib/exabgp/configuration/check.py
+++ b/lib/exabgp/configuration/check.py
@@ -125,6 +125,8 @@ def check_neighbor (neighbors):
 					else:
 						str1r = str1r.replace('next-hop self','next-hop %s' % neighbor.local_address)
 
+				str1r = str1r.replace(' next-hop no-nexthop', '')
+
 				if ' name ' in str1r:
 					parts = str1r.split(' ')
 					pos = parts.index('name')


### PR DESCRIPTION
`conf-flow` and `conf-flow-redirect` are failing with:

    strings are different:
    [flow destination-ipv4 192.168.0.1/32 source-ipv4 10.0.0.1/32 next-hop no-nexthop community [ 30740:0 30740:30740 ] extended-community [ origin:515:4.5.26.133 origin:2345:6.7.8.9 redirect:65500:12345 ]]
    [flow destination-ipv4 192.168.0.1/32 source-ipv4 10.0.0.1/32 community [ 30740:0 30740:30740 ] extended-community [ origin:515:4.5.26.133 origin:2345:6.7.8.9 redirect:65500:12345 ]]

Just ignore the `next-hop no-nexthop` part to make them succeed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/807)
<!-- Reviewable:end -->
