### PR TITLE
Fix test infrastructure issues preventing CI from passing

### DIFF
--- a/qa/bin/functional
+++ b/qa/bin/functional
@@ -146,6 +146,8 @@ class Exec(object):
             return
         if self.code != -1:
             return
+        if self._process is None:
+            return
 
         signal.signal(signal.SIGALRM, alarm_handler)
         try:
@@ -161,10 +163,11 @@ class Exec(object):
             pass
 
     def terminate(self):
-        try:
-            self._process.send_signal(signal.SIGTERM)
-        except OSError:  # No such process, Errno 3
-            pass
+        if self._process is not None:
+            try:
+                self._process.send_signal(signal.SIGTERM)
+            except OSError:  # No such process, Errno 3
+                pass
         self.collect()
 
     def __del__(self):

--- a/qa/sbin/bgp
+++ b/qa/sbin/bgp
@@ -571,10 +571,14 @@ class BGPService(object):
         self.checker = checker
         self.loop = loop
         self.queue = queue
+        self.server = None
+        self.shutdown_event = asyncio.Event()
 
     def exit(self, code):
         self.queue.put(code)
-        self.loop.stop()
+        self.shutdown_event.set()
+        if self.server:
+            self.server.close()
 
 
 class BGPProtocol(asyncio.Protocol):
@@ -837,9 +841,11 @@ async def main(options, checker, queue):
         sock=sock,
     )
     # perhaps set backlog to 1 ..
+    service.server = server
 
     async with server:
-        await server.serve_forever()
+        # Wait for shutdown signal instead of serve_forever
+        await service.shutdown_event.wait()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit fixes two critical issues in the test infrastructure:

1. BGP test server shutdown (qa/sbin/bgp):
   - The server was using loop.stop() which doesn't work with asyncio.run()
   - Changed to use asyncio.Event for proper shutdown signaling
   - Added server reference to allow clean closure
   - Now waits on shutdown_event instead of serve_forever()

2. Functional test cleanup (qa/bin/functional):
   - Fixed AttributeError when _process is None during cleanup
   - Added defensive None checks in collect() and terminate()
   - Prevents: AttributeError: 'NoneType' object has no attribute 'send_signal'

Both issues were causing CI test failures. These fixes follow asyncio best practices and ensure proper resource cleanup.

Fixes encoding tests that would hang waiting for server shutdown.