### PR TITLE
Add a Dockerfile for exabgp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,9 +4,7 @@ RUN mkdir -p /src
 COPY setup.py /src
 COPY CHANGELOG /src
 COPY debian/ /src
-# COPY etc/ /src/etc
 COPY lib/ /src/lib/
-# COPY qa/ /src/qa
 
 RUN pip install --upgrade pip setuptools
 RUN cd /src && pip install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:3
+
+RUN mkdir -p /src
+COPY setup.py /src
+COPY CHANGELOG /src
+COPY debian/ /src
+# COPY etc/ /src/etc
+COPY lib/ /src/lib/
+# COPY qa/ /src/qa
+
+RUN pip install --upgrade pip setuptools
+RUN cd /src && pip install .
+
+RUN rm -rf /src
+
+CMD ["exabgp", "--help"]


### PR DESCRIPTION
- Handy to use for testing + future prod deploy
- Could be used when a PyPI release is done and release to Dockerhub

Build Command: cd exabgp && docker build .
Build Output: https://pastebin.com/iEsKnT6q
Test Run: `docker run 2d2c3c98d25d exabgp --help`