### PR TITLE
Decode rbuffer for string comparison

### DIFF
--- a/src/exabgp/application/cli.py
+++ b/src/exabgp/application/cli.py
@@ -170,11 +170,11 @@ def cmdline(cmdarg):
         # we read some data but it is not ending by a new line (ie: not a command completion)
         if rbuffer[-1] != 10:  # \n
             continue
-        if AnswerStream.done.endswith(rbuffer[-len(AnswerStream.done) :]):
+        if AnswerStream.done.endswith(rbuffer.decode()[-len(AnswerStream.done) :]):
             break
-        if AnswerStream.error.endswith(rbuffer[-len(AnswerStream.error) :]):
+        if AnswerStream.error.endswith(rbuffer.decode()[-len(AnswerStream.error) :]):
             break
-        if AnswerStream.shutdown.endswith(rbuffer[-len(AnswerStream.shutdown) :]):
+        if AnswerStream.shutdown.endswith(rbuffer.decode()[-len(AnswerStream.shutdown) :]):
             break
 
     renamed = ['']


### PR DESCRIPTION
Decode `rbuffer` before comparing with the `AnswerStream` strings.

Comparing a non-empty `rbuffer` to the `AnswerStream` strings fails with a TypeError.

This is not an issue in Python2 where the two are of similar object type.

---

### Details

This fixes the following issue where `exabgpcli` and `exabgp --run cli` intermittently fails with:

```
$ sudo /usr/bin/exabgp --run cli version

********************************************************************************
-- Please provide ALL the information below on :
-- https://github.com/Exa-Networks/exabgp/issues
********************************************************************************

ExaBGP version : 4.2.21
Python version : 3.8.10 (default, May 26 2023, 14:05:08)  [GCC 9.4.0]
System Uname   : #85~20.04.1-Ubuntu SMP Mon Jul 17 09:42:39 UTC 2023
System MaxInt  : 9223372036854775807


-- Traceback


Traceback (most recent call last):
  File "/usr/bin/exabgpcli", line 11, in <module>
    load_entry_point('exabgp==4.2.21', 'console_scripts', 'exabgpcli')()
  File "/usr/lib/python3/dist-packages/exabgp/application/__init__.py", line 38, in run_cli
    main()
  File "/usr/lib/python3/dist-packages/exabgp/application/cli.py", line 205, in main
    if AnswerStream.done.endswith(rbuffer[-len(AnswerStream.done) :]):
TypeError: endswith first arg must be str or a tuple of str, not bytes


-- Configuration





-- Logging History
```

Printing the output of `rbuffer` when it's non-empty in the above scenario show that it contains `lete\n\done\n`.

--- 

### Version

The issue above and fix has been tested on:

OS: Ubuntu Focal
ExaBGP: 4.2.21 downloaded from https://github.com/Exa-Networks/exabgp/releases