### PR TITLE
update manpage to point to the correct redirect-to-ip draft

### DIFF
--- a/doc/man/exabgp.1
+++ b/doc/man/exabgp.1
@@ -346,8 +346,8 @@ The Accumulated IGP Metric Attribute for BGP
 .It draft-raszuk-idr-flow-spec-v6-03
 (draft-ietf-idr-flow-spec-v6-06), Dissemination of Flow Specification
 Rules for IPv6
-.It draft-ietf-idr-flowspect-redirect-ip-00 (-02)
-BGP Flow-Spect Redirect to IP Action
+.It draft-simpson-idr-flowspec-redirect-00 (-02)
+BGP Flow-Spec Redirect to IP Action
 .It draft-ietf-idr-add-paths-08 (-10)
 Advertisement of Multiple Paths in BGP
 .It draft-ietf-idr-bgp-multisession-07 (??)


### PR DESCRIPTION
There are two drafts for flowspec redirect-to-ip. The manpage points
ietf, but simpson is the one currently implemented.

See eg. https://github.com/Exa-Networks/exabgp/blob/40f00b5e89e4a3f127639ac474b51371bd177b64/lib/exabgp/bgp/message/update/attribute/community/extended/traffic.py#L187