### PR TITLE
Adding option --local-preference to healtchcheck.py

### DIFF
--- a/lib/exabgp/application/healthcheck.py
+++ b/lib/exabgp/application/healthcheck.py
@@ -480,11 +480,9 @@ def loop(options):
                 options.next_hop or "self")
 
             if command == "announce":
-                localprefphrase=""
+                announce = "{0} med {1}".format(announce, metric)
                 if options.local_preference >= 0:
-                    localprefphrase = " local-preference {}".format(options.local_preference)
-
-                announce = "{0} med {1}{2}".format(announce, metric, localprefphrase)
+                    announce = "{0} local-preference {1}".format(announce, options.local_preference)
                 if options.community or options.disabled_community:
                     community = options.community
                     if target in (states.DOWN, states.DISABLED):

--- a/lib/exabgp/application/healthcheck.py
+++ b/lib/exabgp/application/healthcheck.py
@@ -165,6 +165,9 @@ def parse():
     g.add_argument("--ip", metavar='IP',
                    type=ip_network, dest="ips", action="append",
                    help="advertise this IP address or network (CIDR notation)")
+    g.add_argument("--local-preference", metavar='P',
+                   type=int, default=-1,
+                   help="advertise with local preference P")
     g.add_argument("--deaggregate-networks",
                    dest="deaggregate_networks", action="store_true",
                    help="Deaggregate Networks specified in --ip")
@@ -477,7 +480,11 @@ def loop(options):
                 options.next_hop or "self")
 
             if command == "announce":
-                announce = "{0} med {1}".format(announce, metric)
+                localprefphrase=""
+                if options.local_preference >= 0:
+                    localprefphrase = " local-preference {}".format(options.local_preference)
+
+                announce = "{0} med {1}{2}".format(announce, metric, localprefphrase)
                 if options.community or options.disabled_community:
                     community = options.community
                     if target in (states.DOWN, states.DISABLED):


### PR DESCRIPTION
I propose to add option --local-preference to healthcheck.py.

The patch does this:
-  if not specified, the behavior of healthcheck.py is unchanged
- if healthcheck is called with --local-preference P, then the announcement towards the exabgp engine is extended with 'local-preference P'

Quite useful for single-IP announcements. 