### PR TITLE
docs: fix simple typo, opperation -> operation

### DIFF
--- a/dev/profile/pyprof2calltree.py
+++ b/dev/profile/pyprof2calltree.py
@@ -50,7 +50,7 @@ class Entry(object):
 def pstats2entries(data):
     """Helper to convert serialized pstats back to a list of raw entries
 
-    Converse opperation of cProfile.Profile.snapshot_stats()
+    Converse operation of cProfile.Profile.snapshot_stats()
     """
     entries = dict()
     allcallers = dict()


### PR DESCRIPTION
There is a small typo in dev/profile/pyprof2calltree.py.

Should read `operation` rather than `opperation`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md