### PR TITLE
healthcheck.py - BGP Add Path

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -41,6 +41,7 @@ Version 5.0.0:
  * Compatibility: change node-descriptors to be list
  * Compatibility: remove L from target in JSON extended communities
  * Fix: issue with extended community generation (still not supporting ASN)
+ * Feature: add support for setting BGP path ID for healthcheck.py advertised routes
 
 Version 4.2.7:
  * Feature: logging parsing in debug mode will now print the JSON of updates

--- a/src/exabgp/application/healthcheck.py
+++ b/src/exabgp/application/healthcheck.py
@@ -110,6 +110,7 @@ def setargs(parser):
     g.add_argument("--down-as-path", metavar='ASPATH', type=str, default=None, help="announce IPs with the supplied as-path when the service is down")
     g.add_argument("--disabled-as-path", metavar='ASPATH', type=str, default=None, help="announce IPs with the supplied as-path when the service is disabled")
     g.add_argument("--withdraw-on-down", action="store_true", help="Instead of increasing the metric on health failure, withdraw the route")
+    g.add_argument("--path-id", metavar='PATHID', type=int, default=None, help="path ID to advertise for the route")
 
     g = parser.add_argument_group("reporting")
     g.add_argument("--execute", metavar='CMD', type=str, action="append", help="execute CMD on state change")
@@ -395,6 +396,10 @@ def loop(options):
                     announce = "{0} large-community [ {1} ]".format(announce, options.large_community)
                 if as_path:
                     announce = "{0} as-path [ {1} ]".format(announce, options.as_path)
+
+            # append path ID if required
+            if options.path_id:
+                announce = "{0} path-information {1}".format(announce, options.path_id)
 
             metric += options.increase
 


### PR DESCRIPTION
Hi,

I would like to request BGP add path support for `healthcheck.py`. The server running ExaBGP may be separate from the devices being health checked; when this is the case it can be useful to have BGP add path support to allow equal cost multipath if there are multiple routes for the same prefix.