### PR TITLE
Spec file refactor

### DIFF
--- a/redhat/python-exabgp.spec
+++ b/redhat/python-exabgp.spec
@@ -83,6 +83,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %defattr(-,root,root,-)
 %attr(755, root, root) %{_sbindir}/exabgp
 %attr(755, root, root) %{_sbindir}/exabgpcli
+%attr(755, root, root) %{_sbindir}/exabgp-cli
 %attr(755, root, root) %{_sbindir}/exabgp-healthcheck
 %dir %{_sysconfdir}/exabgp
 %{_sysconfdir}/exabgp/exabgp.conf

--- a/redhat/python-exabgp.spec
+++ b/redhat/python-exabgp.spec
@@ -66,7 +66,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %post -n exabgp
 %systemd_post exabgp.service
 # Default env
-[ -f %{_sysconfdir}/exabgp/exabgp.env ] || %{_sbindir}/exabgp  > %{_sysconfdir}/exabgp/exabgp.env
+[ -f %{_sysconfdir}/exabgp/exabgp.env ] || %{_sbindir}/exabgp --fi > %{_sysconfdir}/exabgp/exabgp.env
 
 %preun -n exabgp
 %systemd_preun exabgp.service

--- a/redhat/python-exabgp.spec
+++ b/redhat/python-exabgp.spec
@@ -88,7 +88,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %dir %{_sysconfdir}/exabgp
 %{_sysconfdir}/exabgp/exabgp.conf
 %dir %{_sysconfdir}/exabgp/examples
-%attr(744, root, root) %{_prefix}/share/exabgp/*
+%attr(744, root, root) %{_prefix}/etc/exabgp/*
 %attr(744, root, root) %{_sysconfdir}/exabgp/examples/*
 %{_unitdir}/exabgp.service
 %{_unitdir}/exabgp@.service

--- a/redhat/python-exabgp.spec
+++ b/redhat/python-exabgp.spec
@@ -77,7 +77,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %files
 %defattr(-,root,root,-)
 %{python3_sitelib}/*
-%doc COPYRIGHT CHANGELOG README.md
+%doc CHANGELOG.rst README.md
 
 %files -n exabgp
 %defattr(-,root,root,-)
@@ -92,7 +92,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %{_unitdir}/exabgp.service
 %{_unitdir}/exabgp@.service
 %attr(644, root, root) %{_unitdir}/*
-%doc COPYRIGHT CHANGELOG README.md
+%doc CHANGELOG.rst README.md
 %{_mandir}/man1/*
 %{_mandir}/man5/*
 

--- a/redhat/python-exabgp.spec.git
+++ b/redhat/python-exabgp.spec.git
@@ -85,7 +85,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %files
 %defattr(-,root,root,-)
 %{python3_sitelib}/*
-%doc COPYRIGHT CHANGELOG README.md
+%doc CHANGELOG.rst README.md
 
 %files -n exabgp
 %defattr(-,root,root,-)
@@ -100,7 +100,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %{_unitdir}/exabgp.service
 %{_unitdir}/exabgp@.service
 %attr(644, root, root) %{_unitdir}/*
-%doc COPYRIGHT CHANGELOG README.md
+%doc CHANGELOG.rst README.md
 %{_mandir}/man1/*
 %{_mandir}/man5/*
 

--- a/redhat/python-exabgp.spec.git
+++ b/redhat/python-exabgp.spec.git
@@ -96,7 +96,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %dir %{_sysconfdir}/exabgp
 %{_sysconfdir}/exabgp/exabgp.conf
 %dir %{_sysconfdir}/exabgp/examples
-%attr(744, root, root) %{_prefix}/share/exabgp/*
+%attr(744, root, root) %{_prefix}/etc/exabgp/*
 %attr(744, root, root) %{_sysconfdir}/exabgp/examples/*
 %{_unitdir}/exabgp.service
 %{_unitdir}/exabgp@.service

--- a/redhat/python-exabgp.spec.git
+++ b/redhat/python-exabgp.spec.git
@@ -91,6 +91,7 @@ ln -s %{_sysconfdir}/exabgp/examples/api-api.conf %{buildroot}/%{_sysconfdir}/ex
 %defattr(-,root,root,-)
 %attr(755, root, root) %{_sbindir}/exabgp
 %attr(755, root, root) %{_sbindir}/exabgpcli
+%attr(755, root, root) %{_sbindir}/exabgp-cli
 %attr(755, root, root) %{_sbindir}/exabgp-healthcheck
 %dir %{_sysconfdir}/exabgp
 %{_sysconfdir}/exabgp/exabgp.conf


### PR DESCRIPTION
Here's various fixies for the current .spec files in repo.

List of errors:
* corrupted .env file after build - exabgp starts with error
* missing `exabgp-cli` file
* change the path from `share` to `etc`
* extension fix for `CHANGELOG.rst README.md 



After all changes - successful build performed without any problems

```
exabgp/4.2.21/rpmbuild/RPMS
└── noarch
    ├── exabgp-4.2.21-1.el7.noarch.rpm
    └── python-exabgp-4.2.21-1.el7.noarch.rpm
```