### PR TITLE
Rfc5575bis review / treat as withdraw feature

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/mprnlri.py
+++ b/lib/exabgp/bgp/message/update/attribute/mprnlri.py
@@ -157,11 +157,15 @@ class MPRNLRI (Attribute,Family):
 			if nexthops:
 				for nexthop in nexthops:
 					nlri,left = NLRI.unpack_nlri(afi,safi,data,IN.ANNOUNCED,addpath)
-					nlri.nexthop = NextHop.unpack(nexthop)
-					nlris.append(nlri)
+					# allow unpack_nlri to return none for "treat as withdraw" controlled by NLRI.unpack_nlri
+					if nlri:
+						nlri.nexthop = NextHop.unpack(nexthop)
+						nlris.append(nlri)
 			else:
 				nlri,left = NLRI.unpack_nlri(afi,safi,data,IN.ANNOUNCED,addpath)
-				nlris.append(nlri)
+				# allow unpack_nlri to return none for "treat as withdraw" controlled by NLRI.unpack_nlri
+				if nlri:
+					nlris.append(nlri)
 
 			if left == data:
 				raise RuntimeError("sub-calls should consume data")

--- a/lib/exabgp/bgp/message/update/attribute/mpurnlri.py
+++ b/lib/exabgp/bgp/message/update/attribute/mpurnlri.py
@@ -98,7 +98,9 @@ class MPURNLRI (Attribute,Family):
 
 		while data:
 			nlri,data = NLRI.unpack_nlri(afi,safi,data,IN.WITHDRAWN,addpath)
-			nlris.append(nlri)
+			# allow unpack_nlri to return none for "treat as withdraw" controlled by NLRI.unpack_nlri
+			if nlri:
+				nlris.append(nlri)
 
 		return cls(afi,safi,nlris)
 

--- a/lib/exabgp/bgp/message/update/nlri/flow.py
+++ b/lib/exabgp/bgp/message/update/nlri/flow.py
@@ -675,4 +675,4 @@ class Flow (NLRI):
 
 			return nlri, bgp+over
 		except (Notify, ValueError, IndexError) as exc:
-			return None, bgp+over
+			return None, over


### PR DESCRIPTION
This pull request suggests the following changes to the code:

* General: Allow unpack_nlri of NLRI implementations to return a None value to MPRNLRI, MPURNLRI to allow a mechanism of "Treat as withdraw" handling of undecodable NLRI (this implementation is more a "ignore". Maybe the undecodeable NLRI should still be saved as a "Generic-unknown-NLRI" containing the undecoded byte-string received)
* Flowspec: Use the above to allow flowspec to treat undecodeable NLRI as withdraw according to RFC5575-bis
* Flowspec: Swap always "true"/"false" numeric operator (has been swapped during history the draft)
* Flowspec: TODO in flow.py line 551 -> why should the afi change during the livetime of the NLRI instance

I do not know if this is appropriate sending a pull-request this way (first pull-request ever). If you find time have a look

Cheers Christoph
