### PR TITLE
Fix the CLI 'show neighbor' commands to match against the peer IP add…

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -24,6 +24,8 @@ Version 4.0.7
    patch by: Vincent Bernart
  * Improvement: exit with error code 0 on SIGTERM
    reported by: Johan Guldmyr
+ * Fix: fix neighbor CLI to match against peer address
+   patch by: Malcolm Dodds
 
 Version 4.0.6
  * Fix: default network for IPv6 is 128 .. not 32

--- a/lib/exabgp/reactor/api/command/neighbor.py
+++ b/lib/exabgp/reactor/api/command/neighbor.py
@@ -160,7 +160,7 @@ def show_neighbor (self, reactor, service, command):
 			peer = reactor.peers.get(peer_name,None)
 			if not peer:
 				continue
-			if limit and limit not in peer.neighbor.name():
+			if limit and limit != str(peer.neighbor.peer_address):
 				continue
 			for line in Neighbor.summary(peer.cli_data()).split('\n'):
 				reactor.processes.answer(service,line)
@@ -180,5 +180,5 @@ def show_neighbor (self, reactor, service, command):
 		return True
 
 	reactor.processes.answer(service,'please specify summary, extensive or configuration')
-	reactor.processes.answer(service,'you can filter by per ip address adding it after the word neighbor')
+	reactor.processes.answer(service,'you can filter by peer ip address adding it after the word neighbor')
 	reactor.processes.answer_done(service)


### PR DESCRIPTION
Previous the 'exabgpcli' command would match against any neighbor which contained the IP address.
e.g. a search for 192.168.1.1 would match 192.168.1.1, 192.168.1.11, 192.168.1.111.

With extensive, it was easy to miss that you have multiple peer's returned when you requested one.
It also makes it more difficult to script using 'exabgpcli' (my problem).

Changed the matching so that it does an exact match on the peer IP address, consistent with the documentation.