### PR TITLE
Experimental fix for accumulating families

### DIFF
--- a/lib/exabgp/configuration/neighbor/__init__.py
+++ b/lib/exabgp/configuration/neighbor/__init__.py
@@ -201,6 +201,7 @@ class ParseNeighbor (Section):
 
 		neighbor.changes = []
 		neighbor.changes.extend(self.scope.pop_routes())
+		local.get('family').clear()
 
 		# old format
 		for section in ('static','l2vpn','flow'):


### PR DESCRIPTION
When parsing multiple configuration address families from previous
neighbors appear to be added to subsequent peers (see issue #826).

This commit attempts to clear the parsed families after being used with
the current neighbor.