### PR TITLE
simplify systemd service definition

### DIFF
--- a/etc/systemd/exabgp.service
+++ b/etc/systemd/exabgp.service
@@ -10,13 +10,10 @@ ConditionPathExists=/etc/exabgp/exabgp.conf
 User=exabgp
 Group=exabgp
 Environment=exabgp_daemon_daemonize=false
-PermissionsStartOnly=true
-ExecStartPre=-/usr/bin/env mkfifo /run/exabgp.in
-ExecStartPre=-/usr/bin/env mkfifo /run/exabgp.out
-ExecStartPre=/usr/bin/env chmod 600 /run/exabgp.in
-ExecStartPre=/usr/bin/env chmod 600 /run/exabgp.out
-ExecStartPre=/usr/bin/env chown exabgp.exabgp /run/exabgp.in
-ExecStartPre=/usr/bin/env chown exabgp.exabgp /run/exabgp.out
+RuntimeDirectory=exabgp
+RuntimeDirectoryMode=0750
+ExecStartPre=-/usr/bin/mkfifo /run/exabgp/exabgp.in
+ExecStartPre=-/usr/bin/mkfifo /run/exabgp/exabgp.out
 ExecStart=/usr/sbin/exabgp /etc/exabgp/exabgp.conf
 ExecReload=/bin/kill -USR1 $MAINPID
 Restart=always

--- a/etc/systemd/exabgp@.service
+++ b/etc/systemd/exabgp@.service
@@ -10,14 +10,12 @@ ConditionPathExists=/etc/exabgp/exabgp-%i.conf
 User=exabgp
 Group=exabgp
 Environment=exabgp_daemon_daemonize=false
-PermissionsStartOnly=true
-ExecStartPre=-/usr/bin/env mkfifo /run/exabgp.in
-ExecStartPre=-/usr/bin/env mkfifo /run/exabgp.out
-ExecStartPre=/usr/bin/env chmod 600 /run/exabgp.in
-ExecStartPre=/usr/bin/env chmod 600 /run/exabgp.out
-ExecStartPre=/usr/bin/env chown exabgp.exabgp /run/exabgp.in
-ExecStartPre=/usr/bin/env chown exabgp.exabgp /run/exabgp.out
-ExecStart=/usr/sbin/exabgp /etc/exabgp/exabgp.conf
+Environment=exabgp_api_pipename=exabgp-%i
+RuntimeDirectory=exabgp
+RuntimeDirectoryMode=0750
+ExecStartPre=-/usr/bin/mkfifo /run/exabgp/exabgp-%i.in
+ExecStartPre=-/usr/bin/mkfifo /run/exabgp/exabgp-%i.out
+ExecStart=/usr/sbin/exabgp /etc/exabgp/exabgp-%i.conf
 ExecReload=/bin/kill -USR1 $MAINPID
 Restart=always
 CapabilityBoundingSet=CAP_NET_ADMIN


### PR DESCRIPTION
Move the named pipe into /run/exabgp so that we don't have to deal
with a lot of permission-related stuff.

Moreover, for the parametrized service, use the correct configuration
file name (`exabgp-%i.conf`) and use dedicated pipes for CLI.