### PR TITLE
feat(bgpls): add Delay Metric and Local/Remote ID TLVs / 5.0 backport

### DIFF
--- a/src/exabgp/bgp/message/update/attribute/bgpls/__init__.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/__init__.py
@@ -41,3 +41,5 @@ from exabgp.bgp.message.update.attribute.bgpls.link.sradjlan import SrAdjacencyL
 from exabgp.bgp.message.update.attribute.bgpls.prefix.srprefix import SrPrefix
 from exabgp.bgp.message.update.attribute.bgpls.prefix.srigpprefixattr import SrIgpPrefixAttr
 from exabgp.bgp.message.update.attribute.bgpls.prefix.srrid import SrSourceRouterID
+from exabgp.bgp.message.update.attribute.bgpls.link.delaymetric import DelayMetric
+from exabgp.bgp.message.update.attribute.bgpls.link.localremoteid import LinkLocalRemoteIdentifiers

--- a/src/exabgp/bgp/message/update/attribute/bgpls/link/__init__.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/link/__init__.py
@@ -86,3 +86,30 @@ from exabgp.bgp.message.update.attribute.bgpls.link.srv6capabilities import Srv6
 from exabgp.bgp.message.update.attribute.bgpls.link.srv6locator import Srv6Locator
 from exabgp.bgp.message.update.attribute.bgpls.link.srv6endpointbehavior import Srv6EndpointBehavior
 from exabgp.bgp.message.update.attribute.bgpls.link.srv6lanendx import Srv6LanEndXISIS, Srv6LanEndXOSPF
+#  +================+===========================================+===========+
+#  | TLV Code Point | Description                               | Reference |
+#  +================+===========================================+===========+
+#  | 1114           | Unidirectional Link Delay                 | RFC 8571  |
+#  | 1115           | Min/Max Unidirectional Link Delay         | RFC 8571  |
+#  | 1116           | Unidirectional Delay Variation            | RFC 8571  |
+#  | 1117           | Unidirectional Link Loss                  | RFC 8571  |
+#  | 1118           | Unidirectional Residual Bandwidth         | RFC 8571  |
+#  | 1119           | Unidirectional Available Bandwidth        | RFC 8571  |
+#  | 1120           | Unidirectional Utilized Bandwidth         | RFC 8571  |
+#  +----------------+-------------------------------------------+-----------+
+from exabgp.bgp.message.update.attribute.bgpls.link.delaymetric import (
+    UnidirectionalLinkDelay,
+    MinMaxUnidirectionalLinkDelay,
+    UnidirectionalDelayVariation,
+    UnidirectionalLinkLoss,
+    UnidirectionalResidualBandwidth,
+    UnidirectionalAvailableBandwidth,
+    UnidirectionalUtilizedBandwidth,
+)
+
+#  +----------------+-------------------------------+-----------+
+#  | TLV Code Point | Description                    | Reference |
+#  +----------------+-------------------------------+-----------+
+#  |  258           | Link Local/Remote Identifiers  | RFC 5307  |
+#  +----------------+-------------------------------+-----------+
+from exabgp.bgp.message.update.attribute.bgpls.link.localremoteid import LinkLocalRemoteIdentifiers

--- a/src/exabgp/bgp/message/update/attribute/bgpls/link/delaymetric.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/link/delaymetric.py
@@ -1,0 +1,154 @@
+# encoding: utf-8
+"""
+delaymetric.py
+
+Created by (you).
+"""
+
+from __future__ import annotations
+
+from struct import unpack
+
+from exabgp.bgp.message.update.attribute.bgpls.linkstate import LinkState
+from exabgp.bgp.message.update.attribute.bgpls.linkstate import BaseLS
+
+
+def _u24(b: bytes) -> int:
+    # Convert 3 bytes (big-endian) to int
+    # Expect exactly 3 bytes (bytes[1:4] slices below always pass 3 bytes)
+    return unpack('!L', b'\x00' + b)[0]
+
+
+# 1114 - Unidirectional Link Delay
+# Layout (RFC 8571): byte0 A|RESERVED, bytes1..3 Delay(u24, microseconds)
+@LinkState.register()
+class UnidirectionalLinkDelay(BaseLS):
+    TLV = 1114
+    REPR = 'Unidirectional Link Delay'
+    JSON = 'unidirectional-link-delay'
+    LEN = 4
+
+    @classmethod
+    def unpack(cls, data: bytes):
+        cls.check(data)
+        anomalous = bool(data[0] & 0x80)
+        delay_us = _u24(data[1:4])
+        return cls({'delay-us': delay_us, 'anomalous': anomalous})
+
+
+# 1115 - Min/Max Unidirectional Link Delay
+# Layout (RFC 8571): byte0 A|RESERVED, bytes1..3 Min(u24), byte4 RESERVED, bytes5..7 Max(u24)
+@LinkState.register()
+class MinMaxUnidirectionalLinkDelay(BaseLS):
+    TLV = 1115
+    REPR = 'Min/Max Unidirectional Link Delay'
+    JSON = 'minmax-unidirectional-link-delay'
+    LEN = 8
+
+    @classmethod
+    def unpack(cls, data: bytes):
+        cls.check(data)
+        anomalous = bool(data[0] & 0x80)
+        min_delay_us = _u24(data[1:4])
+        max_delay_us = _u24(data[5:8])
+        return cls({'min-delay-us': min_delay_us, 'max-delay-us': max_delay_us, 'anomalous': anomalous})
+
+
+# 1116 - Unidirectional Delay Variation
+# Layout (RFC 8571): byte0 RESERVED, bytes1..3 Variation(u24, microseconds)
+@LinkState.register()
+class UnidirectionalDelayVariation(BaseLS):
+    TLV = 1116
+    REPR = 'Unidirectional Delay Variation'
+    JSON = 'unidirectional-delay-variation'
+    LEN = 4
+
+    @classmethod
+    def unpack(cls, data: bytes):
+        cls.check(data)
+        variation_us = _u24(data[1:4])
+        return cls(variation_us)
+
+
+# 1117 - Unidirectional Link Loss
+# Layout (RFC 8571): byte0 A|RESERVED, bytes1..3 Loss(u24), unidade = 0.000003% por unidade
+@LinkState.register()
+class UnidirectionalLinkLoss(BaseLS):
+    TLV = 1117
+    REPR = 'Unidirectional Link Loss'
+    JSON = 'unidirectional-link-loss'
+    LEN = 4
+
+    _UNIT_PERCENT = 0.000003  # 3e-6 percent per unit
+
+    @classmethod
+    def unpack(cls, data: bytes):
+        cls.check(data)
+        anomalous = bool(data[0] & 0x80)
+        enc = _u24(data[1:4])
+        loss_percent = enc * cls._UNIT_PERCENT
+        return cls({'loss-percent': loss_percent, 'anomalous': anomalous})
+
+
+# 1118 - Unidirectional Residual Bandwidth (IEEE-754 float, bytes/s)
+@LinkState.register()
+class UnidirectionalResidualBandwidth(BaseLS):
+    TLV = 1118
+    REPR = 'Unidirectional Residual Bandwidth'
+    JSON = 'unidirectional-residual-bandwidth'
+    LEN = 4
+
+    @classmethod
+    def unpack(cls, data: bytes):
+        cls.check(data)
+        return cls(unpack('!f', data)[0])
+
+
+# 1119 - Unidirectional Available Bandwidth (IEEE-754 float, bytes/s)
+@LinkState.register()
+class UnidirectionalAvailableBandwidth(BaseLS):
+    TLV = 1119
+    REPR = 'Unidirectional Available Bandwidth'
+    JSON = 'unidirectional-available-bandwidth'
+    LEN = 4
+
+    @classmethod
+    def unpack(cls, data: bytes):
+        cls.check(data)
+        return cls(unpack('!f', data)[0])
+
+
+# 1120 - Unidirectional Utilized Bandwidth (IEEE-754 float, bytes/s)
+@LinkState.register()
+class UnidirectionalUtilizedBandwidth(BaseLS):
+    TLV = 1120
+    REPR = 'Unidirectional Utilized Bandwidth'
+    JSON = 'unidirectional-utilized-bandwidth'
+    LEN = 4
+
+    @classmethod
+    def unpack(cls, data: bytes):
+        cls.check(data)
+        return cls(unpack('!f', data)[0])
+
+
+class DelayMetric(object):
+    """Convenience wrapper for delay-related link TLVs."""
+
+    TYPES = (
+        UnidirectionalLinkDelay,
+        MinMaxUnidirectionalLinkDelay,
+        UnidirectionalDelayVariation,
+        UnidirectionalLinkLoss,
+        UnidirectionalResidualBandwidth,
+        UnidirectionalAvailableBandwidth,
+        UnidirectionalUtilizedBandwidth,
+    )
+    BY_TLV = dict((klass.TLV, klass) for klass in TYPES)
+
+    @classmethod
+    def unpack(cls, tlv, data):
+        klass = cls.BY_TLV.get(tlv)
+        if klass is None:
+            return None
+        return klass.unpack(data)

--- a/src/exabgp/bgp/message/update/attribute/bgpls/link/localremoteid.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/link/localremoteid.py
@@ -1,0 +1,29 @@
+# encoding: utf-8
+"""
+localremoteid.py
+
+Created by Klaus Schneider.
+"""
+
+from __future__ import annotations
+
+from struct import unpack
+
+from exabgp.bgp.message.update.attribute.bgpls.linkstate import LinkState
+from exabgp.bgp.message.update.attribute.bgpls.linkstate import BaseLS
+
+
+# 258 - Link Local/Remote Identifiers (RFC 5307 carried in BGP-LS per RFC 7752)
+# Value length: 8 bytes -> Local Identifier (4 bytes) + Remote Identifier (4 bytes)
+@LinkState.register()
+class LinkLocalRemoteIdentifiers(BaseLS):
+    TLV = 258
+    REPR = 'Link Local/Remote Identifiers'
+    JSON = 'link-local-remote-identifiers'
+    LEN = 8
+
+    @classmethod
+    def unpack(cls, data):
+        cls.check(data)
+        local_id, remote_id = unpack('!II', data)
+        return cls({'local-id': local_id, 'remote-id': remote_id})


### PR DESCRIPTION
Summary
Backport of the Delay Metric and Local/Remote ID BGP-LS Link TLV support to the 5.0 branch, enabling ExaBGP to parse and emit link-level metric information. This is especially relevant for SDN use cases where controllers consume BGP-LS topology plus performance attributes (e.g., delay) for path computation, traffic engineering, and policy-driven automation.

Changes
Added new TLV implementations:
src/exabgp/bgp/message/update/attribute/bgpls/link/delaymetric.py
src/exabgp/bgp/message/update/attribute/bgpls/link/localremoteid.py
Wired the new TLVs into the BGP-LS Link encode/decode path (imports/registry/dispatch) following the existing project conventions.