### PR TITLE
Add lazy evaluation to logging calls

### DIFF
--- a/src/exabgp/bgp/message/update/__init__.py
+++ b/src/exabgp/bgp/message/update/__init__.py
@@ -286,14 +286,14 @@ class Update(Message):
         nlris = []
         while withdrawn:
             nlri, left = NLRI.unpack_nlri(AFI.ipv4, SAFI.unicast, withdrawn, Action.WITHDRAW, addpath)
-            log.debug('withdrawn NLRI %s' % nlri, 'routes')
+            logfunc.debug(lambda nlri=nlri: 'withdrawn NLRI %s' % nlri, 'routes')
             withdrawn = left
             nlris.append(nlri)
 
         while announced:
             nlri, left = NLRI.unpack_nlri(AFI.ipv4, SAFI.unicast, announced, Action.ANNOUNCE, addpath)
             nlri.nexthop = nexthop
-            log.debug('announced NLRI %s' % nlri, 'routes')
+            logfunc.debug(lambda nlri=nlri: 'announced NLRI %s' % nlri, 'routes')
             announced = left
             nlris.append(nlri)
 

--- a/src/exabgp/configuration/check.py
+++ b/src/exabgp/configuration/check.py
@@ -32,6 +32,7 @@ from exabgp.bgp.message.action import Action
 from exabgp.bgp.message.direction import Direction
 
 from exabgp.logger import log
+from exabgp.logger import logfunc
 from exabgp.logger import option
 
 # check_neighbor
@@ -104,8 +105,8 @@ def check_generation(neighbors):
             log.debug('parsed route requires %d updates' % len(packed), 'parser')
             log.debug('update size is %d' % len(pack1), 'parser')
 
-            log.debug('parsed route %s' % str1, 'parser')
-            log.debug('parsed hex   %s' % od(pack1), 'parser')
+            logfunc.debug(lambda: 'parsed route %s' % str1, 'parser')
+            logfunc.debug(lambda: 'parsed hex   %s' % od(pack1), 'parser')
 
             # This does not take the BGP header - let's assume we will not break that :)
             try:
@@ -118,8 +119,8 @@ def check_generation(neighbors):
                 str2 = change2.extensive()
                 pack2 = list(Update([update.nlris[0]], update.attributes).messages(negotiated))[0]
 
-                log.debug('recoded route %s' % str2, 'parser')
-                log.debug('recoded hex   %s' % od(pack2), 'parser')
+                logfunc.debug(lambda: 'recoded route %s' % str2, 'parser')
+                logfunc.debug(lambda: 'recoded hex   %s' % od(pack2), 'parser')
 
                 str1 = str1.replace('attribute [ 0x04 0x80 0x00000064 ]', 'med 100')
                 str1r = (
@@ -166,15 +167,15 @@ def check_generation(neighbors):
                     log.debug('skipping encoding for update with non-transitive attribute(s)', 'parser')
                 elif pack1 != pack2:
                     log.debug('encoding are different', 'parser')
-                    log.debug('[%s]' % (od(pack1)), 'parser')
-                    log.debug('[%s]' % (od(pack2)), 'parser')
+                    logfunc.debug(lambda: '[%s]' % (od(pack1)), 'parser')
+                    logfunc.debug(lambda: '[%s]' % (od(pack2)), 'parser')
                     return False
                 else:
                     log.debug('encoding is fine', 'parser')
                     log.debug('----------------------------------------', 'parser')
 
-                log.debug('JSON nlri %s' % change1.nlri.json(), 'parser')
-                log.debug('JSON attr %s' % change1.attributes.json(), 'parser')
+                logfunc.debug(lambda: 'JSON nlri %s' % change1.nlri.json(), 'parser')
+                logfunc.debug(lambda: 'JSON attr %s' % change1.attributes.json(), 'parser')
 
             except Notify as exc:
                 log.debug('----------------------------------------', 'parser')
@@ -253,7 +254,7 @@ def _make_nlri(neighbor, routes):
     nlris = []
     try:
         while announced:
-            log.debug('parsing NLRI %s' % announced, 'parser')
+            logfunc.debug(lambda announced=announced: 'parsing NLRI %s' % announced, 'parser')
             nlri, announced = NLRI.unpack_nlri(afi, safi, announced, Action.ANNOUNCE, addpath)
             nlris.append(nlri)
     except Exception as exc:
@@ -275,7 +276,7 @@ def check_nlri(neighbor, routes):
 
     log.debug('', 'parser')  # new line
     for nlri in nlris:
-        log.info('nlri json %s' % nlri.json(), 'parser')
+        logfunc.info(lambda nlri=nlri: 'nlri json %s' % nlri.json(), 'parser')
     return True
 
 
@@ -417,8 +418,8 @@ def check_update(neighbor, raw):
     log.debug('', 'parser')  # new line
     for number in range(len(update.nlris)):
         change = Change(update.nlris[number], update.attributes)
-        log.info('decoded %s %s %s' % ('update', change.nlri.action, change.extensive()), 'parser')
-    log.info('update json %s' % Response.JSON(json_version).update(neighbor, 'in', update, None, '', ''), 'parser')
+        logfunc.info(lambda change=change: 'decoded %s %s %s' % ('update', change.nlri.action, change.extensive()), 'parser')
+    logfunc.info(lambda: 'update json %s' % Response.JSON(json_version).update(neighbor, 'in', update, None, '', ''), 'parser')
 
     return True
 

--- a/src/exabgp/reactor/protocol.py
+++ b/src/exabgp/reactor/protocol.py
@@ -44,6 +44,7 @@ from exabgp.bgp.message.update.attribute import Attribute
 from exabgp.protocol.ip import IP
 
 from exabgp.logger import log
+from exabgp.logger import logfunc
 
 # This is the number of chuncked message we are willing to buffer, not the number of routes
 MAX_BACKLOG = 15000
@@ -467,11 +468,11 @@ class Protocol(object):
     def new_operational(self, operational, negotiated):
         for _ in self.write(operational, negotiated):
             yield _NOP
-        log.debug('>> OPERATIONAL %s' % str(operational), self.connection.session())
+        logfunc.debug(lambda: '>> OPERATIONAL %s' % str(operational), self.connection.session())
         yield operational
 
     def new_refresh(self, refresh):
         for _ in self.write(refresh, None):
             yield _NOP
-        log.debug('>> REFRESH %s' % str(refresh), self.connection.session())
+        logfunc.debug(lambda: '>> REFRESH %s' % str(refresh), self.connection.session())
         yield refresh

--- a/src/exabgp/rib/outgoing.py
+++ b/src/exabgp/rib/outgoing.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from exabgp.logger import log
+from exabgp.logger import logfunc
 
 from exabgp.protocol.family import AFI
 from exabgp.protocol.family import SAFI
@@ -156,7 +157,7 @@ class OutgoingRIB(Cache):
                 self._watchdog[watchdog]['+'].pop(change.index())
 
     def del_from_rib(self, change):
-        log.debug('remove %s' % change, 'rib')
+        logfunc.debug(lambda: 'remove %s' % change, 'rib')
 
         change_index = change.index()
         change_family = change.nlri.family().afi_safi()
@@ -181,7 +182,7 @@ class OutgoingRIB(Cache):
         self._refresh_changes.append(change)
 
     def add_to_rib(self, change, force=False):
-        log.debug('insert %s' % change, 'rib')
+        logfunc.debug(lambda: 'insert %s' % change, 'rib')
 
         if not force and self.in_cache(change):
             return


### PR DESCRIPTION
This commit improves performance by converting expensive logging calls to use lazy evaluation (logfunc), preventing string formatting and object serialization when logging is disabled for a given source.

Changes:
- configuration/check.py: Convert calls using od(), .json(), and .extensive() methods to use logfunc with lambdas
- rib/outgoing.py: Convert RIB change logging to use lazy evaluation
- bgp/message/update/__init__.py: Convert NLRI logging to lazy evaluation
- reactor/protocol.py: Convert operational and refresh message logging to lazy evaluation

Impact:
- Eliminates expensive string formatting when logging is disabled
- Prevents calling od() (binary data formatting) when not needed
- Prevents JSON serialization when logs are disabled
- Improves performance in high-throughput scenarios

The lazy evaluation pattern defers all formatting operations until after checking if the logging source is enabled, providing significant performance improvements when logging is disabled or filtered.