### PR TITLE
[Travis] Test in more Python Versions + be more venv focused

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,30 @@
 language: python
+dist: xenial
 
-python:
-  - "2.7"
-  - "3.7"
-  - "pypy"
-
-before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -y python-pip python-dev python-psutil
-  - sudo apt-get install -y python3-pip python3-setuptools python3-psutil
+matrix:
+  fast_finish: true
+  include:
+    - python: 2.7
+    - python: pypy
+    - python: 3.7
+    - python: 3.8-dev
+    - python: nightly
+  allow_failures:
+    - python: 2.7
+    - python: pypy
+    - python: 3.8-dev
+    - python: nightly
 
 install:
+  - pip install --upgrade pip setuptools wheel
   - pip install -r requirements.txt
-  - pip3 install -r requirements.txt
-  - pip3 install -r qa/requirements.txt
+  - pip install -r qa/requirements.txt
 
 script:
-  - export INTERPRETER=python3
   - export SKIPCLEANUP=exabgp
-  - sbin/exabgp --version
-  - sbin/exabgp --fi > etc/exabgp/exabgp.env
+  - ./sbin/exabgp --version
+  - ./sbin/exabgp --fi > etc/exabgp/exabgp.env
+  - cat etc/exabgp/exabgp.env
   - set pipefail
   - ./qa/bin/parsing
   - ./qa/bin/functional all

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ script:
 
 after_success:
   - coveralls
-  - ocular
 
 notifications:
   irc:

--- a/qa/requirements.txt
+++ b/qa/requirements.txt
@@ -3,4 +3,3 @@ six
 coveralls
 nose
 psutil
-scrutinizer-ocular

--- a/sbin/exabgp
+++ b/sbin/exabgp
@@ -16,12 +16,14 @@ path="$(cd "$(dirname "$0")"/.. ; pwd)"
 
 export PYTHONPATH="$path"/lib
 
-for INTERPRETER in "$INTERPRETER" python3 pypy3; do
+# A python3 venv still has a python binary / symlink that points @ Python 3
+# We need python so we're actually testing in Python 2 as well
+for INTERPRETER in "$INTERPRETER" pypy pypy3 python python3; do
     INTERPRETER="$(command -v "$INTERPRETER")" && break
 done
 
 if [ "$INTERPRETER" = "" ]; then
-	echo "ExaBGP could not find a python3 interpreter"
+	echo "ExaBGP could not find a python interpreter"
 	exit 1
 fi
 


### PR DESCRIPTION
- Test in nightly and 3.8 builds + allow failure. Move to xenial to allow for this
- Move to matrix for fast finish
- Modify sbin/exabgp so that we will pickup venv python
- Ensure we're running latest pip, setuptools + wheel
- Install dependencies only into the venv - Remove apt installs ...
- Allow python2 + pypy to fail unitl we fix the functional tests

Addresses parts of #905 