### PR TITLE
Fix BGP MD5

### DIFF
--- a/lib/exabgp/reactor/network/tcp.py
+++ b/lib/exabgp/reactor/network/tcp.py
@@ -165,9 +165,8 @@ def MD5 (io, ip, port, md5, md5_base64):
 			if md5:
 				if md5_bytes is None:
 					md5_bytes = bytes_ascii(md5)
-					key = pack('2xH4x%ds' % TCP_MD5SIG_MAXKEYLEN, len(md5_bytes), md5_bytes)
-				else:
-					key = pack('2xH4x%ds' % TCP_MD5SIG_MAXKEYLEN, 0, b'')
+
+				key = pack('2xH4x%ds' % TCP_MD5SIG_MAXKEYLEN, len(md5_bytes), md5_bytes)
 
 				TCP_MD5SIG = 14
 				io.setsockopt(socket.IPPROTO_TCP, TCP_MD5SIG, sockaddr + key)


### PR DESCRIPTION
In cases where md5_bytes was already set (which seems to be almost always due to the creative base64 decoding), we were setting the `key` variable to null bytes. I'm not sure why that was done but it seems entirely wrong.

To fix that I adjusted things to always pack `md5_bytes` to `key`, but, only convert `md5` to `md5_bytes` if we don't already have `md5_bytes` set