### PR TITLE
Make sure we accept received Hostname capability

### DIFF
--- a/src/exabgp/bgp/message/open/capability/hostname.py
+++ b/src/exabgp/bgp/message/open/capability/hostname.py
@@ -11,13 +11,15 @@ License: 3-clause BSD. (See the COPYRIGHT file)
 
 
 from exabgp.bgp.message.open.capability.capability import Capability
+from exabgp.util.dns import host, domain
 
 
+@Capability.register()
 class HostName(Capability):
     ID = Capability.CODE.HOSTNAME
     HOSTNAME_MAX_LEN = 64
 
-    def __init__(self, host_name, domain_name):
+    def __init__(self, host_name = host(), domain_name = domain()):
         self.host_name = host_name
         self.domain_name = domain_name
 


### PR DESCRIPTION
Without this patch, we mark this capability as Unassigned, instead of really printing it.

E.g.:

```
15:31:48 290980 outgoing-1      << OPEN version=4 asn=65001 hold_time=180 router_id=192.168.10.252 capabilities=[Multiprotocol(ipv4 unicast), Route Refresh, Extended Message(65535), Graceful Restart Flags 0x4 Time 120 , ASN4(65001), AddPath(receive ipv4 unicast), Enhanced Route Refresh, Unassigned 71, Hostname(donatas-laptop ), Unassigned 75, Unassigned 76]
```