### PR TITLE
Minor text changes

### DIFF
--- a/lib/exabgp/configuration/usage.py
+++ b/lib/exabgp/configuration/usage.py
@@ -26,7 +26,7 @@ positional arguments:
   configuration         peer and route configuration file
 
 optional arguments:
-  --help, -h            exabgp manual page
+  --help, -h            ExaBGP manual page
   --version, -v         shows ExaBGP version
   --root ROOT, -f ROOT
                         root folder where etc,bin,sbin are located

--- a/lib/exabgp/environment/setup.py
+++ b/lib/exabgp/environment/setup.py
@@ -216,7 +216,7 @@ CONFIGURATION = {
             'read': parsing.integer,
             'write': parsing.nop,
             'value': '60',
-            'help': 'how many second we wait for an open once the TCP session is established',
+            'help': 'how many seconds we wait for an open once the TCP session is established',
         },
     },
     'cache': {


### PR DESCRIPTION
- Grammar on openwait environment
- Change exabgp to ExaBGP in usage help for consistency with the line below
