### PR TITLE
A hostname that starts or ends with a digit should be considered valid.

### DIFF
--- a/src/exabgp/configuration/neighbor/parser.py
+++ b/src/exabgp/configuration/neighbor/parser.py
@@ -39,9 +39,11 @@ def inherit(tokeniser):
 
 def hostname(tokeniser):
     value = string(tokeniser)
+    if not value:
+        raise ValueError('bad host-name')
     if not value[0].isalnum():
         raise ValueError('bad host-name (alphanumeric)')
-    if not value[-1].isalnum() or value[-1].isdigit():
+    if not value[-1].isalnum():
         raise ValueError('bad host-name (alphanumeric)')
     if '..' in value:
         raise ValueError('bad host-name (double period)')
@@ -57,9 +59,9 @@ def domainname(tokeniser):
     value = string(tokeniser)
     if not value:
         raise ValueError('bad domain-name')
-    if not value[0].isalnum() or value[0].isdigit():
+    if not value[0].isalnum():
         raise ValueError('bad domain-name')
-    if not value[-1].isalnum() or value[-1].isdigit():
+    if not value[-1].isalnum():
         raise ValueError('bad domain-name')
     if '..' in value:
         raise ValueError('bad domain-name')


### PR DESCRIPTION
Hostnames should be able to start with a digit as well as end with one. 

We use several VMS for testing that end in numbers indicating the VM that is being accessed, and noticed that anytime we set the hostname on them exabgp would fail while parsing the hostname field in the config.