### PR TITLE
Remove options.ip_setup in dynamic ip management

### DIFF
--- a/lib/exabgp/application/healthcheck.py
+++ b/lib/exabgp/application/healthcheck.py
@@ -458,7 +458,7 @@ def loop(options):
             logger.info("service down, deleting loopback ips")
             remove_ips(options.ips, options.label, options.sudo)
         # if ips was deleted with dyn ip, re-setup them
-        if target == states.UP and options.ip_dynamic and options.ip_setup:
+        if target == states.UP and options.ip_dynamic:
             logger.info("service up, restoring loopback ips")
             setup_ips(options.ips, options.label, options.sudo)
 


### PR DESCRIPTION
Hello,

When I added dynamic IPs, I backported the code from 3.4 to 4.
But I can"t remember why I didn't put the same line here

3.4 => https://github.com/Exa-Networks/exabgp/pull/571/files#diff-f94226e54e04eb31c60e0778c53f95f5R371

```
+        if target == states.UP and options.ip_dynamic: 
```

4   => https://github.com/Exa-Networks/exabgp/pull/572/files#diff-f94226e54e04eb31c60e0778c53f95f5R449

```
 +        if target == states.UP and options.ips_deleted and options.ip_setup: 
```

The change here https://github.com/Exa-Networks/exabgp/pull/587, removes ips_deleted but we still got `options.ip_setup`.
It's a non-sens when we set dynamic ip.

So we must remove this test too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/817)
<!-- Reviewable:end -->
