### PR TITLE
Improve systemd unit configs

### DIFF
--- a/etc/systemd/exabgp.service
+++ b/etc/systemd/exabgp.service
@@ -7,16 +7,16 @@ After=network.target
 ConditionPathExists=/etc/exabgp/exabgp.conf
 
 [Service]
-#User=exabgp
-#Group=exabgp
+User=exabgp
+Group=exabgp
 Environment=exabgp_daemon_daemonize=false
 PermissionsStartOnly=true
-ExecStartPre=-mkfifo /run/exabgp.in
-ExecStartPre=-mkfifo /run/exabgp.out
-ExecStartPre=chmod 600 /run/exabgp.in
-ExecStartPre=chmod 600 /run/exabgp.out
-ExecStartPre=chown exabgp.exabgp /run/exabgp.in
-ExecStartPre=chown exabgp.exabgp /run/exabgp.out
+ExecStartPre=-/usr/bin/env mkfifo /run/exabgp.in
+ExecStartPre=-/usr/bin/env mkfifo /run/exabgp.out
+ExecStartPre=/usr/bin/env chmod 600 /run/exabgp.in
+ExecStartPre=/usr/bin/env chmod 600 /run/exabgp.out
+ExecStartPre=/usr/bin/env chown exabgp.exabgp /run/exabgp.in
+ExecStartPre=/usr/bin/env chown exabgp.exabgp /run/exabgp.out
 ExecStart=/usr/sbin/exabgp /etc/exabgp/exabgp.conf
 ExecReload=/bin/kill -USR1 $MAINPID
 Restart=always

--- a/etc/systemd/exabgp@.service
+++ b/etc/systemd/exabgp@.service
@@ -7,16 +7,16 @@ After=network.target
 ConditionPathExists=/etc/exabgp/exabgp-%i.conf
 
 [Service]
-#User=exabgp
-#Group=exabgp
+User=exabgp
+Group=exabgp
 Environment=exabgp_daemon_daemonize=false
 PermissionsStartOnly=true
-ExecStartPre=-mkfifo /run/exabgp.in
-ExecStartPre=-mkfifo /run/exabgp.out
-ExecStartPre=chmod 600 /run/exabgp.in
-ExecStartPre=chmod 600 /run/exabgp.out
-ExecStartPre=chown exabgp.exabgp /run/exabgp.in
-ExecStartPre=chown exabgp.exabgp /run/exabgp.out
+ExecStartPre=-/usr/bin/env mkfifo /run/exabgp.in
+ExecStartPre=-/usr/bin/env mkfifo /run/exabgp.out
+ExecStartPre=/usr/bin/env chmod 600 /run/exabgp.in
+ExecStartPre=/usr/bin/env chmod 600 /run/exabgp.out
+ExecStartPre=/usr/bin/env chown exabgp.exabgp /run/exabgp.in
+ExecStartPre=/usr/bin/env chown exabgp.exabgp /run/exabgp.out
 ExecStart=/usr/sbin/exabgp /etc/exabgp/exabgp.conf
 ExecReload=/bin/kill -USR1 $MAINPID
 Restart=always


### PR DESCRIPTION
There are two changes here:

* set user and group to 'exabgp'. Without this I can't use
  'exabgpcli'. For example, without this 'sudo exabgpcli version'
  fails with "could not send command to ExaBGP (command timeout)".

* use absolute paths in the 'ExecStartPre' commands. This doesn't seem
  to matter on Debian 10, but on Ubuntu 18.04 the non-absolute-path
  versions cause an error.

Note that if you're testing these changes by editing
/lib/systemd/system/exabgp.service, you need to run

    systemctl daemon-reload

before

    systemcl restart exabgp

for the changes to take effect.