### PR TITLE
Fix handling of processes when the configuration reload fails

### DIFF
--- a/lib/exabgp/configuration/configuration.py
+++ b/lib/exabgp/configuration/configuration.py
@@ -376,6 +376,7 @@ class Configuration (_Configuration):
 
 	def _rollback_reload (self):
 		self.neighbors = self._previous_neighbors
+		self.processes = self.process.processes
 		self._neighbors = {}
 		self._previous_neighbors = {}
 
@@ -431,6 +432,7 @@ class Configuration (_Configuration):
 
 		if self.section('root') is not True:
 			# XXX: Should it be in neighbor ?
+			self.process.add_api()
 			self._rollback_reload()
 
 			return self.error.set(


### PR DESCRIPTION
This appears to resolve the issue reported in #812 

I've made the handling of processes consistent with the reload success case.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/813)
<!-- Reviewable:end -->
