### PR TITLE
Debug test failures on macOS

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+# encoding: utf-8
+"""
+ExaBGP tests package.
+
+This file makes the tests directory a Python package,
+allowing imports like 'from tests.fuzz.update_helpers import ...'
+"""

--- a/tests/unit/test_network_tcp.py
+++ b/tests/unit/test_network_tcp.py
@@ -51,8 +51,9 @@ class TestSocketCreation:
         """Test that SO_REUSEADDR is set"""
         io = tcp.create(AFI.ipv4)
         # Get the socket option to verify it's set
+        # Note: On macOS, getsockopt may return 4 instead of 1, so check for truthy value
         reuse = io.getsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR)
-        assert reuse == 1
+        assert reuse != 0
         io.close()
 
     def test_create_socket_with_interface(self):
@@ -308,8 +309,9 @@ class TestNagleAlgorithm:
         tcp.nagle(io, '127.0.0.1')
 
         # Verify TCP_NODELAY is set
+        # Note: On macOS, getsockopt may return 4 instead of 1, so check for truthy value
         nodelay = io.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY)
-        assert nodelay == 1
+        assert nodelay != 0
 
         io.close()
 
@@ -542,7 +544,8 @@ class TestIntegration:
         tcp.asynchronous(io, '127.0.0.1')
 
         # Verify all settings
-        assert io.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY) == 1
+        # Note: On macOS, getsockopt may return 4 instead of 1, so check for truthy value
+        assert io.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY) != 0
         assert io.getblocking() is False
 
         io.close()
@@ -563,7 +566,8 @@ class TestIntegration:
             tcp.asynchronous(io, '::1')
 
             # Verify all settings
-            assert io.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY) == 1
+            # Note: On macOS, getsockopt may return 4 instead of 1, so check for truthy value
+            assert io.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY) != 0
             assert io.getblocking() is False
 
             io.close()


### PR DESCRIPTION
This commit addresses two categories of test failures on macOS:

1. Socket option assertion failures (test_network_tcp.py):
   - On macOS, getsockopt() returns 4 instead of 1 for enabled socket options
   - Changed assertions from `== 1` to `!= 0` to check for truthy values
   - Affected tests:
     * test_create_socket_sets_reuse_addr
     * test_nagle_disable_success * test_full_socket_setup_ipv4 * test_full_socket_setup_ipv6

2. Module import failures (test_update_message.py):
   - Added tests/__init__.py to make 'tests' a proper Python package
   - This allows imports like 'from tests.fuzz.update_helpers import ...'
   - Fixed all 20 test_update_message.py tests

All 59 tests now pass successfully.