### PR TITLE
Support additional sub-type of BGP-Prefix-SID for SRv6-VPN

### DIFF
--- a/etc/exabgp/conf-prefix-sid-srv6.conf
+++ b/etc/exabgp/conf-prefix-sid-srv6.conf
@@ -1,0 +1,24 @@
+neighbor 127.0.0.1 {
+	router-id 198.51.100.200;
+	local-address 127.0.0.1;
+	local-as 65000;
+	peer-as 65000;
+
+	capability {
+		nexthop true;
+	}
+	family {
+		ipv4 unicast;
+		ipv4 mpls-vpn;
+		ipv6 unicast;
+		ipv6 mpls-vpn;
+	}
+	nexthop {
+		ipv4 mpls-vpn ipv6;
+	}
+
+	static {
+		route 10.0.0.0/24 rd 1:1 next-hop cafe::1 extended-community [ 0x0002fde800000001 ] label 3 bgp-prefix-sid-srv6 ( vpn 2001:1::10 );
+		route 10.1.0.0/24 rd 1:1 next-hop cafe::1 extended-community [ 0x0002fde800000001 ] label 3 bgp-prefix-sid-srv6 ( l3vpn 2001:1::20 );
+	}
+}

--- a/lib/exabgp/bgp/message/update/attribute/mprnlri.py
+++ b/lib/exabgp/bgp/message/update/attribute/mprnlri.py
@@ -139,7 +139,7 @@ class MPRNLRI (Attribute,Family):
 		length, rd = Family.size[(afi, safi)]
 
 		if negotiated.nexthop:
-			if len_nh in (16, 32):
+			if len_nh in (16, 32, 24):
 				nh_afi = AFI.ipv6
 			elif len_nh in (4,):
 				nh_afi = AFI.ipv4

--- a/lib/exabgp/bgp/message/update/attribute/sr/ipv6sid.py
+++ b/lib/exabgp/bgp/message/update/attribute/sr/ipv6sid.py
@@ -59,7 +59,7 @@ class SrV6Sid(object):
 		# transmission an MUST be ignored at reception.
 		data = data[3:19]
 		v6sid = IP.unpack(data)
-		return cls(v6sid=v6sid,packed=data)
+		return cls(v6sid=str(v6sid),packed=data)
 
 	def json (self, compact=None):
 		return '"sr-v6-sid": "%s"' % (self.v6sid)

--- a/lib/exabgp/bgp/message/update/attribute/sr/srv6l3vpnsid.py
+++ b/lib/exabgp/bgp/message/update/attribute/sr/srv6l3vpnsid.py
@@ -1,0 +1,63 @@
+# encoding: utf-8
+"""
+sr/srv6l3vpnsid.py
+
+Created by Hiroki Shirokura 2020-01-09
+Copyright (c) 2020 Hiroki Shirokura . All rights reserved.
+"""
+from struct import pack
+
+from exabgp.util import concat_bytes
+from exabgp.protocol.ip import IP
+
+from exabgp.bgp.message.notification import Notify
+from exabgp.bgp.message.update.attribute.sr.prefixsid import PrefixSid
+
+# 0                   1                   2                   3
+# 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+# +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+# |       Type    |             Length            |   RESERVED    |
+# +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+# |                                                               |
+# |                      L3VPN SID (16 octets)                    |
+# |                                                               |
+# |                                                               |
+# +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+# | 　SID Flags   |       Endpoint Behavior       |   RESERVED    |
+# +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+# 3.2.  SRv6 L3 Service
+
+
+@PrefixSid.register()
+class Srv6L3vpnSid(object):
+	TLV = 5
+	LENGTH = 21
+
+	def __init__ (self,l3vpnsid,packed=None):
+		self.l3vpnsid = l3vpnsid
+		self.packed = self.pack()
+
+	def __repr__ (self):
+		return "srv6-l3vpn-sid %s" % (self.l3vpnsid)
+
+	def pack (self):
+		return concat_bytes(
+			pack('!B', self.TLV),
+			pack('!H', self.LENGTH),
+			pack('!B', 0),
+			IP.pton(self.l3vpnsid),
+			pack('!B', 0),
+			pack('!H', 0xffff),
+			pack('!B', 0),
+		)
+
+	@classmethod
+	def unpack (cls,data,length):
+		l3vpnsid = -1
+		if cls.LENGTH != length:
+			raise Notify(3,5, "Invalid TLV size. Should be {0} but {1} received".format(cls.LENGTH, length))
+		l3vpnsid = IP.unpack(data[1:17])
+		return cls(l3vpnsid=str(l3vpnsid),packed=data)
+
+	def json (self, compact=None):
+		return '"srv6-l3vpn-sid": "%s"' % (self.l3vpnsid)

--- a/lib/exabgp/bgp/message/update/attribute/sr/srv6vpnsid.py
+++ b/lib/exabgp/bgp/message/update/attribute/sr/srv6vpnsid.py
@@ -1,0 +1,64 @@
+# encoding: utf-8
+"""
+sr/srv6vpnsid.py
+
+Created by Hiroki Shirokura 2020-01-09
+Copyright (c) 2020 Hiroki Shirokura . All rights reserved.
+"""
+from struct import pack
+
+from exabgp.util import concat_bytes
+from exabgp.protocol.ip import IP
+
+from exabgp.bgp.message.notification import Notify
+from exabgp.bgp.message.update.attribute.sr.prefixsid import PrefixSid
+
+# 0                   1                   2                   3
+# 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+# +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+# |       Type    |             Length            |   RESERVED    |
+# +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+# |   SID-Type    |   SID-Flags   |                               |
+# +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+                               |
+# |                                                               |
+# |                        IPv6 SID (16 octets)                   |
+# |                                                               |
+# |                               +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+# |                               |
+# +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+# 3.2.  SRv6 VPN SID
+
+
+@PrefixSid.register()
+class Srv6VpnSid(object):
+	TLV = 4
+	LENGTH = 19
+
+	def __init__ (self,vpnsid,packed=None):
+		self.vpnsid = vpnsid
+		self.packed = self.pack()
+
+	def __repr__ (self):
+		return "srv6-vpn-sid %s" % (self.vpnsid)
+
+	def pack (self):
+		return concat_bytes(
+			pack('!B', self.TLV),
+			pack('!H', self.LENGTH),
+			pack('!B', 0),
+			pack('!B', 0),
+			pack('!B', 0),
+			IP.pton(self.vpnsid)
+		)
+
+	@classmethod
+	def unpack (cls,data,length):
+		vpnsid = -1
+		if cls.LENGTH != length:
+			raise Notify(3,5, "Invalid TLV size. Should be {0} but {1} received".format(cls.LENGTH, length))
+		data = data[3:19]
+		vpnsid = IP.unpack(data)
+		return cls(vpnsid=str(vpnsid),packed=data)
+
+	def json (self, compact=None):
+		return '"srv6-vpn-sid": "%s"' % (self.vpnsid)

--- a/lib/exabgp/configuration/static/mpls.py
+++ b/lib/exabgp/configuration/static/mpls.py
@@ -18,6 +18,7 @@ from exabgp.bgp.message.update.attribute.sr.prefixsid import PrefixSid
 from exabgp.bgp.message.update.attribute.sr.labelindex import SrLabelIndex
 from exabgp.bgp.message.update.attribute.sr.ipv6sid import SrV6Sid
 from exabgp.bgp.message.update.attribute.sr.srv6vpnsid import Srv6VpnSid
+from exabgp.bgp.message.update.attribute.sr.srv6l3vpnsid import Srv6L3vpnSid
 from exabgp.bgp.message.update.attribute.sr.srgb import SrGb
 
 
@@ -116,7 +117,7 @@ def prefix_sid (tokeniser):
 
 	return PrefixSid(sr_attrs)
 
-# { ipv6 <ipv6-addr> | vpn <ipv4-addr> }
+# { ipv6 <ipv6-addr> | vpn <ipv6-addr> | l3vpn <ipv6-addr> }
 def prefix_sid_srv6 (tokeniser):
 	sr_attrs = []
 	value = tokeniser()
@@ -133,6 +134,13 @@ def prefix_sid_srv6 (tokeniser):
 			if value == 'vpn':
 				value = tokeniser()
 				sr_attrs.append(Srv6VpnSid(value))
+				value = tokeniser()
+				if value == ')':
+					return PrefixSid(sr_attrs)
+
+			if value == 'l3vpn':
+				value = tokeniser()
+				sr_attrs.append(Srv6L3vpnSid(value))
 				value = tokeniser()
 				if value == ')':
 					return PrefixSid(sr_attrs)

--- a/lib/exabgp/configuration/static/mpls.py
+++ b/lib/exabgp/configuration/static/mpls.py
@@ -16,6 +16,7 @@ from exabgp.bgp.message.update.nlri.qualifier import Labels
 from exabgp.bgp.message.update.nlri.qualifier import RouteDistinguisher
 from exabgp.bgp.message.update.attribute.sr.prefixsid import PrefixSid
 from exabgp.bgp.message.update.attribute.sr.labelindex import SrLabelIndex
+from exabgp.bgp.message.update.attribute.sr.ipv6sid import SrV6Sid
 from exabgp.bgp.message.update.attribute.sr.srgb import SrGb
 
 
@@ -113,3 +114,21 @@ def prefix_sid (tokeniser):
 		sr_attrs.append(SrGb(srgbs))
 
 	return PrefixSid(sr_attrs)
+
+# { ipv6 <ipv6-addr> }
+def prefix_sid_srv6 (tokeniser):
+	sr_attrs = []
+	value = tokeniser()
+	try:
+		if value == '(':
+			value = tokeniser()
+			if value == 'ipv6':
+				value = tokeniser()
+				sr_attrs.append(SrV6Sid(value))
+				value = tokeniser()
+				if value == ')':
+					return PrefixSid(sr_attrs)
+
+		raise Exception("format error")
+	except Exception as e:
+		raise ValueError('could not parse BGP PrefixSid Srv6 attribute: {}'.format(e))

--- a/lib/exabgp/configuration/static/mpls.py
+++ b/lib/exabgp/configuration/static/mpls.py
@@ -17,6 +17,7 @@ from exabgp.bgp.message.update.nlri.qualifier import RouteDistinguisher
 from exabgp.bgp.message.update.attribute.sr.prefixsid import PrefixSid
 from exabgp.bgp.message.update.attribute.sr.labelindex import SrLabelIndex
 from exabgp.bgp.message.update.attribute.sr.ipv6sid import SrV6Sid
+from exabgp.bgp.message.update.attribute.sr.srv6vpnsid import Srv6VpnSid
 from exabgp.bgp.message.update.attribute.sr.srgb import SrGb
 
 
@@ -115,7 +116,7 @@ def prefix_sid (tokeniser):
 
 	return PrefixSid(sr_attrs)
 
-# { ipv6 <ipv6-addr> }
+# { ipv6 <ipv6-addr> | vpn <ipv4-addr> }
 def prefix_sid_srv6 (tokeniser):
 	sr_attrs = []
 	value = tokeniser()
@@ -125,6 +126,13 @@ def prefix_sid_srv6 (tokeniser):
 			if value == 'ipv6':
 				value = tokeniser()
 				sr_attrs.append(SrV6Sid(value))
+				value = tokeniser()
+				if value == ')':
+					return PrefixSid(sr_attrs)
+
+			if value == 'vpn':
+				value = tokeniser()
+				sr_attrs.append(Srv6VpnSid(value))
 				value = tokeniser()
 				if value == ')':
 					return PrefixSid(sr_attrs)

--- a/lib/exabgp/configuration/static/route.py
+++ b/lib/exabgp/configuration/static/route.py
@@ -54,6 +54,7 @@ from exabgp.configuration.static.parser import withdraw
 from exabgp.configuration.static.mpls import route_distinguisher
 from exabgp.configuration.static.mpls import label
 from exabgp.configuration.static.mpls import prefix_sid
+from exabgp.configuration.static.mpls import prefix_sid_srv6
 
 
 # Take an integer an created it networked packed representation for the right family (ipv4/ipv6)
@@ -79,6 +80,7 @@ class ParseStaticRoute (Section):
 		'cluster-list <ipv4>',
 		'label <15 bits number>',
 		'bgp-prefix-sid [ 32 bits number> ] | [ <32 bits number>, [ ( <24 bits number>,<24 bits number> ) ]]',
+		'bgp-prefix-sid-srv6 ( ipv6 <ipv6 formated number> | l3vpn <ipv6 formated number> | vpn <ipv6 formated number> )',
 		'aggregator ( <asn16>:<ipv4> )',
 		'aigp <40 bits number>',
 		'attribute [ generic attribute format ]'
@@ -98,6 +100,7 @@ class ParseStaticRoute (Section):
 		'route-distinguisher': route_distinguisher,
 		'label':               label,
 		'bgp-prefix-sid':      prefix_sid,
+		'bgp-prefix-sid-srv6': prefix_sid_srv6,
 		'attribute':           attribute,
 		'next-hop':            next_hop,
 		'origin':              origin,
@@ -124,6 +127,7 @@ class ParseStaticRoute (Section):
 		'route-distinguisher': 'nlri-set',
 		'label':               'nlri-set',
 		'bgp-prefix-sid':      'attribute-add',
+		'bgp-prefix-sid-srv6': 'attribute-add',
 		'attribute':           'attribute-add',
 		'next-hop':            'nexthop-and-attribute',
 		'origin':              'attribute-add',


### PR DESCRIPTION
This commit makes exabgp to support additional sub-type of prefix-sid
path attributes for SRv6 VPNv4. following ietf-drafts define about it.

prefix-sid type-4 is defined as generic srv6-vpn-sid, that is used by
Cisco IOS-XR's VPNv4 with SRv6 backend. prefix-sid type-5 is
defined as srv6-L3-vpn-sid that is used by Cisco NX-OS's VPNv4 with
SRv6 backend.

Also type-4 is already deprecated but this values is used some production
network fields (i.e. softbank mobile backend), so supporting type-4 is
really important.  In current IETF status, type-5 is preferred and IOS-XR
seems to support type-5 for VPNv4 with SRv6 backend.

- https://tools.ietf.org/html/draft-dawra-idr-srv6-vpn-04
- https://tools.ietf.org/html/draft-dawra-idr-srv6-vpn-05

Signed-off-by: Hiroki Shirokura <slank.dev@gmail.com>