### PR TITLE
Announce user defined loopback ips when '--ip' was not configured

### DIFF
--- a/src/exabgp/application/healthcheck.py
+++ b/src/exabgp/application/healthcheck.py
@@ -590,6 +590,7 @@ def main():
         options.pid.close()
     try:
         # Setup IP to use
+        options.ips = options.ips or system_ips(None, options.label, False, options.label_exact_match)
         if not options.ips:
             logger.error('No IP found')
             sys.exit(1)


### PR DESCRIPTION
Ensure backward compatibility with healthcheck behavior after PR #1263.

When healthcheck is configured without '--ip' parameters, this code retrieves the user defined loopback addresses (ipv4/32 and ipv6/128) and use them as '--ip' address to announce and manage. 

The fix just implements the same behavior of the code before PR #1263