### PR TITLE
Add missing debug/__init__.py

### DIFF
--- a/src/exabgp/debug/__init__.py
+++ b/src/exabgp/debug/__init__.py
@@ -1,0 +1,14 @@
+"""debug/__init__.py
+
+Created by Thomas Mangin
+Copyright (c) 2009-2017 Exa Networks. All rights reserved.
+License: 3-clause BSD. (See the COPYRIGHT file)
+"""
+
+from __future__ import annotations
+
+from exabgp.debug.report import string_exception
+from exabgp.debug.report import format_exception
+from exabgp.debug.report import format_panic
+
+__all__ = ['string_exception', 'format_exception', 'format_panic']


### PR DESCRIPTION
The `__init__.py` from src/exabgp/debug seems to have disappeared at some point, it was re-added to the main branch but still seems to be missing from the 5.0 branch. This simply pulls the one from main into 5.0