### PR TITLE
github: use latest Ubuntu image for old Python versions

### DIFF
--- a/.github/workflows/functional-3.6.yml
+++ b/.github/workflows/functional-3.6.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.6"]
-        os: ["ubuntu-20.04"]
+        os: ["ubuntu-latest"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/functional-3.7.yml
+++ b/.github/workflows/functional-3.7.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.7"]
-        os: ["ubuntu-22.04"]
+        os: ["ubuntu-latest"]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This should not prevent to use older Python versions as actions/setup-python is able to download older Python versions from actions/python-versions.