### PR TITLE
✏️  Typo(prefixsid.py): remove redundant assignment for "FLAG"

### DIFF
--- a/src/exabgp/bgp/message/update/attribute/sr/prefixsid.py
+++ b/src/exabgp/bgp/message/update/attribute/sr/prefixsid.py
@@ -21,7 +21,7 @@ from exabgp.util import hexstring
 @Attribute.register()
 class PrefixSid(Attribute):
     ID = Attribute.CODE.BGP_PREFIX_SID
-    FLAG = FLAG = Attribute.Flag.TRANSITIVE | Attribute.Flag.OPTIONAL
+    FLAG = Attribute.Flag.TRANSITIVE | Attribute.Flag.OPTIONAL
     CACHING = True
     TLV = -1
 


### PR DESCRIPTION
Only found this `FLAG=FLAG` in the code, did not find it in other files.