### PR TITLE
BGP LS IPv6 parsing support

### DIFF
--- a/lib/exabgp/bgp/message/update/nlri/bgpls/__init__.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/__init__.py
@@ -14,3 +14,4 @@ from exabgp.bgp.message.update.nlri.bgpls.nlri import BGPLS
 from exabgp.bgp.message.update.nlri.bgpls.node import NODE
 from exabgp.bgp.message.update.nlri.bgpls.link import LINK
 from exabgp.bgp.message.update.nlri.bgpls.prefixv4 import PREFIXv4
+from exabgp.bgp.message.update.nlri.bgpls.prefixv6 import PREFIXv6

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/link.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/link.py
@@ -54,7 +54,7 @@ from exabgp.bgp.message.update.nlri.bgpls.tlvs.node import NodeDescriptor
 @BGPLS.register
 class LINK(BGPLS):
 	CODE = 2
-	NAME = "Link NLRI"
+	NAME = "bgpls-link"
 	SHORT_NAME = "Link"
 
 	def __init__ (
@@ -166,7 +166,7 @@ class LINK(BGPLS):
 		remote = ', '.join(d.json() for d in self.remote_node)
 		interface_addrs = ', '.join(d.json() for d in self.iface_addrs)
 		neighbor_addrs = ', '.join(d.json() for d in self.neigh_addrs)
-		content = '"ls-nlri-type": 2, '
+		content = '"ls-nlri-type": "%s", ' % self.NAME
 		content += '"l3-routing-topology": %d, ' % int(self.domain)
 		content += '"protocol-id": %d, ' % int(self.proto_id)
 		content += '"local-node-descriptors": { %s }, ' % local

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/node.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/node.py
@@ -35,7 +35,7 @@ from exabgp.bgp.message.update.nlri.bgpls.tlvs.node import NodeDescriptor
 @BGPLS.register
 class NODE(BGPLS):
 	CODE = 1
-	NAME = "Node NLRI"
+	NAME = "bgpls-node"
 	SHORT_NAME = "Node"
 
 	def __init__ (
@@ -53,7 +53,7 @@ class NODE(BGPLS):
 	def json (self,compact=None):
 		nodes = ', '.join(d.json() for d in self.node_ids)
 		content = ', '.join([
-			'"ls-nlri-type": 1',
+			'"ls-nlri-type": "%s"' % self.NAME,
 			'"l3-routing-topology": %d' % int(self.domain),
 			'"protocol-id": %d' % int(self.proto_id),
 			'"node-descriptors": { %s }' % nodes,

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv4.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv4.py
@@ -82,7 +82,7 @@ class PREFIXv4(BGPLS):
 				tlvs = tlvs[4 + tlv_length:]
 			if tlv_type == 265:
 				values = tlvs[4: 4 + tlv_length]
-				prefix = IpReach.unpack(values)
+				prefix = IpReach.unpack(values, 3)
 				tlvs = tlvs[4 + tlv_length:]
 
 		return cls(

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv4.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv4.py
@@ -34,7 +34,7 @@ from exabgp.bgp.message.update.nlri.bgpls.tlvs.ipreach import IpReach
 @BGPLS.register
 class PREFIXv4(BGPLS):
 	CODE = 3
-	NAME = " IPv4 Topology Prefix"
+	NAME = "bgpls-prefix-v4"
 	SHORT_NAME = "PREFIX_V4"
 
 	def __init__ (
@@ -111,7 +111,7 @@ class PREFIXv4(BGPLS):
 	def json (self, compact=None):
 		nodes = ', '.join(d.json() for d in self.local_node)
 		content = ', '.join([
-			'"ls-nlri-type": 3',
+			'"ls-nlri-type": "%s"' % self.NAME,
 			'"l3-routing-topology": %d' % int(self.domain),
 			'"protocol-id": %d' % int(self.proto_id),
 			'"node-descriptors": { %s }' % nodes,

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv6.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv6.py
@@ -1,6 +1,6 @@
 """
 prefixv6.py
-Created by Tinus Flagstad on 2018-07-02.
+Created by Tinus Flagstad & Håvard Eidnes on 2018-07-02.
 Copyright (c) 2009-2018 Exa Networks. All rights reserved.
 License: 3-clause BSD. (See the COPYRIGHT file)
 """
@@ -83,7 +83,7 @@ class PREFIXv6(BGPLS):
 				tlvs = tlvs[4 + tlv_length:]
 			if tlv_type == 265:
 				values = tlvs[4: 4 + tlv_length]
-				prefix = IpReach.unpack(values)
+				prefix = IpReach.unpack(values, 4)
 				tlvs = tlvs[4 + tlv_length:]
 
 		return cls(

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv6.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv6.py
@@ -1,0 +1,131 @@
+"""
+prefixv6.py
+Created by Tinus Flagstad on 2018-07-02.
+Copyright (c) 2009-2018 Exa Networks. All rights reserved.
+License: 3-clause BSD. (See the COPYRIGHT file)
+"""
+
+from struct import pack
+from struct import unpack
+import json
+
+from exabgp.bgp.message.update.nlri.bgpls.nlri import BGPLS
+from exabgp.bgp.message.update.nlri.bgpls.nlri import PROTO_CODES
+from exabgp.bgp.message.update.nlri.bgpls.tlvs.node import NodeDescriptor
+from exabgp.bgp.message.update.nlri.bgpls.tlvs.ospfroute import OspfRoute
+from exabgp.bgp.message.update.nlri.bgpls.tlvs.ipreach import IpReach
+
+#   The IPv4 and IPv6 Prefix NLRIs (NLRI Type = 3 and Type = 4) use the
+#   same format, as shown in the following figure.
+#
+#      0                   1                   2                   3
+#      0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+#     +-+-+-+-+-+-+-+-+
+#     |  Protocol-ID  |
+#     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+#     |                           Identifier                          |
+#     |                            (64 bits)                          |
+#     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+#     //              Local Node Descriptors (variable)              //
+#     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+#     //                Prefix Descriptors (variable)                //
+#     +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+
+@BGPLS.register
+class PREFIXv6(BGPLS):
+	CODE = 4
+	NAME = " IPv6 Topology Prefix"
+	SHORT_NAME = "PREFIX_V6"
+
+	def __init__ (
+			self,domain,proto_id,local_node,
+			packed=None,ospf_type=None,prefix=None,
+			nexthop=None,route_d=None,action=None, addpath=None):
+		BGPLS.__init__(self,action,addpath)
+		self.domain = domain
+		self.ospf_type = ospf_type
+		self.proto_id = proto_id
+		self.local_node = local_node
+		self.prefix = prefix
+		self.nexthop = nexthop
+		self._pack = packed
+		self.route_d = route_d
+
+	@classmethod
+	def unpack_nlri (cls, data, rd):
+		ospf_type = None
+		proto_id = unpack('!B',data[0:1])[0]
+		if proto_id not in PROTO_CODES.keys():
+			raise Exception('Protocol-ID {} is not valid'.format(proto_id))
+		domain = unpack('!Q',data[1:9])[0]
+		tlvs = data[9:]
+
+		while tlvs:
+			tlv_type, tlv_length = unpack('!HH', tlvs[:4])
+			if tlv_type == 256:
+				values = tlvs[4: 4 + tlv_length]
+				local_node = []
+				while values:
+					# Unpack Local Node Descriptor Sub-TLVs
+					# We pass proto_id as TLV interpretation
+					# follows IGP type
+					node, left = NodeDescriptor.unpack(values, proto_id)
+					local_node.append(node)
+					if left == values:
+						raise RuntimeError("sub-calls should consume data")
+					values = left
+				tlvs = tlvs[4 + tlv_length:]
+				continue
+			if tlv_type == 264:
+				values = tlvs[4: 4 + tlv_length]
+				ospf_type = OspfRoute.unpack(values)
+				tlvs = tlvs[4 + tlv_length:]
+			if tlv_type == 265:
+				values = tlvs[4: 4 + tlv_length]
+				prefix = IpReach.unpack(values)
+				tlvs = tlvs[4 + tlv_length:]
+
+		return cls(
+			domain=domain,proto_id=proto_id,packed=data,
+			local_node=local_node,ospf_type=ospf_type,
+			prefix=prefix,route_d=rd
+		)
+
+	def __eq__ (self, other):
+		return \
+			isinstance(other, PREFIXv6) and \
+			self.CODE == other.CODE and \
+			self.domain == other.domain and \
+			self.proto_id == other.proto_id and \
+			self.route_d == other.route_d
+
+	def __ne__ (self, other):
+		return not self.__eq__(other)
+
+	def __str__ (self):
+		return self.json()
+
+	def __hash__ (self):
+		return hash((self))
+
+	def json (self, compact=None):
+		nodes = ', '.join(d.json() for d in self.local_node)
+		content = ', '.join([
+			'"ls-nlri-type": %d' % self.CODE,
+			'"l3-routing-topology": %d' % int(self.domain),
+			'"protocol-id": %d' % int(self.proto_id),
+			'"node-descriptors": { %s }' % nodes,
+			self.prefix.json(),
+			'"nexthop": "%s"' % self.nexthop,
+		])
+		if self.ospf_type:
+			content += ', %s' % self.ospf_type.json()
+
+		if self.route_d:
+			content += ', %s' % self.route_d.json()
+
+		return '{ %s }' % (content)
+
+	def pack (self,negotiated=None):
+		return self._pack

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv6.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/prefixv6.py
@@ -35,7 +35,7 @@ from exabgp.bgp.message.update.nlri.bgpls.tlvs.ipreach import IpReach
 @BGPLS.register
 class PREFIXv6(BGPLS):
 	CODE = 4
-	NAME = " IPv6 Topology Prefix"
+	NAME = "bgpls-prefix-v6"
 	SHORT_NAME = "PREFIX_V6"
 
 	def __init__ (
@@ -112,7 +112,7 @@ class PREFIXv6(BGPLS):
 	def json (self, compact=None):
 		nodes = ', '.join(d.json() for d in self.local_node)
 		content = ', '.join([
-			'"ls-nlri-type": %d' % self.CODE,
+			'"ls-nlri-type": "%s"' % self.NAME,
 			'"l3-routing-topology": %d' % int(self.domain),
 			'"protocol-id": %d' % int(self.proto_id),
 			'"node-descriptors": { %s }' % nodes,

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/ipreach.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/ipreach.py
@@ -10,6 +10,7 @@ License: 3-clause BSD. (See the COPYRIGHT file)
 from __future__ import division
 from struct import unpack
 import math
+import ipaddress
 
 from exabgp.protocol.ip import IP
 from exabgp.util import ordinal
@@ -40,7 +41,7 @@ class IpReach(object):
 		self.plength = plength
 
 	@classmethod
-	def unpack (cls, data):
+	def unpack (cls, data, code):
 		# FIXME
 		# There seems to be a bug in the Cisco Xr implementation
 		# that causes the Prefix IP field to be one octet less than
@@ -56,7 +57,8 @@ class IpReach(object):
 		# octet = int(math.ceil(plength / 8))
 		octet = len(data[1:])
 
-		if octet > 4:
+		if code == 4:
+			# IPv6
 			if len(data[1:octet + 1]) % 2 == 1:
 				# Not an even number.
 				# So we add an empty octet.
@@ -66,19 +68,16 @@ class IpReach(object):
 			prefix_list = [str(format(x, 'x')) for x in prefix_list]
 			# fill out to a complete 128-bit address
 			prefix_list = prefix_list + ["0"] * (8 - len(prefix_list))
-
-			# Could optimize to use "::" for longest :0: seqence
-			# but we don't yet
 			prefix = ":".join(prefix_list)
+			prefix = ipaddress.ip_address(prefix).compressed
 		else:
+			# IPv4
 			prefix_list = unpack("!%dB" % octet,data[1:octet + 1])
 			prefix_list = [str(x) for x in prefix_list]
 			# fill the rest of the octets with 0 to construct
 			# a 4 octet IP prefix
 			prefix_list = prefix_list + ["0"]*(4 - len(prefix_list))
 			prefix = '.'.join(prefix_list)
-
-
 
 		return cls(prefix=prefix, plength=plength)
 

--- a/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/ipreach.py
+++ b/lib/exabgp/bgp/message/update/nlri/bgpls/tlvs/ipreach.py
@@ -10,7 +10,7 @@ License: 3-clause BSD. (See the COPYRIGHT file)
 from __future__ import division
 from struct import unpack
 import math
-import ipaddress
+from exabgp.vendoring import ipaddress
 
 from exabgp.protocol.ip import IP
 from exabgp.util import ordinal

--- a/qa/tests/bgpls/tlvs.py
+++ b/qa/tests/bgpls/tlvs.py
@@ -9,10 +9,15 @@ import unittest
 
 class TestTlvs(unittest.TestCase):
 
-    def test_ip_reach(self,):
+    def test_ip_reach_ipv4(self,):
         data = b'\n\n\x00'
-        tlv = IpReach.unpack(data)
-        self.assertEqual(tlv.json(), '"ip-reachability-tlv": "10.0.0.0"')
+        tlv = IpReach.unpack(data, 3)
+        self.assertEqual(tlv.json(), '"ip-reachability-tlv": "10.0.0.0", "ip-reach-prefix": "10.0.0.0/10"')
+
+    def test_ip_reach_ipv6(self,):
+        data =b'\x7f \x01\x07\x00\x00\x00\x80'
+        tlv = IpReach.unpack(data, 4)
+        self.assertEqual(tlv.json(), '"ip-reachability-tlv": "2001:700:0:8000::", "ip-reach-prefix": "2001:700:0:8000::/127"')
 
     def test_igp_tags(self,):
         data = b'\x00\x00\xff\xfe'


### PR DESCRIPTION
IPv6 pasing now works for "ip-reachability-tlv" and "ip-reach-prefix".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/837)
<!-- Reviewable:end -->
