### PR TITLE
Fix crash when daemonizing and Python 3.8

### DIFF
--- a/lib/exabgp/reactor/daemon.py
+++ b/lib/exabgp/reactor/daemon.py
@@ -153,7 +153,7 @@ class Daemon(object):
     def _is_socket(fd):
         try:
             s = socket.fromfd(fd, socket.AF_INET, socket.SOCK_RAW)
-        except ValueError:
+        except (ValueError, OSError):
             # The file descriptor is closed
             return False
         try:


### PR DESCRIPTION
With Python 3.8, I am getting the following exception when asking
ExaBGP to daemonize while not supervised:

      File "/usr/lib/python3/dist-packages/exabgp/reactor/daemon.py", line 188, in daemonise
        if self._is_socket(sys.__stdin__.fileno()) or os.getppid() == 1:
      File "/usr/lib/python3/dist-packages/exabgp/reactor/daemon.py", line 158, in _is_socket
        s = socket.fromfd(fd, socket.AF_INET, socket.SOCK_RAW)
      File "/usr/lib/python3.8/socket.py", line 544, in fromfd
        return socket(family, type, proto, nfd)
      File "/usr/lib/python3.8/socket.py", line 231, in __init__
        _socket.socket.__init__(self, family, type, proto, fileno)
    OSError: [Errno 88] Socket operation on non-socket

Therefore, add `OSError` as a possible exception we can get if we
don't have a socket as stdin.