### PR TITLE
Fix BGP test server shutdown for asyncio compatibility

### DIFF
--- a/qa/sbin/bgp
+++ b/qa/sbin/bgp
@@ -571,10 +571,14 @@ class BGPService(object):
         self.checker = checker
         self.loop = loop
         self.queue = queue
+        self.server = None
+        self.shutdown_event = asyncio.Event()
 
     def exit(self, code):
         self.queue.put(code)
-        self.loop.stop()
+        self.shutdown_event.set()
+        if self.server:
+            self.server.close()
 
 
 class BGPProtocol(asyncio.Protocol):
@@ -837,9 +841,11 @@ async def main(options, checker, queue):
         sock=sock,
     )
     # perhaps set backlog to 1 ..
+    service.server = server
 
     async with server:
-        await server.serve_forever()
+        # Wait for shutdown signal instead of serve_forever
+        await service.shutdown_event.wait()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The BGP test server (qa/sbin/bgp) was using loop.stop() which doesn't work correctly with asyncio.run() and server.serve_forever().

Changes:
- Added shutdown_event (asyncio.Event) to BGPService class
- Modified exit() to set the event and close the server
- Changed main() to wait on shutdown_event instead of serve_forever()

This allows the test server to properly terminate when tests complete, fixing an issue where encoding tests would hang waiting for the server to shutdown.

The fix follows asyncio best practices for graceful server shutdown.