### PR TITLE
daemon: fix socket validation traceback on startup

### DIFF
--- a/lib/exabgp/reactor/daemon.py
+++ b/lib/exabgp/reactor/daemon.py
@@ -159,6 +159,9 @@ class Daemon(object):
         except ValueError:
             # The file descriptor is closed
             return False
+        except OSError:
+            # Not a socket.
+            return False
         try:
             s.getsockopt(socket.SOL_SOCKET, socket.SO_TYPE)
         except socket.error as exc:


### PR DESCRIPTION
Problem found on Ubuntu 20.04 on both packaged ExaBGP and newest version installed with `pip`. To reproduce it just run with the following command line:

```sh
env exabgp.daemon.daemonize=true exabgp /etc/exabgp/exabgp.cfg
```

Fixes the following traceback when running ExaBGP as daemon:

```
Traceback (most recent call last):
File "/usr/local/bin/exabgp", line 8, in <module>
  sys.exit(run_exabgp())
File "/usr/local/lib/python3.8/dist-packages/exabgp/application/__init__.py", line 20, in run_exabgp
  main()
File "/usr/local/lib/python3.8/dist-packages/exabgp/application/bgp.py", line 314, in main
  run(env, comment, configurations, root, options["--validate"])
File "/usr/local/lib/python3.8/dist-packages/exabgp/application/bgp.py", line 388, in run
  exit_code = Reactor(configurations).run(validate, root)
File "/usr/local/lib/python3.8/dist-packages/exabgp/reactor/loop.py", line 226, in run
  self.daemon.daemonise()
File "/usr/local/lib/python3.8/dist-packages/exabgp/reactor/daemon.py", line 188, in daemonise
  if self._is_socket(sys.__stdin__.fileno()) or os.getppid() == 1:
File "/usr/local/lib/python3.8/dist-packages/exabgp/reactor/daemon.py", line 158, in _is_socket
  s = socket.fromfd(fd, socket.AF_INET, socket.SOCK_RAW)
File "/usr/lib/python3.8/socket.py", line 544, in fromfd
  return socket(family, type, proto, nfd)
File "/usr/lib/python3.8/socket.py", line 231, in __init__
  _socket.socket.__init__(self, family, type, proto, fileno)
OSError: [Errno 88] Socket operation on non-socket
```