### PR TITLE
qa: FakeNeighbor should have an extended_message attribute

### DIFF
--- a/qa/tests/decode_test.py
+++ b/qa/tests/decode_test.py
@@ -317,6 +317,7 @@ class FakeNeighbor (object):
 	hold_time = HoldTime(180)
 	asn4 = False
 	add_path = 0
+	extended_message = False
 
 	# capability
 	route_refresh = False


### PR DESCRIPTION
Otherwise, we fail here:

    + env INTERPRETER=python2.7 ETC=/build/exabgp-4.0.6/etc/exabgp exabgp_log_enable=false python2.7 -m nose ./qa/tests/cache_test.py ./qa/tests/control_test.py ./qa/tests/decode_test.py ./qa/tests/flow_test.py ./qa/tests/l2vpn_test.py ./qa/tests/open_test.py ./qa/tests/parsing_test.py
    ......EE.........
    ======================================================================
    ERROR: test_decoding_udpate_asn (decode_test.TestUpdateDecoding)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/build/exabgp-4.0.6/qa/tests/decode_test.py", line 356, in setUp
        capa = Capabilities().new(neighbor,False)
      File "/build/exabgp-4.0.6/lib/exabgp/bgp/message/open/capability/capabilities.py", line 145, in new
        self._extended_message(neighbor)
      File "/build/exabgp-4.0.6/lib/exabgp/bgp/message/open/capability/capabilities.py", line 119, in _extended_message
        if not neighbor.extended_message:
    AttributeError: 'FakeNeighbor' object has no attribute 'extended_message'

    ======================================================================
    ERROR: test_decoding_udpate_asn4 (decode_test.TestUpdateDecoding)
    ----------------------------------------------------------------------
    Traceback (most recent call last):
      File "/build/exabgp-4.0.6/qa/tests/decode_test.py", line 356, in setUp
        capa = Capabilities().new(neighbor,False)
      File "/build/exabgp-4.0.6/lib/exabgp/bgp/message/open/capability/capabilities.py", line 145, in new
        self._extended_message(neighbor)
      File "/build/exabgp-4.0.6/lib/exabgp/bgp/message/open/capability/capabilities.py", line 119, in _extended_message
        if not neighbor.extended_message:
    AttributeError: 'FakeNeighbor' object has no attribute 'extended_message'

    ----------------------------------------------------------------------
    Ran 17 tests in 1.986s