### PR TITLE
QA utility script setup and testing

### DIFF
--- a/qa/bin/functional
+++ b/qa/bin/functional
@@ -523,6 +523,7 @@ class EncodingTests(Tests):
         for test in running:
             test.fail()
             test.terminate()
+            success = False
 
         self.display()
         return success
@@ -659,6 +660,7 @@ class DecodingTests(Tests):
         for test in running:
             test.fail()
             test.terminate()
+            success = False
 
         self.display()
         return success
@@ -733,6 +735,7 @@ class ParsingTests(Tests):
         for test in running:
             test.fail()
             test.terminate()
+            success = False
 
         self.display()
         return success


### PR DESCRIPTION
The functional test script was failing to report test timeouts correctly, causing tests that timed out to exit with success (0) instead of failure (1).

This issue affected all three test types (encoding, decoding, and parsing):
- When tests exceeded the timeout threshold, they were marked as failed but the success variable was never set to False
- This caused CI/CD to incorrectly report test runs as successful even when tests actually failed due to timeout

The fix adds `success = False` in the timeout cleanup loop for:
- EncodingTests.run_selected() (line 526)
- DecodingTests.run_selected() (line 663)
- ParsingTests.run_selected() (line 738)

This ensures that any test timeout is correctly reported as a failure, allowing CI/CD to properly detect and report test failures.

Fixes: Test V (api-teardown) and any other tests that timeout