### PR TITLE
Update parse-md5.conf

### DIFF
--- a/etc/exabgp/parse-md5.conf
+++ b/etc/exabgp/parse-md5.conf
@@ -9,8 +9,8 @@ neighbor 10.0.0.3 {
 	md5-password abc123;
 #	md5-password "my md5 of the day";
 #	md5-password 'another md5 valid syntax';
-#	md5-password oh ! parenthesis are optional;
-#	md5-password "oh ! parenthesis are optional";
+#	md5-password oh ! quotes are optional;
+#	md5-password "oh ! quotes are optional";
 #	can not recall what happens with the start and end spaces/tabs .. check it.
 #  optional (otherwise it uses the local-address)
 	md5-ip 10.0.0.2;


### PR DESCRIPTION
I believe it meant to say quotes instead of parentheses.