### PR TITLE
Move import of lsprofcalltree in bgp.py

### DIFF
--- a/lib/exabgp/application/bgp.py
+++ b/lib/exabgp/application/bgp.py
@@ -22,7 +22,6 @@ from exabgp.version import version
 from exabgp.reactor.loop import Reactor
 
 from exabgp.vendoring import docopt
-from exabgp.vendoring import lsprofcalltree
 
 from exabgp.configuration.usage import usage
 
@@ -402,6 +401,7 @@ def run (env, comment, configurations, root, validate, pid=0):
 			exit_code = Reactor.Exit.unknown
 			raise
 		finally:
+			from exabgp.vendoring import lsprofcalltree
 			profiler.disable()
 			kprofile = lsprofcalltree.KCacheGrind(profiler)
 			try:


### PR DESCRIPTION
- This needs to be moved to only be imported IF profiling is enabled in the env file

Test: 
Applied this patch locally and saw `exabgp` start when there is no cProfile module available