### PR TITLE
Refactor how config originated routes are deleted from outgoing RIB t…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Version explained:
  - bug   : increase on bug or incremental changes
 
 Version 4.2.22
+ * Fix: route reload for offline neighbors #1126
+   patch: Malcolm Dodds
 
 Version 4.2.21
  * Fix: regressing on announcing routes from the API #1108

--- a/lib/exabgp/bgp/neighbor.py
+++ b/lib/exabgp/bgp/neighbor.py
@@ -87,8 +87,6 @@ class Neighbor(object):
 
         # The routes we have parsed from the configuration
         self.changes = []
-        # On signal update, the previous routes so we can compare what changed
-        self.backup_changes = []
 
         self.operational = None
         self.eor = deque()
@@ -196,6 +194,12 @@ class Neighbor(object):
     def remove_addpath(self, family):
         if family in self.addpaths():
             self._addpath.remove(family)
+
+    def process_previous_changes(self, previous_changes):
+        # Withdraw any configuration routes which have been removed
+        for change in previous_changes:
+            if change not in self.changes:
+                self.rib.outgoing.del_from_rib(change)
 
     def missing(self):
         if self.local_address is None and not self.auto_discovery:

--- a/lib/exabgp/configuration/configuration.py
+++ b/lib/exabgp/configuration/configuration.py
@@ -329,10 +329,10 @@ class Configuration(_Configuration):
         self.processes = self.process.processes
         self._neighbors = {}
 
-        # Add the changes prior to the reload to the neighbor to correct handling of deleted routes
+        # Withdraw any old changes
         for neighbor in self.neighbors:
             if neighbor in self._previous_neighbors:
-                self.neighbors[neighbor].backup_changes = self._previous_neighbors[neighbor].changes
+                self.neighbors[neighbor].process_previous_changes(self._previous_neighbors[neighbor].changes)
 
         self._previous_neighbors = {}
         self._cleanup()

--- a/lib/exabgp/reactor/peer.py
+++ b/lib/exabgp/reactor/peer.py
@@ -482,13 +482,6 @@ class Peer(object):
                 if self._reconfigure:
                     self._reconfigure = False
 
-                    # we are here following a configuration change
-                    if self._neighbor:
-                        # see what changed in the configuration
-                        self.neighbor.rib.outgoing.replace(self._neighbor.backup_changes, self._neighbor.changes)
-                        # do not keep the previous routes in memory as they are not useful anymore
-                        self._neighbor.backup_changes = []
-
                 # Take the routes already sent to that peer and resend them
                 if self._resend_routes != SEND.DONE:
                     enhanced = True if refresh_enhanced and self._resend_routes == SEND.REFRESH else False

--- a/lib/exabgp/rib/outgoing.py
+++ b/lib/exabgp/rib/outgoing.py
@@ -99,14 +99,6 @@ class OutgoingRIB(Cache):
         for change in self._new_nlri.values():
             yield change
 
-    def replace(self, previous, changes):
-        for change in previous:
-            change.nlri.action = OUT.WITHDRAW
-            self.add_to_rib(change, True)
-
-        for change in changes:
-            self.add_to_rib(change, True)
-
     def add_to_rib_watchdog(self, change):
         watchdog = change.attributes.watchdog()
         withdraw = change.attributes.withdraw()


### PR DESCRIPTION
Previous the old routes from the configuration were deleted from the peer reactor, leading to the RIB become out of date if the neighbor was offline when an update or sequence of updates was made.

Refactored to this so that any deleted configuration routes are removed from RIB during configuration reload rather than from the reactor.

Tested this with a variety of normal and FlowSpec routes and the RIB is correct all configuration reloads.