### PR TITLE
debian/control: Remove unneeded debconf pre-dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -35,8 +35,7 @@ Description: BGP swiss army knife of networking - Python 3 module
 
 Package: exabgp
 Architecture: all
-Pre-Depends: debconf (>= 1.5.34),
-             dpkg (>= 1.15.7.2),
+Pre-Depends: dpkg (>= 1.15.7.2),
              ${misc:Pre-Depends}
 Depends: adduser,
          python3-exabgp (= ${binary:Version}),


### PR DESCRIPTION
exabgp does not make use of debconf at all, so this (outdated) pre-dependency can be removed. An appropriate dependency will be added by `dh_installdebconf` if needed.