### PR TITLE
Fix variable name error in daemon.py f-string conversion

### DIFF
--- a/src/exabgp/reactor/daemon.py
+++ b/src/exabgp/reactor/daemon.py
@@ -174,7 +174,7 @@ class Daemon(object):
 
         logging = getenv().log
         if logging.enable and logging.destination.lower() in ('stdout', 'stderr'):
-            log.critical(f'ExaBGP can not fork when logs are going to {log.destination.lower()}', 'daemon')
+            log.critical(f'ExaBGP can not fork when logs are going to {logging.destination.lower()}', 'daemon')
             return
 
         def fork_exit():


### PR DESCRIPTION
Fixed bug in daemon.py:177 where the f-string conversion incorrectly used 'log.destination.lower()' instead of 'logging.destination.lower()'.

The variable 'logging' is assigned from getenv().log on line 175, but the f-string was referencing the 'log' module instead of the 'logging' local variable, causing an AttributeError at runtime.

This bug was introduced in commit b022530 during Phase 2 of the f-string conversion.

The error would occur when ExaBGP tries to daemonize while logging to stdout or stderr.