### PR TITLE
Session Title Needed - Incomplete Description

### DIFF
--- a/src/exabgp/bgp/message/operational.py
+++ b/src/exabgp/bgp/message/operational.py
@@ -239,7 +239,11 @@ class Advisory(object):
         code = Operational.CODE.ADM
 
         def __init__(self, afi, safi, advisory, routerid=None):
-            utf8 = advisory.encode('utf-8')
+            # Handle both string and bytes input
+            if isinstance(advisory, bytes):
+                utf8 = advisory
+            else:
+                utf8 = advisory.encode('utf-8')
             if len(utf8) > MAX_ADVISORY:
                 utf8 = utf8[: MAX_ADVISORY - 3] + '...'.encode('utf-8')
             Advisory._Advisory.__init__(self, Operational.CODE.ADM, afi, safi, utf8)
@@ -250,7 +254,11 @@ class Advisory(object):
         code = Operational.CODE.ASM
 
         def __init__(self, afi, safi, advisory, routerid=None):
-            utf8 = advisory.encode('utf-8')
+            # Handle both string and bytes input
+            if isinstance(advisory, bytes):
+                utf8 = advisory
+            else:
+                utf8 = advisory.encode('utf-8')
             if len(utf8) > MAX_ADVISORY:
                 utf8 = utf8[: MAX_ADVISORY - 3] + '...'.encode('utf-8')
             Advisory._Advisory.__init__(self, Operational.CODE.ASM, afi, safi, utf8)

--- a/tests/test_operational_nop.py
+++ b/tests/test_operational_nop.py
@@ -486,21 +486,47 @@ def test_response_counter_encoding():
 def test_operational_unpack_adm():
     """
     Test unpacking Advisory Demand Message (ADM).
-
-    Note: ADM unpacking has a known issue where the constructor expects
-    strings but receives bytes. This test is disabled for now.
     """
-    pytest.skip("ADM/ASM unpacking has constructor type mismatch - bytes vs string")
+    advisory_text = b"Critical alert message"
+
+    data = (
+        struct.pack('!H', Operational.CODE.ADM) +  # Type
+        struct.pack('!H', 2 + 1 + len(advisory_text)) +  # Length: AFI(2)+SAFI(1)+message
+        struct.pack('!H', AFI.ipv4) +  # AFI
+        struct.pack('!B', SAFI.unicast) +  # SAFI
+        advisory_text  # Advisory message
+    )
+
+    op = Operational.unpack_message(data, Direction.IN, {})
+
+    assert isinstance(op, Advisory.ADM)
+    assert op.afi == AFI.ipv4
+    assert op.safi == SAFI.unicast
+    assert op.data == advisory_text
+    assert op.name == 'ADM'
 
 
 def test_operational_unpack_asm():
     """
     Test unpacking Advisory Static Message (ASM).
-
-    Note: ASM unpacking has a known issue where the constructor expects
-    strings but receives bytes. This test is disabled for now.
     """
-    pytest.skip("ADM/ASM unpacking has constructor type mismatch - bytes vs string")
+    advisory_text = b"Static configuration message"
+
+    data = (
+        struct.pack('!H', Operational.CODE.ASM) +  # Type
+        struct.pack('!H', 2 + 1 + len(advisory_text)) +  # Length: AFI(2)+SAFI(1)+message
+        struct.pack('!H', AFI.ipv6) +  # AFI
+        struct.pack('!B', SAFI.multicast) +  # SAFI
+        advisory_text  # Advisory message
+    )
+
+    op = Operational.unpack_message(data, Direction.IN, {})
+
+    assert isinstance(op, Advisory.ASM)
+    assert op.afi == AFI.ipv6
+    assert op.safi == SAFI.multicast
+    assert op.data == advisory_text
+    assert op.name == 'ASM'
 
 
 def test_operational_unpack_rpcq():


### PR DESCRIPTION
This commit fixes the ADM/ASM unpacking issue where constructors expected strings but received bytes during message unpacking.

Changes:
- Modified ADM and ASM constructors to handle both string and bytes input
- When advisory parameter is bytes, use it directly
- When advisory parameter is string, encode it to UTF-8 as before
- Implemented test_operational_unpack_adm() with proper unpacking test
- Implemented test_operational_unpack_asm() with proper unpacking test
- Removed pytest.skip() from both tests

All 46 tests in test_operational_nop.py now pass.

Fixes: Type mismatch in ADM/ASM unpacking