### PR TITLE
Lookup ip and ifconfig from path in healthcheck

### DIFF
--- a/src/exabgp/application/healthcheck.py
+++ b/src/exabgp/application/healthcheck.py
@@ -240,7 +240,7 @@ def system_ips(
         labelre = re.compile(r'.*\s+(?:' + '|'.join(ifnames) + r'):(?P<label>[^\\\s]+).*')
         for ifname in ifnames:
             cmd = subprocess.Popen(
-                f'/sbin/ip -o address show dev {ifname}'.split(), shell=False, stdout=subprocess.PIPE
+                ["ip", "-o", "address", "show", "dev", ifname], shell=False, stdout=subprocess.PIPE
             )
             if cmd.stdout is not None:
                 output += [line for line in cmd.stdout]
@@ -253,7 +253,7 @@ def system_ips(
         )
         labelre = re.compile(r'')
         for ifname in ifnames:
-            cmd = subprocess.Popen(f'/sbin/ifconfig {ifname}'.split(), shell=False, stdout=subprocess.PIPE)
+            cmd = subprocess.Popen(["ifconfig", ifname], shell=False, stdout=subprocess.PIPE)
             if cmd.stdout is not None:
                 output += [line for line in cmd.stdout]
     for line_bytes in output or []:


### PR DESCRIPTION
With Popen we can rely on lookups in the PATH variable to find ip and ifconfig and stop making assumptions about its locations.

Fixes the following problem in 5.0.1 on nixpkgs. The `ifconfig` change is here for good measure.

```pytb
❯ ./result/bin/exabgp-healthcheck
ERROR[healthcheck] Uncaught exception: [Errno 2] No such file or directory: '/sbin/ip'
Traceback (most recent call last):
  File "/nix/store/2n48xsia16388z7rcqazvvv5p1vknp9r-exabgp-5.0.1/lib/python3.13/site-packages/exabgp/application/healthcheck.py", line 597, in main
    options.ips = options.ips or system_ips(None, options.label, False, options.label_exact_match)
                                 ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/2n48xsia16388z7rcqazvvv5p1vknp9r-exabgp-5.0.1/lib/python3.13/site-packages/exabgp/application/healthcheck.py", line 225, in system_ips
    cmd = subprocess.Popen(f'/sbin/ip -o address show dev {ifname}'.split(), shell=False, stdout=subprocess.PIPE)
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/subprocess.py", line 1039, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                        pass_fds, cwd, env,
                        ^^^^^^^^^^^^^^^^^^^
    ...<5 lines>...
                        gid, gids, uid, umask,
                        ^^^^^^^^^^^^^^^^^^^^^^
                        start_new_session, process_group)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/subprocess.py", line 1857, in _execute_child
    self._posix_spawn(args, executable, env, restore_signals, close_fds,
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                      p2cread, p2cwrite,
                      ^^^^^^^^^^^^^^^^^^
                      c2pread, c2pwrite,
                      ^^^^^^^^^^^^^^^^^^
                      errread, errwrite)
                      ^^^^^^^^^^^^^^^^^^
  File "/nix/store/3lll9y925zz9393sa59h653xik66srjb-python3-3.13.9/lib/python3.13/subprocess.py", line 1801, in _posix_spawn
    self.pid = os.posix_spawn(executable, args, env, **kwargs)
               ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/sbin/ip'
```