### PR TITLE
add support for multiple bgp-ls adj sids

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Version 4.3.0:
    reported by: thomas955
  * Fix: high CPU load to do sleeptime in second and not ms
    reported by: Gary Buhrmaster
+ * Fix: support for more than one BGP-LS Adjacency SID per link(requires reformat of output data structure)
+   patch: tomjshine
  * Change: BGP-LS TE-RIDs are now reported as a list (as Arista reports more than one)
    patch: tomjshine
  * reported: the RIB code so withdraw message before any announce are sent

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/link/sradj.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/link/sradj.py
@@ -29,20 +29,18 @@ from exabgp.bgp.message.update.attribute.bgpls.linkstate import LINKSTATE, LsGen
 @LINKSTATE.register()
 class SrAdjacency(object):
 	TLV = 1099
+	_sr_adj_sids = []
 
-	def __init__ (self, flags, sids, weight, undecoded=[]):
-		self.flags = flags
-		self.sids = sids
-		self.weight = weight
-		self.undecoded = undecoded
+	def __init__ (self):
+		self.sr_adj_sids = SrAdjacency._sr_adj_sids.copy()
 
 	def __repr__ (self):
-		return "adj_flags: %s, sids: %s, undecoded_sid" % (self.flags, self.sids, self.undecoded)
+		return "sr-adj-sids: {}".format(self.sr_adj_sids)
 
 	@classmethod
 	def unpack (cls,data,length):
 		# We only support IS-IS flags for now.
-		flags = LsGenericFlags.unpack(data[0:1],LsGenericFlags.ISIS_SR_ADJ_FLAGS)
+		flags = LsGenericFlags.unpack(data[0:1],LsGenericFlags.ISIS_SR_ADJ_FLAGS).flags
 		# Parse adj weight
 		weight = six.indexbytes(data,1)
 		# Move pointer 4 bytes: Flags(1) + Weight(1) + Reserved(2)
@@ -56,29 +54,26 @@ class SrAdjacency(object):
 		# *  A 4 octet index defining the offset in the SID/Label space
 		# 	 advertised by this router using the encodings defined in
 		#  	 Section 3.1.  In this case V and L flags MUST be unset.
-		sids = []
 		raw = []
 		while data:
 			# Range Size: 3 octet value indicating the number of labels in
 			# the range.
-			if int(flags.flags['V']) and int(flags.flags['L']):
+			if int(flags['V']) and int(flags['L']):
 				b = BitArray(bytes=data[:3])
-				sid = b.unpack('uintbe:24')[0:1]
+				sid = b.unpack('uintbe:24')[0]
 				data = data[3:]
-				sids.append(sid)
-			elif (not flags.flags['V']) and \
-				(not flags.flags['L']):
-				sid = unpack('!I',data[:4])[0:1]
+			elif (not flags['V']) and (not flags['L']):
+				sid = unpack('!I',data[:4])[0]
 				data = data[4:]
-				sids.append(sid)
 			else:
 				raw.append(hexstring(data))
 				break
-
-		return cls(flags=flags, sids=sids, weight=weight,undecoded=raw)
+		cls._sr_adj_sids.append({'flags': flags, 'weight': weight, 'sid': sid, 'undecoded': raw})
+		return cls()
 
 	def json (self,compact=None):
-		return ', '.join(['"sr-adj-flags": {}'.format(self.flags.json()),
-			'"sids": {}'.format(json.dumps(self.sids)),
-			'"undecoded-sids": {}'.format(json.dumps(self.undecoded)),
-			'"sr-adj-weight": {}'.format(json.dumps(self.weight))])
+		return '"sr-adj-sids": {}'.format(json.dumps(self.sr_adj_sids))
+
+	@classmethod
+	def reset(cls):
+		cls._sr_adj_sids = []

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
@@ -62,7 +62,7 @@ class LINKSTATE(Attribute):
 		# Remove all but last instance of each TLV class - the last holds state for all TLVs of that type
 		ls_attrs = list({ls_attr.TLV: ls_attr for ls_attr in ls_attrs}.values())
 		for klass in ls_attrs:
-			if hasattr(klass, 'terids') or hasattr(klass, 'sr_adj_sids') or hasattr(klass, 'sr_adj_lan_sids'):
+			if hasattr(klass, 'reset'):
 				klass.reset()
 
 		return cls(ls_attrs=ls_attrs)

--- a/lib/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
+++ b/lib/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
@@ -59,8 +59,10 @@ class LINKSTATE(Attribute):
 			klass.TLV = scode
 			ls_attrs.append(klass)
 			data = data[length+4:]
+		# Remove all but last instance of each TLV class - the last holds state for all TLVs of that type
+		ls_attrs = list({ls_attr.TLV: ls_attr for ls_attr in ls_attrs}.values())
 		for klass in ls_attrs:
-			if hasattr(klass, 'terids'):
+			if hasattr(klass, 'terids') or hasattr(klass, 'sr_adj_sids') or hasattr(klass, 'sr_adj_lan_sids'):
 				klass.reset()
 
 		return cls(ls_attrs=ls_attrs)


### PR DESCRIPTION
```
{'counter': 4,
 'exabgp': '4.0.1',
 'host': 'ubuntu',
 'neighbor': {'address': {'local': '192.168.116.137',
                          'peer': '192.168.116.201'},
              'asn': {'local': 65000, 'peer': 65000},
              'direction': 'receive',
              'message': {'update': {'announce': {'bgp-ls bgp-ls': {'192.168.116.201': [{'interface-address': {'interface-address': '10.0.0.0'},
                                                                                         'l3-routing-topology': 0,
                                                                                         'local-node-descriptors': {'router-id': '000100000001'},
                                                                                         'ls-nlri-type': 'bgpls-link',
                                                                                         'neighbor-address': {'neighbor-address': '10.0.0.1'},
                                                                                         'protocol-id': 2,
                                                                                         'remote-node-descriptors': {'router-id': '000100000002'}}]}},
                                     'attribute': {'bgp-ls': {'admin-group-mask': [0],
                                                              'igp-metric': 10,
                                                              'maximum-link-bandwidth': 125000000.0,
                                                              'maximum-reservable-link-bandwidth': 125000000.0,
                                                              'sr-adj-sids': [{'flags': {'B': 0,
                                                                                         'F': 0,
                                                                                         'L': 1,
                                                                                         'P': 0,
                                                                                         'RSV': 0,
                                                                                         'S': 0,
                                                                                         'V': 1},
                                                                               'sid': 299936,
                                                                               'undecoded': [],
                                                                               'weight': 0},
                                                                              {'flags': {'B': 1,
                                                                                         'F': 0,
                                                                                         'L': 1,
                                                                                         'P': 0,
                                                                                         'RSV': 0,
                                                                                         'S': 0,
                                                                                         'V': 1},
                                                                               'sid': 299920,
                                                                               'undecoded': [],
                                                                               'weight': 0}],
                                                              'te-metric': 20,
                                                              'unreserved-bandwidth': [125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0,
                                                                                       125000000.0]},
                                                   'local-preference': 100,
                                                   'origin': 'igp'}}}},
 'pid': 18519,
 'ppid': 10181,
 'time': 1585008309.3309605,
 'type': 'update'}
```