### PR TITLE
Negotiated.validate: fix peer-as auto

### DIFF
--- a/lib/exabgp/bgp/message/open/capability/negotiated.py
+++ b/lib/exabgp/bgp/message/open/capability/negotiated.py
@@ -115,7 +115,7 @@ class Negotiated (object):
 		# 		self.received_open_size = self.peer.bgp.received_open_size - 19
 
 	def validate (self, neighbor):
-		if self.peer_as != neighbor.peer_as:
+		if neighbor.peer_as is not None and self.received_open.asn != neighbor.peer_as:
 			return (2,2,'ASN in OPEN (%d) did not match ASN expected (%d)' % (self.received_open.asn,neighbor.peer_as))
 
 		# RFC 6286 : https://tools.ietf.org/html/rfc6286


### PR DESCRIPTION
Handle the `peer-as auto` case, where neighbor.peer_as is expected to be
None. These prevents the following error triggered by `peer-as auto`:
```
<class 'TypeError'>
%d format: a number is required, not NoneType
Traceback (most recent call last):
  File "/usr/lib64/python3.6/site-packages/exabgp/reactor/peer.py", line 541, in _run
    for action in self._establish():
  File "/usr/lib64/python3.6/site-packages/exabgp/reactor/peer.py", line 361, in _establish
    self.proto.validate_open()
  File "/usr/lib64/python3.6/site-packages/exabgp/reactor/protocol.py", line 257, in validate_open
    error = self.negotiated.validate(self.neighbor)
  File "/usr/lib64/python3.6/site-packages/exabgp/bgp/message/open/capability/negotiated.py", line 119, in validate
    return (2,2,'ASN in OPEN (%d) did not match ASN expected (%d)' % (self.received_open.asn,neighbor.peer_as))
TypeError: %d format: a number is required, not NoneType
```