### PR TITLE
source-interface parameter for peering

### DIFF
--- a/src/exabgp/bgp/neighbor.py
+++ b/src/exabgp/bgp/neighbor.py
@@ -66,6 +66,7 @@ class Neighbor(dict):
         'description': '',
         'router-id': None,
         'local-address': None,
+        'source-interface': None,
         'peer-address': None,
         'local-as': None,
         'peer-as': None,
@@ -397,6 +398,7 @@ class Neighbor(dict):
             '\thost-name %s;\n'
             '\tdomain-name %s;\n'
             '\tlocal-address %s;\n'
+            '\tsource-interface %s;\n'
             '\tlocal-as %s;\n'
             '\tpeer-as %s;\n'
             '\thold-time %s;\n'
@@ -421,6 +423,7 @@ class Neighbor(dict):
                 self['host-name'],
                 self['domain-name'],
                 self['local-address'] if not self.auto_discovery else 'auto',
+                self['source-interface'],
                 self['local-as'],
                 self['peer-as'],
                 self['hold-time'],

--- a/src/exabgp/configuration/neighbor/__init__.py
+++ b/src/exabgp/configuration/neighbor/__init__.py
@@ -38,6 +38,7 @@ from exabgp.configuration.neighbor.parser import md5
 from exabgp.configuration.neighbor.parser import hold_time
 from exabgp.configuration.neighbor.parser import router_id
 from exabgp.configuration.neighbor.parser import local_address
+from exabgp.configuration.neighbor.parser import source_interface
 from exabgp.configuration.neighbor.parser import hostname
 from exabgp.configuration.neighbor.parser import domainname
 from exabgp.configuration.neighbor.parser import description
@@ -63,6 +64,7 @@ class ParseNeighbor(Section):
         'hold-time': hold_time,
         'rate-limit': rate_limit,
         'local-address': local_address,
+        'source-interface': source_interface,
         'peer-address': peer_ip,
         'local-as': auto_asn,
         'peer-as': auto_asn,
@@ -90,6 +92,7 @@ class ParseNeighbor(Section):
         'hold-time': 'set-command',
         'rate-limit': 'set-command',
         'local-address': 'set-command',
+        'source-interface': 'set-command',
         'peer-address': 'set-command',
         'local-as': 'set-command',
         'peer-as': 'set-command',

--- a/src/exabgp/configuration/neighbor/parser.py
+++ b/src/exabgp/configuration/neighbor/parser.py
@@ -101,6 +101,12 @@ def local_address(tokeniser):
     except (IndexError, ValueError, socket.error):
         raise ValueError('"%s" is an invalid IP address' % value)
 
+def source_interface(tokeniser):
+    try:
+        return string(tokeniser)
+    except Exception:
+        raise ValueError('bad source interface')
+
 
 def router_id(tokeniser):
     value = tokeniser()

--- a/src/exabgp/reactor/network/outgoing.py
+++ b/src/exabgp/reactor/network/outgoing.py
@@ -19,7 +19,7 @@ from exabgp.logger import log
 class Outgoing(Connection):
     direction = 'outgoing'
 
-    def __init__(self, afi, peer, local, port=179, md5='', md5_base64=False, ttl=None):
+    def __init__(self, afi, peer, local, port=179, md5='', md5_base64=False, ttl=None, itf=None):
         Connection.__init__(self, afi, peer, local)
 
         self.ttl = ttl
@@ -27,10 +27,11 @@ class Outgoing(Connection):
         self.md5 = md5
         self.md5_base64 = md5_base64
         self.port = port
+        self.interface = itf
 
     def _setup(self):
         try:
-            self.io = create(self.afi)
+            self.io = create(self.afi, self.interface)
             MD5(self.io, self.peer, self.port, self.md5, self.md5_base64)
             if self.afi == AFI.ipv4:
                 TTL(self.io, self.peer, self.ttl)

--- a/src/exabgp/reactor/protocol.py
+++ b/src/exabgp/reactor/protocol.py
@@ -103,7 +103,8 @@ class Protocol(object):
         md5 = self.neighbor['md5-password']
         md5_base64 = self.neighbor['md5-base64']
         ttl_out = self.neighbor['outgoing-ttl']
-        self.connection = Outgoing(afi, peer, local, self.port, md5, md5_base64, ttl_out)
+        itf = self.neighbor['source-interface']
+        self.connection = Outgoing(afi, peer, local, self.port, md5, md5_base64, ttl_out, itf)
 
         for connected in self.connection.establish():
             yield False


### PR DESCRIPTION
running exabgp in a vrf context is buggy on some OSes
this PR adds an optional `source-interface` parameter to the peer configuration
this allows selecting over which interface the the session with the peer is established
the interface may be in a vrf

