### PR TITLE
Send state down messages on peer removal

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,7 @@ Version explained:
  bug   : increase on bug or incremental changes
 
 Version 3.4.27
+ * Fix: Send state down messages on peer removal and shutdown
  * Improvement: RFC 7674 - Support redirect traffic to a VRF encoded as 4-octet AS, 2-octet Value
    patch by: Omri Matitiau
  * Fix: correctly decode flow routes with multiple NLRI

--- a/lib/exabgp/reactor/loop.py
+++ b/lib/exabgp/reactor/loop.py
@@ -401,7 +401,7 @@ class Reactor (object):
 		for key, peer in self.peers.items():
 			if key not in self.configuration.neighbor:
 				self.logger.reactor("Removing peer: %s" % peer.neighbor.name())
-				peer.stop()
+				peer.remove()
 
 		for key, neighbor in self.configuration.neighbor.items():
 			# new peer
@@ -467,7 +467,7 @@ class Reactor (object):
 			if key not in self.configuration.neighbor.keys():
 				neighbor = self.configuration.neighbor[key]
 				self.logger.reactor("Removing Peer %s" % neighbor.name())
-				self.peers[key].stop()
+				self.peers[key].remove()
 			else:
 				self.peers[key].reestablish()
 		self.processes.terminate()

--- a/lib/exabgp/reactor/loop.py
+++ b/lib/exabgp/reactor/loop.py
@@ -378,7 +378,7 @@ class Reactor (object):
 			self.listener.stop()
 			self.listener = None
 		for key in self.peers.keys():
-			self.peers[key].stop()
+			self.peers[key].shutdown()
 		self.processes.terminate()
 		self.daemon.removepid()
 		self._stopping = True

--- a/lib/exabgp/reactor/peer.py
+++ b/lib/exabgp/reactor/peer.py
@@ -185,9 +185,11 @@ class Peer (object):
 			self._[direction]['proto'] = None
 
 	def _stop (self, direction, message):
-		self._[direction]['generator'] = False
-		self._[direction]['proto'].close('%s loop, stop, message [%s]' % (direction,message))
-		self._[direction]['proto'] = None
+		if self._[direction]:
+			self._[direction]['generator'] = False
+			if self._[direction]['proto']:
+				self._[direction]['proto'].close('%s loop, stop, message [%s]' % (direction,message))
+				self._[direction]['proto'] = None
 
 	# connection delay
 
@@ -218,6 +220,11 @@ class Peer (object):
 		self._restarted = False
 		self._reset_skip()
 		self.neighbor.rib.uncache()
+
+	def remove (self):
+		for direction in ['in','out']:
+			self._stop(direction, "removed")
+		self.stop()
 
 	def resend (self):
 		self._resend_routes = SEND.NORMAL

--- a/lib/exabgp/reactor/peer.py
+++ b/lib/exabgp/reactor/peer.py
@@ -226,6 +226,11 @@ class Peer (object):
 			self._stop(direction, "removed")
 		self.stop()
 
+	def shutdown (self):
+		for direction in ['in','out']:
+			self._stop(direction, "shutting down")
+		self.stop()
+
 	def resend (self):
 		self._resend_routes = SEND.NORMAL
 		self._reset_skip()


### PR DESCRIPTION
When we remove peers from the configuration, we don't receive down messages for these peers, causing the announcements from those peers to still be visible. This fix explicitly sends down messages on removal.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/845)
<!-- Reviewable:end -->
