### PR TITLE
When reloading, force kill old process after a timeout

### DIFF
--- a/src/exabgp/application/healthcheck.py
+++ b/src/exabgp/application/healthcheck.py
@@ -496,7 +496,7 @@ def loop(options):
 
     signal.signal(signal.SIGTERM, sigterm_handler)
 
-    while os.getppid() != 1:
+    while True:
         checks, state = one(checks, state)
 
         try:


### PR DESCRIPTION
This is related to #1006. If the process does not shutdown with
SIGTERM, use SIGKILL.

Note that the `timeout` argument for `wait()` is an addition for
Python 3. If we still need to support Python 2, the easiest way would
be to just not to do that and instead use `kill()` instead of
`terminate()` to not have this issue.

Also revert the change in `healthcheck.py` checking for the PPID.
AFAIK, the process is not reparented.