### PR TITLE
Change Flake8 for Ruff

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -31,10 +31,6 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r qa/requirements.txt
 
-      - name: flake8
-        run: |
-          flake8 . --max-line-length 120 --exclude src/exabgp/vendoring/ --exclude build/ --exclude site-packages --count --select=E9,F63,F7,F82 --show-source --statistics
-
       - name: ruff
         run: |
-          ruff check src
+          ruff check . --output-format=full --statistics

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,15 @@ markers = [
 
 [tool.ruff]
 line-length = 120
-exclude = ["dev", "lib/exabgp/vendoring"]
+exclude = ["dev", "lib/exabgp/vendoring", "build", "site-packages", "src/exabgp/vendoring"]
+
+[tool.ruff.lint]
+# Select same critical error codes as flake8 configuration:
+# E9: Runtime/syntax errors
+# F63: Invalid print statements
+# F7: Syntax errors in docstrings and type comments
+# F82: Undefined names in __all__
+select = ["E9", "F63", "F7", "F82"]
 
 [tool.ruff.format]
 quote-style = "single"

--- a/qa/requirements.txt
+++ b/qa/requirements.txt
@@ -1,6 +1,5 @@
 # running the test suite/code
 ruff
-flake8
 coveralls
 nose
 psutil


### PR DESCRIPTION
- Configure ruff in pyproject.toml to check same critical error codes as flake8 (E9, F63, F7, F82)
- Update linting workflow to use ruff instead of flake8
- Remove flake8 from dependencies as it's now fully replaced by ruff
- Maintain same exclusions (vendoring, build, site-packages) and line length (120)