### PR TITLE
Add missing `exc` exception variable for qa/bin/functional

### DIFF
--- a/qa/bin/functional
+++ b/qa/bin/functional
@@ -151,7 +151,7 @@ class Exec(object):
         except ValueError as exc:  # I/O operation on closed file
             self.message = str(exc)
             pass
-        except Alarm:
+        except Alarm as exc:
             self.message = str(exc)
             pass
 


### PR DESCRIPTION
  File "./exabgp/./qa/bin/functional", line 155, in collect
    self.message = str(exc)
UnboundLocalError: local variable 'exc' referenced before assignment