### PR TITLE
Fix to allow for multiple TE-RIDs in BGP-LS node attribute

### DIFF
--- a/lib/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
@@ -59,6 +59,9 @@ class LINKSTATE(Attribute):
 			klass.TLV = scode
 			ls_attrs.append(klass)
 			data = data[length+4:]
+		for klass in ls_attrs:
+			if hasattr(klass, 'terids'):
+				klass.reset()
 
 		return cls(ls_attrs=ls_attrs)
 

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/node/lterid.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/node/lterid.py
@@ -22,12 +22,13 @@ from exabgp.bgp.message.update.attribute.bgpls.linkstate import LINKSTATE
 @LINKSTATE.register(lsid=1028)
 @LINKSTATE.register(lsid=1029)
 class LocalTeRid(object):
+	_terids = []
 
-	def __init__ (self, terid):
-		self.terid = terid
+	def __init__ (self):
+		self.terids = [str(terid) for terid in LocalTeRid._terids]
 
 	def __repr__ (self):
-		return "Local TE Router ID: %s" % (self.terid)
+		return "Local TE Router IDs: %s" % ', '.join(self.terids)
 
 	@classmethod
 	def unpack (cls,data,length):
@@ -37,7 +38,12 @@ class LocalTeRid(object):
 		elif len(data) == 16:
 			# IPv6
 			terid = IP.unpack(data[:16])
-		return cls(terid=terid)
+		cls._terids.append(terid)
+		return cls()
 
 	def json (self,compact=None):
-		return '"local-te-router-id": "%s"' % str(self.terid)
+		return '"local-te-router-ids": ["%s"]' % '", "'.join(self.terids)
+
+	@classmethod
+	def reset(cls):
+	    cls._terids = []


### PR DESCRIPTION
```
00:41:36 | 12383  | welcome       | Thank you for using ExaBGP
00:41:36 | 12383  | version       | fix-640b05aabdb14707f945415d4f1405993401446f
00:41:36 | 12383  | interpreter   | 3.5.2 (default, Oct  8 2019, 13:06:37)  [GCC 5.4.0 20160609]
00:41:36 | 12383  | os            | Linux ubuntu 4.4.0-174-generic #204-Ubuntu SMP Wed Jan 29 06:41:01 UTC 2020 x86_64
00:41:36 | 12383  | installation  | /home/tom/EXA/exabgp
00:41:36 | 12383  | cli control   | named pipes for the cli are:
00:41:36 | 12383  | cli control   | to send commands  /home/tom/EXA/exabgp/run/exabgp.in
00:41:36 | 12383  | cli control   | to read responses /home/tom/EXA/exabgp/run/exabgp.out
00:41:36 | 12383  | configuration | performing reload of exabgp fix-640b05aabdb14707f945415d4f1405993401446f
00:41:36 | 12383  | configuration | > process          | 'ted-receive'
00:41:36 | 12383  | configuration | . run              | 'python3' '/home/tom/EXA/ted_receive.py'
00:41:36 | 12383  | configuration | . encoder          | 'json'
00:41:36 | 12383  | configuration | < process          |
00:41:36 | 12383  | configuration | > neighbor         | '192.168.116.201'
00:41:36 | 12383  | configuration | . local-address    | '192.168.116.137'
00:41:36 | 12383  | configuration | . local-as         | '65000'
00:41:36 | 12383  | configuration | . peer-as          | '65000'
00:41:36 | 12383  | configuration | > family           |
00:41:36 | 12383  | configuration | . bgp-ls           | 'bgp-ls'
00:41:36 | 12383  | configuration | < family           |
00:41:36 | 12383  | configuration | > api              | 'receive'
00:41:36 | 12383  | configuration | . processes        | '[' 'ted-receive' ']'
00:41:36 | 12383  | configuration | > receive          |
00:41:36 | 12383  | configuration | . parsed           |
00:41:36 | 12383  | configuration | . update           |
00:41:36 | 12383  | configuration | < receive          |
00:41:36 | 12383  | configuration | < api              |
00:41:36 | 12383  | configuration | < neighbor         |
00:41:36 | 12383  | reactor       | new peer: neighbor 192.168.116.201 local-ip 192.168.116.137 local-as 65000 peer-as 65000 router-id 192.168.116.137 family-allowed in-open
00:41:36 | 12383  | reactor       | loaded new configuration successfully
00:41:36 | 12383  | process       | forked process api-internal-cli-11aaa606
00:41:36 | 12383  | process       | forked process ted-receive
00:41:36 | 12383  | reactor       | initialising connection to peer-1
00:41:36 | 12383  | outgoing-1    | attempting connection to 192.168.116.201:179
00:41:37 | 12383  | outgoing-1    | sending TCP payload (  49) FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF 0031 0104 FDE8 00B4 C0A8 7489 1402 0601 0440 0400 4702 0206 0002 0641 0400 00FD E8
00:41:37 | 12383  | outgoing-1    | >> OPEN version=4 asn=65000 hold_time=180 router_id=192.168.116.137 capabilities=[Multiprotocol(bgp-ls bgp-ls), Extended Message(65535), ASN4(65000)]
00:41:37 | 12383  | ka-outgoing-1 | receive-timer 60 second(s) left
00:41:37 | 12383  | outgoing-1    | received TCP payload (  19) FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF 003F 01
00:41:37 | 12383  | outgoing-1    | received TCP payload (  44) 04FD E800 5A01 0101 0122 0206 0104 4004 0047 0202 8000 0202 0200 0204 4002 4078 0206 4104 0000 FDE8 0202 4700
00:41:37 | 12383  | outgoing-1    | << message of type OPEN
00:41:37 | 12383  | outgoing-1    | << OPEN version=4 asn=65000 hold_time=90 router_id=1.1.1.1 capabilities=[Multiprotocol(bgp-ls bgp-ls), Route Refresh, Graceful Restart Flags 0x4 Time 120 , ASN4(65000), Unassigned 71, Route Refresh]
00:41:37 | 12383  | outgoing-1    | sending TCP payload (  19) FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF 0013 04
00:41:37 | 12383  | outgoing-1    | >> KEEPALIVE (OPENCONFIRM)
00:41:37 | 12383  | ka-outgoing-1 | receive-timer 90 second(s) left
00:41:37 | 12383  | ka-outgoing-1 | receive-timer 89 second(s) left
00:41:38 | 12383  | ka-outgoing-1 | receive-timer 88 second(s) left
00:41:39 | 12383  | outgoing-1    | received TCP payload (  19) FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF 0013 04
00:41:39 | 12383  | outgoing-1    | << message of type KEEPALIVE
00:41:39 | 12383  | reactor       | connected to peer-1 with outgoing-1 192.168.116.137-192.168.116.201
00:41:39 | 12383  | outgoing-1    | received TCP payload (  19) FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF 0070 02
00:41:39 | 12383  | outgoing-1    | received TCP payload (  93) 0000 0059 4001 0100 4002 0040 0504 0000 0064 801D 2004 0000 0100 0402 0002 5232 0403 0001 4904 0400 0402 0202 0204 0400 0416 1616 1690 0E00 2440 0447 04C0 A874 C900 0001 0017 0200 0000 0000 0000 0001 0000 0A02 0300 0600 0100 0000 02
00:41:39 | 12383  | outgoing-1    | << message of type UPDATE
00:41:39 | 12383  | parser        | parsing UPDATE (  93) 0000 0059 4001 0100 4002 0040 0504 0000 0064 801D 2004 0000 0100 0402 0002 5232 0403 0001 4904 0400 0402 0202 0204 0400 0416 1616 1690 0E00 2440 0447 04C0 A874 C900 0001 0017 0200 0000 0000 0000 0001 0000 0A02 0300 0600 0100 0000 02
00:41:39 | 12383  | routes        | withdrawn NLRI none
00:41:39 | 12383  | parser        | attribute origin             flag 0x40 type 0x01 len 0x01 payload 00
00:41:39 | 12383  | parser        | attribute as-path            flag 0x40 type 0x02 len 0x00
00:41:39 | 12383  | parser        | attribute local-preference   flag 0x40 type 0x05 len 0x04 payload 0000 0064
00:41:39 | 12383  | parser        | attribute bgp-ls             flag 0x80 type 0x1d len 0x20 payload 0400 0001 0004 0200 0252 3204 0300 0149 0404 0004 0202 0202 0404 0004 1616 1616
00:41:39 | 12383  | parser        | attribute mp-reach-nlri      flag 0x90 type 0x0e len 0x24 payload 4004 4704 C0A8 74C9 0000 0100 1702 0000 0000 0000 0000 0100 000A 0203 0006 0001 0000 0002
00:41:39 | 12383  | parser        | NLRI      bgp-ls bgp-ls      without path-information     payload 0001 0017 0200 0000 0000 0000 0001 0000 0A02 0300 0600 0100 0000 02
00:41:39 | 12383  | routes        | announced NLRI none
00:41:39 | 12383  | peer-1        | << UPDATE #1
00:41:39 | 12383  | peer-1        |    UPDATE #1 nlri  (   2) { "ls-nlri-type": "bgpls-node", "l3-routing-topology": 0, "protocol-id": 2, "node-descriptors": { "router-id": "000100000002" }, "nexthop": "192.168.116.201" }
00:41:39 | 12383  | outgoing-1    | sending TCP payload (  30) FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF 001E 0200 0000 0790 0F00 0340 0447
00:41:39 | 12383  | outgoing-1    | >> EOR bgp-ls bgp-ls
00:41:39 | 12383  | peer-1        | >> EOR(s)
00:41:39 | 12383  | outgoing-1    | received TCP payload (  19) FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF 0072 02
00:41:39 | 12383  | outgoing-1    | received TCP payload (  95) 0000 005B 4001 0100 4002 0040 0504 0000 0064 801D 2204 0000 0100 0402 0002 5231 0403 0003 4900 0104 0400 0401 0101 0104 0400 040B 0B0B 0B90 0E00 2440 0447 04C0 A874 C900 0001 0017 0200 0000 0000 0000 0001 0000 0A02 0300 0600 0100 0000 01
00:41:39 | 12383  | outgoing-1    | << message of type UPDATE
00:41:39 | 12383  | parser        | parsing UPDATE (  95) 0000 005B 4001 0100 4002 0040 0504 0000 0064 801D 2204 0000 0100 0402 0002 5231 0403 0003 4900 0104 0400 0401 0101 0104 0400 040B 0B0B 0B90 0E00 2440 0447 04C0 A874 C900 0001 0017 0200 0000 0000 0000 0001 0000 0A02 0300 0600 0100 0000 01
{'counter': 1,
 'exabgp': '4.0.1',
 'host': 'ubuntu',
 'neighbor': {'address': {'local': '192.168.116.137',
                          'peer': '192.168.116.201'},
              'asn': {'local': 65000, 'peer': 65000},
              'direction': 'receive',
              'message': {'update': {'announce': {'bgp-ls bgp-ls': {'192.168.116.201': [{'l3-routing-topology': 0,
                                                                                         'ls-nlri-type': 'bgpls-node',
                                                                                         'nexthop': '192.168.116.201',
                                                                                         'node-descriptors': {'router-id': '000100000002'},
                                                                                         'protocol-id': 2}]}},
                                     'attribute': {'bgp-ls': {'area-id': '49',
                                                              'local-te-router-ids': ['2.2.2.2',
                                                                                      '22.22.22.22'],
                                                              'node-flags': {'B': 0,
                                                                             'E': 0,
                                                                             'O': 0,
                                                                             'R': 0,
                                                                             'RSV': 0,
                                                                             'T': 0,
                                                                             'V': 0},
                                                              'node-name': 'R2'},
                                                   'local-preference': 100,
                                                   'origin': 'igp'}}}},
 'pid': 12383,
 'ppid': 2727,
 'time': 1583368899.0811808,
 'type': 'update'}
00:41:39 | 12383  | routes        | withdrawn NLRI none
00:41:39 | 12383  | parser        | attribute origin             flag 0x40 type 0x01 len 0x01 payload 00
00:41:39 | 12383  | parser        | attribute as-path            flag 0x40 type 0x02 len 0x00
00:41:39 | 12383  | parser        | attribute local-preference   flag 0x40 type 0x05 len 0x04 payload 0000 0064
00:41:39 | 12383  | parser        | attribute bgp-ls             flag 0x80 type 0x1d len 0x22 payload 0400 0001 0004 0200 0252 3104 0300 0349 0001 0404 0004 0101 0101 0404 0004 0B0B 0B0B
00:41:39 | 12383  | parser        | attribute mp-reach-nlri      flag 0x90 type 0x0e len 0x24 payload 4004 4704 C0A8 74C9 0000 0100 1702 0000 0000 0000 0000 0100 000A 0203 0006 0001 0000 0001
00:41:39 | 12383  | parser        | NLRI      bgp-ls bgp-ls      without path-information     payload 0001 0017 0200 0000 0000 0000 0001 0000 0A02 0300 0600 0100 0000 01
00:41:39 | 12383  | routes        | announced NLRI none
00:41:39 | 12383  | peer-1        | << UPDATE #2
00:41:39 | 12383  | peer-1        |    UPDATE #2 nlri  (   2) { "ls-nlri-type": "bgpls-node", "l3-routing-topology": 0, "protocol-id": 2, "node-descriptors": { "router-id": "000100000001" }, "nexthop": "192.168.116.201" }
00:41:39 | 12383  | outgoing-1    | received TCP payload (  19) FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF 00B9 02
00:41:39 | 12383  | outgoing-1    | received TCP payload ( 166) 0000 00A2 4001 0100 4002 0040 0504 0000 0064 801D 4B04 4000 0400 0000 0004 4100 044C EE6B 2804 4200 044C EE6B 2804 4300 204C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 2804 4400 0400 0000 1404 4700 0300 000A 900E 0042 4004 4704 C0A8 74C9 0000 0200 3502 0000 0000 0000 0000 0100 000A 0203 0006 0001 0000 0001 0101 000A 0203 0006 0001 0000 0002 0103 0004 0A00 0000 0104 0004 0A00 0001
00:41:39 | 12383  | outgoing-1    | << message of type UPDATE
00:41:39 | 12383  | parser        | parsing UPDATE ( 166) 0000 00A2 4001 0100 4002 0040 0504 0000 0064 801D 4B04 4000 0400 0000 0004 4100 044C EE6B 2804 4200 044C EE6B 2804 4300 204C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 2804 4400 0400 0000 1404 4700 0300 000A 900E 0042 4004 4704 C0A8 74C9 0000 0200 3502 0000 0000 0000 0000 0100 000A 0203 0006 0001 0000 0001 0101 000A 0203 0006 0001 0000 0002 0103 0004 0A00 0000 0104 0004 0A00 0001
00:41:39 | 12383  | routes        | withdrawn NLRI none
00:41:39 | 12383  | parser        | attribute origin             flag 0x40 type 0x01 len 0x01 payload 00
{'counter': 2,
 'exabgp': '4.0.1',
 'host': 'ubuntu',
 'neighbor': {'address': {'local': '192.168.116.137',
                          'peer': '192.168.116.201'},
              'asn': {'local': 65000, 'peer': 65000},
              'direction': 'receive',
              'message': {'update': {'announce': {'bgp-ls bgp-ls': {'192.168.116.201': [{'l3-routing-topology': 0,
                                                                                         'ls-nlri-type': 'bgpls-node',
                                                                                         'nexthop': '192.168.116.201',
                                                                                         'node-descriptors': {'router-id': '000100000001'},
                                                                                         'protocol-id': 2}]}},
                                     'attribute': {'bgp-ls': {'area-id': '490001',
                                                              'local-te-router-ids': ['1.1.1.1',
                                                                                      '11.11.11.11'],
                                                              'node-flags': {'B': 0,
                                                                             'E': 0,
                                                                             'O': 0,
                                                                             'R': 0,
                                                                             'RSV': 0,
                                                                             'T': 0,
                                                                             'V': 0},
                                                              'node-name': 'R1'},
                                                   'local-preference': 100,
                                                   'origin': 'igp'}}}},
 'pid': 12383,
 'ppid': 2727,
 'time': 1583368899.088285,
 'type': 'update'}
00:41:39 | 12383  | parser        | attribute as-path            flag 0x40 type 0x02 len 0x00
00:41:39 | 12383  | parser        | attribute local-preference   flag 0x40 type 0x05 len 0x04 payload 0000 0064
00:41:39 | 12383  | parser        | attribute bgp-ls             flag 0x80 type 0x1d len 0x4b payload 0440 0004 0000 0000 0441 0004 4CEE 6B28 0442 0004 4CEE 6B28 0443 0020 4CEE 6B28 4CEE 6B28 4CEE 6B28 4CEE 6B28 4CEE 6B28 4CEE 6B28 4CEE 6B28 4CEE 6B28 0444 0004 0000 0014 0447 0003 0000 0A
00:41:39 | 12383  | parser        | attribute mp-reach-nlri      flag 0x90 type 0x0e len 0x42 payload 4004 4704 C0A8 74C9 0000 0200 3502 0000 0000 0000 0000 0100 000A 0203 0006 0001 0000 0001 0101 000A 0203 0006 0001 0000 0002 0103 0004 0A00 0000 0104 0004 0A00 0001
00:41:39 | 12383  | parser        | NLRI      bgp-ls bgp-ls      without path-information     payload 0002 0035 0200 0000 0000 0000 0001 0000 0A02 0300 0600 0100 0000 0101 0100 0A02 0300 0600 0100 0000 0201 0300 040A 0000 0001 0400 040A 0000 01
00:41:39 | 12383  | routes        | announced NLRI none
00:41:39 | 12383  | peer-1        | << UPDATE #3
00:41:39 | 12383  | peer-1        |    UPDATE #3 nlri  (   2) { "ls-nlri-type": "bgpls-link", "l3-routing-topology": 0, "protocol-id": 2, "local-node-descriptors": { "router-id": "000100000001" }, "remote-node-descriptors": { "router-id": "000100000002" }, "interface-address": { "interface-address": "10.0.0.0" }, "neighbor-address": { "neighbor-address": "10.0.0.1" } }
00:41:39 | 12383  | outgoing-1    | received TCP payload (  19) FFFF FFFF FFFF FFFF FFFF FFFF FFFF FFFF 00B9 02
00:41:39 | 12383  | outgoing-1    | received TCP payload ( 166) 0000 00A2 4001 0100 4002 0040 0504 0000 0064 801D 4B04 4000 0400 0000 0004 4100 044C EE6B 2804 4200 044C EE6B 2804 4300 204C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 2804 4400 0400 0000 0A04 4700 0300 000A 900E 0042 4004 4704 C0A8 74C9 0000 0200 3502 0000 0000 0000 0000 0100 000A 0203 0006 0001 0000 0002 0101 000A 0203 0006 0001 0000 0001 0103 0004 0A00 0001 0104 0004 0A00 0000
00:41:39 | 12383  | outgoing-1    | << message of type UPDATE
00:41:39 | 12383  | parser        | parsing UPDATE ( 166) 0000 00A2 4001 0100 4002 0040 0504 0000 0064 801D 4B04 4000 0400 0000 0004 4100 044C EE6B 2804 4200 044C EE6B 2804 4300 204C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 284C EE6B 2804 4400 0400 0000 0A04 4700 0300 000A 900E 0042 4004 4704 C0A8 74C9 0000 0200 3502 0000 0000 0000 0000 0100 000A 0203 0006 0001 0000 0002 0101 000A 0203 0006 0001 0000 0001 0103 0004 0A00 0001 0104 0004 0A00 0000
{'counter': 3,
 'exabgp': '4.0.1',
 'host': 'ubuntu',
 'neighbor': {'address': {'local': '192.168.116.137',
                          'peer': '192.168.116.201'},
              'asn': {'local': 65000, 'peer': 65000},
              'direction': 'receive',
              'message': {'update': {'announce': {'bgp-ls bgp-ls': {'192.168.116.201': [{'interface-address': {'interface-address': '10.0.0.0'},
                                                                                         'l3-routing-topology': 0,
                                                                                         'local-node-descriptors': {'router-id': '000100000001'},
                                                                                         'ls-nlri-type': 'bgpls-link',
                                                                                         'neighbor-address': {'neighbor-address': '10.0.0.1'},
                                                                                         'protocol-id': 2,
                                                                                         'remote-node-descriptors': {'router-id': '000100000002'}}]}},
                                     'attribute': {'bgp-ls': {'admin-group-mask': [0],
                                                              'igp-metric': 10,
                                                              'maximum-link-bandwidth': 125000000.0,
                                                              'maximum-reservable-link-bandwidth': 125000000.0,
                                                              'te-metric': 20,
                                                              'unreserved-bandwidth': [125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0]},
                                                   'local-preference': 100,
                                                   'origin': 'igp'}}}},
 'pid': 12383,
 'ppid': 2727,
 'time': 1583368899.0947993,
 'type': 'update'}
00:41:39 | 12383  | routes        | withdrawn NLRI none
00:41:39 | 12383  | parser        | attribute origin             flag 0x40 type 0x01 len 0x01 payload 00
00:41:39 | 12383  | parser        | attribute as-path            flag 0x40 type 0x02 len 0x00
00:41:39 | 12383  | parser        | attribute local-preference   flag 0x40 type 0x05 len 0x04 payload 0000 0064
00:41:39 | 12383  | parser        | attribute bgp-ls             flag 0x80 type 0x1d len 0x4b payload 0440 0004 0000 0000 0441 0004 4CEE 6B28 0442 0004 4CEE 6B28 0443 0020 4CEE 6B28 4CEE 6B28 4CEE 6B28 4CEE 6B28 4CEE 6B28 4CEE 6B28 4CEE 6B28 4CEE 6B28 0444 0004 0000 000A 0447 0003 0000 0A
00:41:39 | 12383  | parser        | attribute mp-reach-nlri      flag 0x90 type 0x0e len 0x42 payload 4004 4704 C0A8 74C9 0000 0200 3502 0000 0000 0000 0000 0100 000A 0203 0006 0001 0000 0002 0101 000A 0203 0006 0001 0000 0001 0103 0004 0A00 0001 0104 0004 0A00 0000
00:41:39 | 12383  | parser        | NLRI      bgp-ls bgp-ls      without path-information     payload 0002 0035 0200 0000 0000 0000 0001 0000 0A02 0300 0600 0100 0000 0201 0100 0A02 0300 0600 0100 0000 0101 0300 040A 0000 0101 0400 040A 0000 00
00:41:39 | 12383  | routes        | announced NLRI none
00:41:39 | 12383  | peer-1        | << UPDATE #4
00:41:39 | 12383  | peer-1        |    UPDATE #4 nlri  (   2) { "ls-nlri-type": "bgpls-link", "l3-routing-topology": 0, "protocol-id": 2, "local-node-descriptors": { "router-id": "000100000002" }, "remote-node-descriptors": { "router-id": "000100000001" }, "interface-address": { "interface-address": "10.0.0.1" }, "neighbor-address": { "neighbor-address": "10.0.0.0" } }
{'counter': 4,
 'exabgp': '4.0.1',
 'host': 'ubuntu',
 'neighbor': {'address': {'local': '192.168.116.137',
                          'peer': '192.168.116.201'},
              'asn': {'local': 65000, 'peer': 65000},
              'direction': 'receive',
              'message': {'update': {'announce': {'bgp-ls bgp-ls': {'192.168.116.201': [{'interface-address': {'interface-address': '10.0.0.1'},
                                                                                         'l3-routing-topology': 0,
                                                                                         'local-node-descriptors': {'router-id': '000100000002'},
                                                                                         'ls-nlri-type': 'bgpls-link',
                                                                                         'neighbor-address': {'neighbor-address': '10.0.0.0'},
                                                                                         'protocol-id': 2,
                                                                                         'remote-node-descriptors': {'router-id': '000100000001'}}]}},
                                     'attribute': {'bgp-ls': {'admin-group-mask': [0],
                                                              'igp-metric': 10,
                                                              'maximum-link-bandwidth': 125000000.0,
                                                              'maximum-reservable-link-bandwidth': 125000000.0,
                                                              'te-metric': 10,
                                                              'unreserved-bandwidth': [125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0]},
                                                   'local-preference': 100,
                                                   'origin': 'igp'}}}},
 'pid': 12383,
 'ppid': 2727,
 'time': 1583368899.100931,
 'type': 'update'}
```