### PR TITLE
Continue Writing Test Cases

### DIFF
--- a/src/exabgp/bgp/message/update/nlri/bgpls/link.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/link.py
@@ -185,10 +185,10 @@ class LINK(BGPLS):
         return self.json()
 
     def __hash__(self):
-        return hash((self))
+        return hash((self.CODE, self.domain, self.proto_id, tuple(self.topology_ids), self.route_d))
 
     def pack(self, negotiated=None):
-        if self.packed:
+        if self._packed:
             return self._packed
         raise RuntimeError('Not implemented')
 

--- a/src/exabgp/bgp/message/update/nlri/bgpls/node.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/node.py
@@ -106,7 +106,7 @@ class NODE(BGPLS):
         return self.json()
 
     def __hash__(self):
-        return hash((self.proto_id, self.node_ids))
+        return hash((self.proto_id, tuple(self.node_ids)))
 
     def pack(self, negotiated=None):
         return self._pack

--- a/src/exabgp/bgp/message/update/nlri/bgpls/prefixv4.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/prefixv4.py
@@ -128,7 +128,7 @@ class PREFIXv4(BGPLS):
         return self.json()
 
     def __hash__(self):
-        return hash((self))
+        return hash((self.CODE, self.domain, self.proto_id, self.route_d))
 
     def json(self, compact=None):
         nodes = ', '.join(d.json() for d in self.local_node)

--- a/src/exabgp/bgp/message/update/nlri/bgpls/prefixv6.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/prefixv6.py
@@ -128,7 +128,7 @@ class PREFIXv6(BGPLS):
         return self.json()
 
     def __hash__(self):
-        return hash((self))
+        return hash((self.CODE, self.domain, self.proto_id, self.route_d))
 
     def json(self, compact=None):
         nodes = ', '.join(d.json() for d in self.local_node)


### PR DESCRIPTION
This commit fixes all 5 known bugs in BGP-LS NLRI classes that were preventing tests from running:

1. link.py:188 - Fixed RecursionError in __hash__ by hashing specific fields (CODE, domain, proto_id, topology_ids, route_d) instead of the entire object

2. link.py:191 - Fixed AttributeError by correcting pack() method to check self._packed instead of non-existent self.packed attribute

3. prefixv4.py:131 - Fixed RecursionError in __hash__ by hashing specific fields (CODE, domain, proto_id, route_d)

4. prefixv6.py:131 - Fixed RecursionError in __hash__ by hashing specific fields (CODE, domain, proto_id, route_d)

5. node.py:109 - Fixed TypeError by converting node_ids list to tuple before hashing (lists are unhashable)

All 57 BGP-LS tests now pass (previously 5 were skipped due to these bugs).