### PR TITLE
Support for the 'ipv4' and 'ipv6' options in the Announce statement to exabgp-cli.

### DIFF
--- a/src/exabgp/reactor/api/__init__.py
+++ b/src/exabgp/reactor/api/__init__.py
@@ -59,6 +59,36 @@ class API(Command):
         changes = self.configuration.scope.pop_routes()
         return changes
 
+    def api_announce_v4(self, command):
+        action, line = command.split(' ', 1)
+        _, line = line.split(' ', 1)
+
+        self.configuration.static.clear()
+        if not self.configuration.partial('ipv4', line, action):
+            return []
+
+        if self.configuration.scope.location():
+            return []
+
+        self.configuration.scope.to_context()
+        changes = self.configuration.scope.pop_routes()
+        return changes
+
+    def api_announce_v6(self, command):
+        action, line = command.split(' ', 1)
+        _, line = line.split(' ', 1)
+
+        self.configuration.static.clear()
+        if not self.configuration.partial('ipv6', line, action):
+            return []
+
+        if self.configuration.scope.location():
+            return []
+
+        self.configuration.scope.to_context()
+        changes = self.configuration.scope.pop_routes()
+        return changes
+
     def api_flow(self, command):
         action, flow, line = command.split(' ', 2)
 

--- a/src/exabgp/reactor/api/command/announce.py
+++ b/src/exabgp/reactor/api/command/announce.py
@@ -512,3 +512,175 @@ def announce_operational(self, reactor, service, command):
         self.log_failure('issue parsing the command')
         reactor.processes.answer_error(service)
         return False
+
+
+@Command.register('text', 'announce ipv4')
+def announce_ipv4(self, reactor, service, line):
+    def callback():
+        try:
+            descriptions, command = extract_neighbors(line)
+            peers = match_neighbors(reactor.peers(service), descriptions)
+            if not peers:
+                self.log_failure('no neighbor matching the command : %s' % command)
+                reactor.processes.answer_error(service)
+                yield True
+                return
+
+            changes = self.api_announce_v4(command)
+            if not changes:
+                self.log_failure('command could not parse ipv4 in : %s' % command)
+                reactor.processes.answer_error(service)
+                yield True
+                return
+
+            for change in changes:
+                change.nlri.action = Action.ANNOUNCE
+                reactor.configuration.inject_change(peers, change)
+                self.log_message(
+                    'ipv4 added to %s : %s' % (', '.join(peers) if peers else 'all peers', change.extensive())
+                )
+                yield False
+
+            reactor.processes.answer_done(service)
+        except ValueError:
+            self.log_failure('issue parsing the ipv4')
+            reactor.processes.answer_error(service)
+            yield True
+        except IndexError:
+            self.log_failure('issue parsing the ipv4')
+            reactor.processes.answer_error(service)
+            yield True
+
+    reactor.asynchronous.schedule(service, line, callback())
+    return True
+
+@Command.register('text', 'withdraw ipv4')
+def withdraw_ipv4(self, reactor, service, line):
+    def callback():
+        try:
+            descriptions, command = extract_neighbors(line)
+            peers = match_neighbors(reactor.peers(service), descriptions)
+            if not peers:
+                self.log_failure('no neighbor matching the command : %s' % command)
+                reactor.processes.answer_error(service)
+                yield True
+                return
+
+            changes = self.api_announce_v4(command)
+
+            if not changes:
+                self.log_failure('command could not parse ipv4 in : %s' % command)
+                reactor.processes.answer_error(service)
+                yield True
+                return
+
+            for change in changes:
+                change.nlri.action = Action.WITHDRAW
+                if reactor.configuration.inject_change(peers, change):
+                    self.log_message(
+                        'ipv4 removed from %s : %s' % (', '.join(peers) if peers else 'all peers', change.extensive())
+                    )
+                else:
+                    self.log_failure(
+                        'ipv4 not found on %s : %s' % (', '.join(peers) if peers else 'all peers', change.extensive())
+                    )
+                yield False
+
+            reactor.processes.answer_done(service)
+        except ValueError:
+            self.log_failure('issue parsing the ipv4')
+            reactor.processes.answer_error(service)
+            yield True
+        except IndexError:
+            self.log_failure('issue parsing the ipv4')
+            reactor.processes.answer_error(service)
+            yield True
+
+    reactor.asynchronous.schedule(service, line, callback())
+    return True
+
+
+@Command.register('text', 'announce ipv6')
+def announce_ipv6(self, reactor, service, line):
+    def callback():
+        try:
+            descriptions, command = extract_neighbors(line)
+            peers = match_neighbors(reactor.peers(service), descriptions)
+            if not peers:
+                self.log_failure('no neighbor matching the command : %s' % command)
+                reactor.processes.answer_error(service)
+                yield True
+                return
+
+            changes = self.api_announce_v6(command)
+            if not changes:
+                self.log_failure('command could not parse ipv6 in : %s' % command)
+                reactor.processes.answer_error(service)
+                yield True
+                return
+
+            for change in changes:
+                change.nlri.action = Action.ANNOUNCE
+                reactor.configuration.inject_change(peers, change)
+                self.log_message(
+                    'ipv6 added to %s : %s' % (', '.join(peers) if peers else 'all peers', change.extensive())
+                )
+                yield False
+
+            reactor.processes.answer_done(service)
+        except ValueError:
+            self.log_failure('issue parsing the ipv6')
+            reactor.processes.answer_error(service)
+            yield True
+        except IndexError:
+            self.log_failure('issue parsing the ipv6')
+            reactor.processes.answer_error(service)
+            yield True
+
+    reactor.asynchronous.schedule(service, line, callback())
+    return True
+
+@Command.register('text', 'withdraw ipv6')
+def withdraw_ipv6(self, reactor, service, line):
+    def callback():
+        try:
+            descriptions, command = extract_neighbors(line)
+            peers = match_neighbors(reactor.peers(service), descriptions)
+            if not peers:
+                self.log_failure('no neighbor matching the command : %s' % command)
+                reactor.processes.answer_error(service)
+                yield True
+                return
+
+            changes = self.api_announce_v6(command)
+
+            if not changes:
+                self.log_failure('command could not parse ipv6 in : %s' % command)
+                reactor.processes.answer_error(service)
+                yield True
+                return
+
+            for change in changes:
+                change.nlri.action = Action.WITHDRAW
+                if reactor.configuration.inject_change(peers, change):
+                    self.log_message(
+                        'ipv6 removed from %s : %s' % (', '.join(peers) if peers else 'all peers', change.extensive())
+                    )
+                else:
+                    self.log_failure(
+                        'ipv6 not found on %s : %s' % (', '.join(peers) if peers else 'all peers', change.extensive())
+                    )
+                yield False
+
+            reactor.processes.answer_done(service)
+        except ValueError:
+            self.log_failure('issue parsing the ipv6')
+            reactor.processes.answer_error(service)
+            yield True
+        except IndexError:
+            self.log_failure('issue parsing the ipv6')
+            reactor.processes.answer_error(service)
+            yield True
+
+    reactor.asynchronous.schedule(service, line, callback())
+    return True


### PR DESCRIPTION
This enables support for statements related to IPv4 and IPv6. 
Examples of supported IPv4 statements include unicast and mup.

```shell
# unicast case
exabgpcli announce ipv4 unicast 10.0.0.0/24 next-hop 10.0.1.254 local-preference 200;

# mup case
exabgpcli announce ipv4 "mup mup-isd 10.0.1.1/24 rd 100:100 next-hop 2001::1 extended-community [ target:10:10 ] bgp-prefix-sid-srv6 ( l3-service 2001:db8:1:1:: 0x48 [64,24,16,0,0,0] );"
```