### PR TITLE
Add neighbor filtering to healthcheck.py

### DIFF
--- a/doc/CHANGELOG.rst
+++ b/doc/CHANGELOG.rst
@@ -42,6 +42,7 @@ Version 5.0.0:
  * Compatibility: remove L from target in JSON extended communities
  * Fix: issue with extended community generation (still not supporting ASN)
  * Feature: add support for setting BGP path ID for healthcheck.py advertised routes
+ * Feature: allow routes advertised by healthcheck.py to be filtered to specific neighbors
 
 Version 4.2.7:
  * Feature: logging parsing in debug mode will now print the JSON of updates

--- a/src/exabgp/application/healthcheck.py
+++ b/src/exabgp/application/healthcheck.py
@@ -111,6 +111,7 @@ def setargs(parser):
     g.add_argument("--disabled-as-path", metavar='ASPATH', type=str, default=None, help="announce IPs with the supplied as-path when the service is disabled")
     g.add_argument("--withdraw-on-down", action="store_true", help="Instead of increasing the metric on health failure, withdraw the route")
     g.add_argument("--path-id", metavar='PATHID', type=int, default=None, help="path ID to advertise for the route")
+    g.add_argument("--neighbor", metavar='NEIGHBOR', type=ip_address, dest="neighbors", action="append", help="advertise the route to the selected neigbors")
 
     g = parser.add_argument_group("reporting")
     g.add_argument("--execute", metavar='CMD', type=str, action="append", help="execute CMD on state change")
@@ -400,6 +401,13 @@ def loop(options):
             # append path ID if required
             if options.path_id:
                 announce = "{0} path-information {1}".format(announce, options.path_id)
+
+            # allow filtering neighbors that the route should be advertised to
+            if options.neighbors:
+                # routes are filtered to specific neighbors; format them and put into a list
+                neighbors = ["neighbor {0}".format(neighbor) for neighbor in options.neighbors]
+                # comma seperate the neighbor list and prepend to announcement command
+                command = "{0} {1}".format(", ".join(neighbors), command)
 
             metric += options.increase
 


### PR DESCRIPTION
In healthcheck.py, it would be useful to specify an option for a set of neighbors to announce the route to. Currently route advertisements are sent to ExaBGP like this:

```
announce route 192.0.2.1/32 next-hop 192.0.2.250 ...
```

As an option, it would be nice to be able to send announcements like this:

```
neighbor 192.0.2.200 announce route 192.0.2.1/32 next-hop 192.0.2.250 ...
neighbor 192.0.2.200, neighbor 192.0.2.201 announce route 192.0.2.2/32 next-hop 192.0.2.251 ...
```

This patch adds the `--neighbor` option to do exactly this.