### PR TITLE
Updating cli.py to stop hanging stdout

### DIFF
--- a/lib/exabgp/application/cli.py
+++ b/lib/exabgp/application/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # encoding: utf-8
 """
 cli.py

--- a/lib/exabgp/application/cli.py
+++ b/lib/exabgp/application/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # encoding: utf-8
 """
 cli.py
@@ -255,6 +255,7 @@ def main ():
 	waited = 0.0
 	buf = b''
 	done = False
+	done_time_diff = 0.5
 	while not done:
 		try:
 			r, _, _ = select.select([reader], [], [], 0.01)
@@ -318,6 +319,13 @@ def main ():
 				break
 			sys.stdout.write('%s\n' % string)
 			sys.stdout.flush()
+
+		if not env.get('api').get('ack') and not raw.decode():
+			this_moment = time.time()
+			recv_epoch_time = os.path.getmtime(recv)
+			time_diff = this_moment - recv_epoch_time
+			if time_diff >= done_time_diff:
+				done = True
 
 	try:
 		os.close(reader)


### PR DESCRIPTION
When exabgp.api.ack environment config is set to "**false**", exabgpcli doesn't close exabgp.out fifo file (keeps inside an infinite loop (while not done)). This modification was made as a workaround to this situation.

Example environment:

```
[exabgp.api]
ack = false
chunk = 1
cli = true
compact = false
encoder = json
pipename = 'exabgp'
respawn = true
terminate = false

[exabgp.bgp]
openwait = 60

[exabgp.cache]
attributes = true
nexthops = true

[exabgp.daemon]
daemonize = false
drop = true
pid = ''
umask = '0o137'
user = 'nobody'

[exabgp.log]
all = false
configuration = true
daemon = true
destination = 'stdout'
enable = true
level = INFO
message = false
network = true
packets = false
parser = false
processes = true
reactor = true
rib = false
routes = false
short = false
timers = false

[exabgp.pdb]
enable = false

[exabgp.profile]
enable = false
file = ''

[exabgp.reactor]
speed = 1.0

[exabgp.tcp]
acl = false
bind = ''
delay = 0
once = false
port = 179
```