### PR TITLE
Travis CI: Find Python 3 syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,22 @@ python:
   - "2.7"
   - "pypy"
 
+matrix:
+  allow_failures:
+    - python: "3.7"
+  include:
+    - python: "3.7"
+      dist: xenial    # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+      before_install: true  # override the main before_install
+      install: pip install flake8
+      script:
+        # stop the build if there are Python syntax errors or undefined names
+        - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+        # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+        - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      after_success: true  # override the main after_success
+
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -y python-pip python-dev


### PR DESCRIPTION
Add Python 3.7 in __allow_failures__ mode and flake8 testing to the Travis CI build matrix.

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree