### PR TITLE
when klass is of type GenericLSID send correct values to unpack

### DIFF
--- a/src/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
@@ -57,7 +57,11 @@ class LinkState(Attribute):
         ls_attrs = []
         while data:
             scode, length = unpack('!HH', data[:4])
-            klass = cls.klass(scode).unpack(data[4 : length + 4], length)
+            klass = cls.klass(scode)
+            if klass.__name__ == "GenericLSID":
+                klass = klass.unpack(scode, data)
+            else:
+                klass = klass.unpack(data[4: length + 4], length)
             klass.TLV = scode
             data = data[length + 4 :]
             if klass.MERGE:
@@ -79,10 +83,10 @@ class LinkState(Attribute):
 
 class BaseLS(object):
     TLV = -1
-    TLV = -1
     JSON = 'json-name-unset'
     REPR = 'repr name unset'
     LEN = None
+    MERGE = False
 
     def __init__(self, content):
         self.content = content


### PR DESCRIPTION
Hi, found the following (please correct me if that is not the desired behavior)

Function `klass` of `LinkState` returns `GenericLSID` by default

`@classmethod
    def klass(cls, code):
        return cls.registered_lsids.get(code, GenericLSID)`
        
But the `unpack` method from `GenericLSID` calls the unpack from the **klass**. When the class is of type `GenericLSID` the unpack expects the values **scode** and **data** to be passed.