### PR TITLE
Read pipename from env file rather than using default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,8 @@ Version 4.0.9
    orginal patch: Andre Kampert
  * Feature: add != test of flows
    patch by: dhammika
+ * Fix: Read pipename from env file rather than using default 
+   patch by: Craig Milne
 
 Version 4.0.8
  * Fix: PEP-0479

--- a/lib/exabgp/application/cli.py
+++ b/lib/exabgp/application/cli.py
@@ -31,11 +31,13 @@ The BGP swiss army knife of networking
 
 usage: exabgpcli [--root ROOT]
 \t\t\t\t\t\t\t\t [--help|<command>...]
+\t\t\t\t\t\t\t\t [--env ENV]
 
 positional arguments:
 \tcommand               valid exabgpcli command (see below)
 
 optional arguments:
+\t--env ENV,   -e ENV   environment configuration file
 \t--help,      -h       exabgp manual page
 \t--root ROOT, -f ROOT  root folder where etc,bin,sbin are located
 
@@ -52,7 +54,8 @@ class AnswerStream:
 
 def main ():
 	options = docopt.docopt(usage, help=False)
-	options['--env'] = ''  # exabgp compatibility
+	if options['--env'] is None:
+		options['--env'] = ''
 
 	root = root_folder(options,['/bin/exabgpcli','/sbin/exabgpcli','/lib/exabgp/application/cli.py'])
 	prefix = '' if root == '/usr' else root
@@ -73,7 +76,7 @@ def main ():
 
 	command = ' '.join(options['<command>'])
 
-	pipes = named_pipe(root)
+	pipes = named_pipe(root, pipename)
 	if len(pipes) != 1:
 		sys.stdout.write('could not find ExaBGP\'s named pipes (%s.in and %s.out) for the cli\n' % (pipename, pipename))
 		sys.stdout.write('we scanned the following folders (the number is your PID):\n - ')


### PR DESCRIPTION
We'd like to be able to run two instances of ExaBGP on a single machine, supplying a different exabgp.env to each and have both use different pipenames. 

I noticed that this (or very similar) functionality was removed a year or so ago but it's not 100% clear to me why. Made sure this work when the .env file specifies the pipename value and leaves it absent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/exa-networks/exabgp/852)
<!-- Reviewable:end -->
