### PR TITLE
fix: simplify INTERPRETER resolution in sbin/exabgp

### DIFF
--- a/sbin/exabgp
+++ b/sbin/exabgp
@@ -27,13 +27,7 @@ fi
 export EXABGP_ROOT=$path
 export PYTHONPATH="$path"/src
 
-# Prefer `python` binary when in a venv
-INTS="$INTERPRETER python3 python pypy3"
-if [ -d "${VIRTUAL_ENV}" ]; then
-    INTS="$INTERPRETER python3 python pypy3"
-fi
-
-for INTERPRETER in $(echo $INTS); do
+for INTERPRETER in $INTERPRETER python3 python pypy3; do
     INTERPRETER="$(command -v "$INTERPRETER")" && break
 done
 


### PR DESCRIPTION
Previously, a different set of interpreters were probed depending if we were in a virtualenv or not. This is not the case anymore since commit b205e80.