### PR TITLE
istty was generating an exception with syslog as the log destination

### DIFF
--- a/src/exabgp/logger/tty.py
+++ b/src/exabgp/logger/tty.py
@@ -18,4 +18,4 @@ _std = {
 
 
 def istty(std):
-    return _istty(_std[std])
+    return _istty(_std.get(std, None))


### PR DESCRIPTION
When you use a syslog as the log destination an exception is generated due to istty trying to get a non-existent key in the _std dictionary.