### PR TITLE
Bug fix for MUP-BGP T1ST

### DIFF
--- a/src/exabgp/bgp/message/update/nlri/mup/t1st.py
+++ b/src/exabgp/bgp/message/update/nlri/mup/t1st.py
@@ -8,6 +8,7 @@ Copyright (c) 2023 BBSakura Networks Inc. All rights reserved.
 from exabgp.protocol.ip import IP
 from exabgp.bgp.message.update.nlri.qualifier import RouteDistinguisher
 from exabgp.protocol.family import AFI
+from exabgp.protocol.family import Family
 
 from exabgp.bgp.message.update.nlri.mup.nlri import MUP
 from struct import pack
@@ -64,9 +65,6 @@ class Type1SessionTransformedRoute(MUP):
         self.endpoint_ip = endpoint_ip
         self._pack(packed)
 
-    def index(self):
-        return MUP.index(self)
-
     def __eq__(self, other):
         return (
             isinstance(other, Type1SessionTransformedRoute)
@@ -95,6 +93,18 @@ class Type1SessionTransformedRoute(MUP):
             self.endpoint_ip_len,
             self.endpoint_ip,
         )
+
+    def pack_index(self):
+        # removed teid, qfi, endpointip
+        packed = (
+            self.rd.pack()
+            + pack('!B',self.ipprefix_len)
+            + self.ipprefix.pack()
+        )
+        return pack('!BHB', self.ARCHTYPE, self.CODE, len(packed)) + packed
+
+    def index(self):
+        return Family.index(self) + self.pack_index()
 
     def __hash__(self):
         return hash(

--- a/src/exabgp/bgp/message/update/nlri/mup/t1st.py
+++ b/src/exabgp/bgp/message/update/nlri/mup/t1st.py
@@ -136,7 +136,7 @@ class Type1SessionTransformedRoute(MUP):
         size = 4 if afi != AFI.ipv6 else 16
         ipprefix = IP.unpack(data[9: 9 + size])
         size += 9
-        teid = int.from_bytes(data[size: size + 3], "big")
+        teid = int.from_bytes(data[size: size + 4], "big")
         size += 4
         qfi = data[size]
         size += 1


### PR DESCRIPTION
Fixed a bug in T1ST implemented in #1142.
Below is what to fix

- Added because parsing when received by BGP forgot to read 1 byte.
- Excluded because the index included unnecessary items
