### PR TITLE
RFC 7674 - Support redirect traffic to a VRF encoded as 4-octet AS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ Version explained:
  bug   : increase on bug or incremental changes
 
 Version 3.4.27
+ * Improvement: RFC 7674 - Support redirect traffic to a VRF encoded as 4-octet AS, 2-octet Value
+   patch by: Omri Matitiau
  * Fix: correctly decode flow routes with multiple NLRI
    reported by: adrian62
  * Improvement: exit with error code 0 on SIGTERM

--- a/lib/exabgp/bgp/message/update/attribute/community/extended/traffic.py
+++ b/lib/exabgp/bgp/message/update/attribute/community/extended/traffic.py
@@ -10,6 +10,7 @@ from struct import pack
 from struct import unpack
 
 from exabgp.bgp.message.open.asn import ASN
+from exabgp.bgp.message.open.capability.asn4 import ASN4
 from exabgp.bgp.message.update.attribute.community.extended import ExtendedCommunity
 
 
@@ -119,6 +120,33 @@ class TrafficRedirect (ExtendedCommunity):
 	def unpack (data):
 		asn,target = unpack('!HL',data[2:8])
 		return TrafficRedirect(ASN(asn),target,data[:8])
+
+
+class TrafficRedirectASN4 (ExtendedCommunity):
+	COMMUNITY_TYPE = 0x82
+	COMMUNITY_SUBTYPE = 0x08
+
+	__slots__ = ['asn','target']
+
+	def __init__ (self, asn, target, community=None):
+		self.asn = asn
+		self.target = target
+		ExtendedCommunity.__init__(
+			self,
+			community if community is not None else pack(
+				"!2sLH",
+				self._packedTypeSubtype(),
+				asn,target
+			)
+		)
+
+	def __str__ (self):
+		return "redirect:%s:%s" % (self.asn,self.target)
+
+	@staticmethod
+	def unpack (data):
+		asn,target = unpack('!LH',data[2:8])
+		return TrafficRedirectASN4(ASN4(asn),target,data[:8])
 
 
 # ================================================================== TrafficMark

--- a/lib/exabgp/configuration/ancient.py
+++ b/lib/exabgp/configuration/ancient.py
@@ -75,7 +75,7 @@ from exabgp.bgp.message.update.attribute.community.community import Community
 from exabgp.bgp.message.update.attribute.community.communities import Communities
 from exabgp.bgp.message.update.attribute.community.extended.community import ExtendedCommunity
 from exabgp.bgp.message.update.attribute.community.extended.communities import ExtendedCommunities
-from exabgp.bgp.message.update.attribute.community.extended.traffic import TrafficRate
+from exabgp.bgp.message.update.attribute.community.extended.traffic import TrafficRate, TrafficRedirectASN4
 from exabgp.bgp.message.update.attribute.community.extended.traffic import TrafficAction
 from exabgp.bgp.message.update.attribute.community.extended.traffic import TrafficRedirect
 from exabgp.bgp.message.update.attribute.community.extended.traffic import TrafficMark
@@ -2950,8 +2950,15 @@ class Configuration (object):
 				else:
 					asn = int(prefix)
 					route_target = int(suffix)
+
+					if asn >= pow(2,32):
+						raise ValueError('asn is a 32 bits number, value too large %s' % asn)
 					if asn >= pow(2,16):
-						raise ValueError('asn is a 32 bits number, it can only be 16 bit %s' % route_target)
+						if route_target >= pow(2,16):
+							raise ValueError('asn is a 32 bits number, route target can only be 16 bit %s' % route_target)
+						scope[-1]['announce'][-1].attributes[Attribute.CODE.EXTENDED_COMMUNITY].add(
+							TrafficRedirectASN4(asn, route_target))
+						return True
 					if route_target >= pow(2,32):
 						raise ValueError('route target is a 32 bits number, value too large %s' % route_target)
 					scope[-1]['announce'][-1].attributes[Attribute.CODE.EXTENDED_COMMUNITY].add(TrafficRedirect(asn,route_target))


### PR DESCRIPTION
RFC 7674 - Support redirect traffic to a VRF encoded as 4-octet AS, 2-octet Value

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/840)
<!-- Reviewable:end -->
