### PR TITLE
Jsonify show neighbor,adj-rib-in,adj-rib-out cmds output

### DIFF
--- a/src/exabgp/bgp/neighbor.py
+++ b/src/exabgp/bgp/neighbor.py
@@ -173,19 +173,31 @@ class Neighbor(dict):
         self.messages = deque()
         self.refresh = deque()
 
-    def name(self):
+    def name(self, json=False):
         if self['capability']['multi-session']:
             session = '/'.join("%s-%s" % (afi.name(), safi.name()) for (afi, safi) in self.families())
         else:
             session = 'in-open'
-        return "neighbor %s local-ip %s local-as %s peer-as %s router-id %s family-allowed %s" % (
-            self['peer-address'],
-            self['local-address'] if self['peer-address'] is not None else 'auto',
-            self['local-as'] if self['local-as'] is not None else 'auto',
-            self['peer-as'] if self['peer-as'] is not None else 'auto',
-            self['router-id'],
-            session,
-        )
+        data = {
+            "neighbor": self.peer_address,
+            "local-ip": self.local_address if self.peer_address is not None else 'auto',
+            "local-as": self.local_as if self.local_as is not None else 'auto',
+            "peer-as": self.peer_as if self.peer_as is not None else 'auto',
+            "router-id": self.router_id,
+            "family-allowed": session
+        }
+
+        if json:
+            return data
+        else:
+            return "neighbor %s local-ip %s local-as %s peer-as %s router-id %s family-allowed %s" % (
+                data["neighbor"],
+                data["local-ip"],
+                data["local-as"],
+                data["peer-as"],
+                data["router-id"],
+                data["family-allowed"]
+            )
 
     def families(self):
         # this list() is important .. as we use the function to modify self._families

--- a/src/exabgp/reactor/loop.py
+++ b/src/exabgp/reactor/loop.py
@@ -172,12 +172,16 @@ class Reactor(object):
             return
         return peer.neighbor
 
-    def neighbor_name(self, peer_name):
+    def neighbor_name(self, peer_name, json=False):
         peer = self._peers.get(peer_name, None)
         if not peer:
             log.critical('could not find referenced peer', 'reactor')
             return ""
-        return peer.neighbor.name()
+        if json:
+            return peer.neighbor.name(json=True)
+        else:
+            return peer.neighbor.name()
+
 
     def neighbor_ip(self, peer_name):
         peer = self._peers.get(peer_name, None)


### PR DESCRIPTION
This PR updates ExaBGP to optionally provide JSON output for API commands such as show neighbor, adj-rib-in, and adj-rib-out.

Existing Commands:
```
show neighbor [optional neighbor ip] summary
show neighbor [optional neighbor ip] extensive
show neighbor [optional neighbor ip] configuration
show adj-rib in [extensive] (to be integrated with neighbor)
show adj-rib out [extensive] (to be integrated with neighbor)
```

Example Usage for JSON Output:
```
show neighbor [optional json] [optional neighbor ip] summary
show neighbor [optional json] [optional neighbor ip] extensive
show adj-rib in [optional json] [extensive] (to be integrated with neighbor)
show adj-rib out [optional json] [extensive] (to be integrated with neighbor)
```
Examples:
```
show neighbor json summary
show neighbor json extensive
show adj-rib out json
```

This should also resolve the issue detailed in https://github.com/Exa-Networks/exabgp/issues/909