### PR TITLE
exabgp.1: update man page based on 4.2.21's --help output.

### DIFF
--- a/doc/man/exabgp.1
+++ b/doc/man/exabgp.1
@@ -1,4 +1,4 @@
-.Dd February 26, 2015
+.Dd October 14, 2022
 .Dt EXABGP 1
 .OS
 .Sh NAME
@@ -6,7 +6,8 @@
 .Nd Influence or control network using BGP
 .Sh SYNOPSIS
 .Nm
-.Op Fl -folder Ar folder | Fl f Ar folder
+.Op Fl -help | Fl h
+.Op Fl -version | Fl v
 .Op Fl -env Ar env-config | Fl e Ar env-config
 .Op Fl -full-ini | Fl -fi
 .Op Fl -diff-ini | Fl -di
@@ -18,10 +19,9 @@
 .Op Fl -pdb | Fl p
 .Op Fl -memory | Fl s
 .Op Fl -profile Ar profile
+.Op Fl -validate
 .Op Fl -test | Fl t
 .Op Fl -decode Ar hex-message | Fl x Ar hex-message
-.Op Fl -help | Fl h
-.Op Fl -version | Fl v
 .Op Ar configuration ...
 .Sh DESCRIPTION
 .Nm
@@ -37,25 +37,24 @@ formatted text.
 .Pp
 The arguments are as follows:
 .Bl -tag -width indent
-.It Fl -folder Ar folder | Fl f Ar folder
-Specify the directory where the configuration file can be found.
 .It Fl -env Ar env-config | Fl e Ar env-config
 Specify where the environment configuration file can be found.
-.It Fl -full-ini | Fl -fi
-Display the full environment configuration using on stdout using the
-ini format.
-.It Fl -diff-ini | Fl -di
-Display the non-default environment configuration on stdout using the
-ini format.
 .It Fl -full-env | Fl -fe
 Display the full environment configuration on stdout using the env
 format.
 .It Fl -diff-env | Fl -de
-Display the non-default configuration on stdout using the env format.
+Display the non-default environment configuration on stdout
+using the env format.
+.It Fl -full-ini | Fl -fi
+Display the full environment configuration used on stdout using the
+ini format.
+.It Fl -diff-ini | Fl -di
+Display the non-default environment configuration on stdout using the
+ini format.
 .It Fl -debug | Fl d
-Start the python debugger on serious logging on and on reception of
-the SIGTERM signal.  
-This is a shortcut for exabgp.log.all=true and
+Start the python debugger on serious logging and on reception of
+the SIGTERM signal.
+This implies exabgp.log.all=true and
 exabgp.log.level=DEBUG.
 .It Fl -signal Ar time
 Issue a SIGUSR1 signal to reload the configuration after the specified
@@ -71,10 +70,14 @@ This is a shortcut for exabgp.pdb.enable=true.
 Display memory usage information on program exit.
 .It Fl -profile Ar profile
 Enable collection of profiling information to the given file.
-This is a shortcut for exabgp.profile.enable=true and
+This is a shortcut for
+exabgp.profile.enable=true
+and
 exabgp.profile.file=profile.
 .It Fl -test | Fl t
 Only do a configuration validity check.
+.It Fl -validate
+Validate the configuration file format only.
 .It Fl -decode Ar hex-message | Fl x Ar hex-message
 Decode a raw route packet in hexadecimal string.
 .It Fl -help | Fl h
@@ -121,15 +124,36 @@ execution of
 .Nm :
 .Pp
 .Bl -hang -width 20m
+.It exabgp.api.ack
+Acknowledge api comman(s) and report issues.
+Default: true.
+.It exabgp.api.chunk
+Maximum number of lines to print before yielding in "show routes" api.
+Default: 1.
+.It exabgp.api.cli
+Determines if
+.Nm
+should create a named pipe for the CLI.
+Default: true.
+.It exabgp.api.compact
+Determines whether
+.Nm
+should use shorter JSON encoding for IPv4/IPv6 unicast NLRI.
+Default: false.
 .It exabgp.api.encoder
 (experimental) default encoder to use with external API (text or
 json).
 Default: text.
-.It exabgp.api.highres
-Controls whether to use high-resolution timestamps in JSON.
-Default: false.
+.It exabgp.api.pipename
+Base name to be used for the
+.Nm
+pipe for the CLI interface.
+Default: exabgp.
 .It exabgp.api.respawn
 Controls whether to respawn a helper process if it dies.
+Default: false.
+.It exabgp.api.terminate
+Controls whether to exit if any helper process dies.
 Default: false.
 .It exabgp.bgp.openwait
 Controls how many seconds we should wait for a BGP open message once
@@ -140,18 +164,26 @@ Controls whether all attributes (configuration and wire) should be
 cached for faster parsing.
 Default: true.
 .It exabgp.cache.nexthops
-(deprecated) Controls whether route next-hops are cached.
+(deprecated, next-hops are always cached)
 Default: true.
 .It exabgp.daemon.daemonize
 Controls whether
 .Nm
 should run in the background.
 Default: false.
+.It exabgp.daemon.drop
+Determines if
+.Nm
+should drop privileges before forking processes.
+Default: true.
 .It exabgp.daemon.pid
 Where to save the PID of
 .Nm
 if we manage it.  
 Default: '' (not set).
+.It exabgp.daemon.umask
+Controls umask to set, controls permissions of created files, e.g. logs.
+Default: 0137.
 .It exabgp.daemon.user
 The user to run
 .Nm
@@ -170,7 +202,8 @@ Controls whether logging should be done for PID change, forking, etc.
 Default: true.
 .It exabgp.log.destination
 Controls where logging should be sent.
-syslog (or no setting) sends the data to the local syslog server.
+syslog (or no setting) sends the data to the local syslog server
+with the LOG_DAEMON facility (used to be LOG_USER).
 host:<location> sends the data to a remote syslog server.
 stdout sends the data to stdout.
 stderr sends the data to stderr.
@@ -233,7 +266,7 @@ Default: 1.0.
 (experimental, unimplemented).
 Default: empty.
 .It exabgp.tcp.bind
-IP address to bind to when listening (no ip to disable).
+List of IP addresses to bind to when listening (no ip to disable).
 Default: empty.
 .It exabgp.tcp.delay
 Start to announce routes when the minutes in the hour is a modulo of
@@ -262,7 +295,6 @@ command, an example showing parts of this output is:
 .Bd -literal -offset 3m
 [exabgp.api]
 encoder = text
-highres = false
 respawn = false
 
 [exabgp.bgp]


### PR DESCRIPTION
Points for discussion:
  - I mention both the new and previous syslog facility. It could be argued that the old should not be mentioned.
  - It is not entirely clear to me what the actual difference is between -test and -validate (and the wording isn't super precise about that).
  - It appears the exabgp.api.highres setting is gone (no longer in --help output, anyway).
  - The -folder argument appears to be gone (also no longer in --help output).
  - The list of standards has not been reviewed or updated here, I am sure the list has expanded over time, a few drafts have become RFCs or exist in newer versions.  Input solicited.