### PR TITLE
Immediately return empty Capabilties if length is 0

### DIFF
--- a/src/exabgp/bgp/message/open/capability/capabilities.py
+++ b/src/exabgp/bgp/message/open/capability/capabilities.py
@@ -246,6 +246,10 @@ class Capabilities(dict):
 
         # Extended optional parameters
         option_len = data[0]
+
+        if not option_len:
+            return capabilities
+
         option_type = data[1]
 
         if option_len == Capabilities.EXTENDED_LENGTH and option_type == Capabilities.EXTENDED_LENGTH:
@@ -256,8 +260,6 @@ class Capabilities(dict):
             data = data[1 : option_len + 1]
             decoder = _key_values
 
-        if not option_len:
-            return capabilities
 
         while data:
             key, value, data = decoder('parameter', data)


### PR DESCRIPTION
Receiving an open message with no capabilities was generating an exception due not immediately returning an empty set of capabilities if the capabilities length was 0 in the capability unpack function.