### PR TITLE
Fix systemd service permissions within RPM

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,8 @@ Version 4.0.7
    patch by: Ahmet Demir
  * Improvement: many fix to QA code
    patch by: Vincent Bernart
+ * Fix: fix permissions of systemd service files
+   patch by: Malcolm Dodds
 
 Version 4.0.6
  * Fix: default network for IPv6 is 128 .. not 32

--- a/redhat/python-exabgp.spec
+++ b/redhat/python-exabgp.spec
@@ -92,6 +92,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %attr(744, root, root) %{_sysconfdir}/exabgp/examples/*
 %{_unitdir}/exabgp.service
 %{_unitdir}/exabgp@.service
+%attr(644, root, root) %{_unitdir}/*
 %doc COPYRIGHT CHANGELOG README.md
 %{_mandir}/man1/*
 %{_mandir}/man5/*

--- a/redhat/python-exabgp.spec.git
+++ b/redhat/python-exabgp.spec.git
@@ -100,6 +100,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %attr(744, root, root) %{_sysconfdir}/exabgp/examples/*
 %{_unitdir}/exabgp.service
 %{_unitdir}/exabgp@.service
+%attr(644, root, root) %{_unitdir}/*
 %doc COPYRIGHT CHANGELOG README.md
 %{_mandir}/man1/*
 %{_mandir}/man5/*


### PR DESCRIPTION
I noticed this error message on my system:
`May 23 15:04:40 localhost systemd: Configuration file /usr/lib/systemd/system/exabgp.service is marked executable. Please remove executable permission bits. Proceeding anyway.`

Correct permissions is 0644 rather than the default 0755.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/820)
<!-- Reviewable:end -->
