### PR TITLE
Add IPV6_EXTENDED_COMMUNITY to Attributes.representation

### DIFF
--- a/src/exabgp/bgp/message/update/attribute/attributes.py
+++ b/src/exabgp/bgp/message/update/attribute/attributes.py
@@ -108,6 +108,7 @@ class Attributes(dict):
         Attribute.CODE.ORIGINATOR_ID: ('inet', '', 'originator-id', '%s', '%s'),
         Attribute.CODE.CLUSTER_LIST: ('list', '', 'cluster-list', '%s', '%s'),
         Attribute.CODE.EXTENDED_COMMUNITY: ('list', '', 'extended-community', '%s', '%s'),
+        Attribute.CODE.IPV6_EXTENDED_COMMUNITY: ('list', '', 'extended-community-ipv6', '%s', '%s'),
         Attribute.CODE.PMSI_TUNNEL: ('string', '', 'pmsi', '%s', '%s'),
         Attribute.CODE.AIGP: ('integer', '', 'aigp', '%s', '%s'),
         Attribute.CODE.BGP_LS: ('list', '', 'bgp-ls', '%s', '%s'),


### PR DESCRIPTION
The IPV6_EXTENDED_COMMUNITY attribute code is currently missing the representation dictionary. This causes it to displayed using the "attribute-0x{:02X}-0x{:02X}" format, instead of using a more human readable name.