### PR TITLE
fix toremove loopback addresses

### DIFF
--- a/src/exabgp/application/healthcheck.py
+++ b/src/exabgp/application/healthcheck.py
@@ -220,7 +220,7 @@ def loopback_ips(label, label_only):
                     continue
                 if lmo.groupdict().get("label", "").startswith(label):
                     addresses.append(ip)
-            elif not label_only:
+            elif not label_only or label is None:
                 addresses.append(ip)
 
     logger.debug("Loopback addresses: %s", addresses)

--- a/src/exabgp/application/healthcheck.py
+++ b/src/exabgp/application/healthcheck.py
@@ -261,7 +261,7 @@ def remove_ips(ips, label, sudo=False):
     existing = set(loopback_ips(label, True))
 
     # Get intersection of IPs (ips setup, and IPs configured by ExaBGP)
-    toremove = set([ip_network(ip) for net in ips for ip in net]) & existing
+    toremove = set([ip_network(ip) for net in ips for ip in net]) | existing
     for ip in toremove:
         logger.debug("Remove loopback IP address %s", ip)
         with open(os.devnull, "w") as fnull:

--- a/src/exabgp/application/healthcheck.py
+++ b/src/exabgp/application/healthcheck.py
@@ -261,7 +261,7 @@ def remove_ips(ips, label, sudo=False):
     existing = set(loopback_ips(label, True))
 
     # Get intersection of IPs (ips setup, and IPs configured by ExaBGP)
-    toremove = set([ip_network(ip) for net in ips for ip in net]) | existing
+    toremove = set([ip_network(ip) for net in ips for ip in net]) & existing
     for ip in toremove:
         logger.debug("Remove loopback IP address %s", ip)
         with open(os.devnull, "w") as fnull:


### PR DESCRIPTION
Looks like there was already a similar problem as long as 2 years ago.


https://github.com/Exa-Networks/exabgp/issues/1107

I checked, indeed if you join the sets IPs correctly to remove addresses - they are removed without problems


**exabgp.conf**
```
name = rhel01
interval = 5
command = curl -sf http://10.30.3.13:9005/healthcheck
ip = 10.30.4.3
ip = 10.30.4.4
start-ip = 2
ip = 10.30.4.5
next-hop = 10.30.3.13
withdraw-on-down
dynamic-ip-setup
```

```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet 10.30.6.5/32 scope global lo
       valid_lft forever preferred_lft forever
    inet 10.30.6.4/32 scope global lo
       valid_lft forever preferred_lft forever
    inet 10.30.6.3/32 scope global lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
```


Stop loopback ips service (haproxy in my case)

```
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN group default qlen 1000
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
```

Seems working fine