### PR TITLE
Rework the show adj-rib out json output

### DIFF
--- a/src/exabgp/bgp/message/update/attribute/aspath.py
+++ b/src/exabgp/bgp/message/update/attribute/aspath.py
@@ -162,6 +162,15 @@ class ASPath(Attribute):
         self._json = json.dumps(jason)
         return self._json
 
+    def as_dict(self):
+        result = {}
+        for pos, content in enumerate(self.aspath):
+            result[pos] = {
+                'element': content.NAME,
+                'value': list(content),
+            }
+        return result
+
     @classmethod
     def _new_aspaths(cls, data, asn4, klass=None):
         backup = data

--- a/src/exabgp/bgp/message/update/attribute/attributes.py
+++ b/src/exabgp/bgp/message/update/attribute/attributes.py
@@ -144,6 +144,33 @@ class Attributes(dict):
             else:
                 yield ' {} {}'.format(name, presentation % str(attribute))
 
+    def _generate_dict(self):
+        for code in sorted(self.keys()):
+            if code in Attributes.NO_GENERATION:
+                continue
+
+            attribute = self[code]
+
+            if code not in self.representation:
+                key = f"attribute-0x{code:02X}-0x{attribute.FLAG:02X}"
+                yield key, str(attribute)
+                continue
+
+            how, _, name, _, presentation = self.representation[code]
+            if how == 'boolean':
+                yield name, self.has(code)
+            elif how == 'string':
+                yield name, str(attribute)
+            elif how == 'list':
+                yield name, attribute.as_dict()
+            elif how == 'integer':
+                yield name, int(str(attribute))
+            elif how == 'inet':
+                yield name, str(attribute)
+            # Should never be ran
+            else:
+                yield name, str(attribute)
+
     def _generate_json(self):
         for code in sorted(self.keys()):
             # remove the next-hop from the attribute as it is define with the NLRI
@@ -180,6 +207,7 @@ class Attributes(dict):
         self._str = ''
         self._idx = ''
         self._json = ''
+        self._dict = {}
         # The parsed attributes have no mp routes and/or those are last
         self.cacheable = True
 
@@ -201,6 +229,7 @@ class Attributes(dict):
 
             self._str = ''
             self._json = ''
+            self._dict = {}
 
             for community in attribute.communities:
                 self[attribute.ID].add(community)
@@ -208,6 +237,8 @@ class Attributes(dict):
 
         self._str = ''
         self._json = ''
+        self._dict = {}
+
         self[attribute.ID] = attribute
 
     def remove(self, attrid):
@@ -267,6 +298,11 @@ class Attributes(dict):
             message += attribute.pack(negotiated)
 
         return message
+
+    def as_dict(self):
+        if not self._dict:
+            self._dict = dict(self._generate_dict())
+        return self._dict
 
     def json(self):
         if not self._json:

--- a/src/exabgp/bgp/message/update/attribute/bgpls/link/sradj.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/link/sradj.py
@@ -85,3 +85,13 @@ class SrAdjacency(FlagLS):
                 'undecoded-sids': self.undecoded,
             },
         )
+
+    def as_dict(self):
+        return {
+            "sr-adj": {
+                "flags": self.flags,
+                "sids": self.sids,
+                "weight": self.weight,
+                "undecoded-sids": self.undecoded,
+            }
+        }

--- a/src/exabgp/bgp/message/update/attribute/bgpls/link/sradjlan.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/link/sradjlan.py
@@ -89,5 +89,8 @@ class SrAdjacencyLan(FlagLS):
     def json(self, compact=None):
         return f'"sr-adj-lan-sids": {json.dumps(self.sr_adj_lan_sids)}'
 
+    def as_dict(self):
+        return {"sr-adj-lan-sids": self.sr_adj_lan_sids}
+
     def merge(self, klass):
         self.sr_adj_lan_sids.extend(klass.sr_adj_lan_sids)

--- a/src/exabgp/bgp/message/update/attribute/bgpls/link/srv6capabilities.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/link/srv6capabilities.py
@@ -58,3 +58,6 @@ class Srv6Capabilities(BaseLS):
             },
             indent=compact,
         )
+
+    def as_dict(self):
+        return {"srv6-capabilities": {"flags": self.flags}}

--- a/src/exabgp/bgp/message/update/attribute/bgpls/link/srv6endpointbehavior.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/link/srv6endpointbehavior.py
@@ -62,3 +62,12 @@ class Srv6EndpointBehavior(BaseLS):
             },
             indent=compact,
         )
+
+    def as_dict(self):
+        return {
+            "srv6-endpoint-behavior": {
+                "endpoint-behavior": self.endpoint_behavior,
+                "flags": self.flags,
+                "algorithm": self.algorithm,
+            }
+        }

--- a/src/exabgp/bgp/message/update/attribute/bgpls/link/srv6endx.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/link/srv6endx.py
@@ -102,3 +102,6 @@ class Srv6EndX(FlagLS):
 
     def json(self, compact=None):
         return '"srv6-endx": [ {} ]'.format(', '.join([json.dumps(d, indent=compact) for d in self.content]))
+
+    def as_dict(self):
+        return {"srv6-endx": self.content}

--- a/src/exabgp/bgp/message/update/attribute/bgpls/link/srv6lanendx.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/link/srv6lanendx.py
@@ -124,6 +124,9 @@ class Srv6LanEndXISIS(FlagLS):
     def json(self, compact=None):
         return '"srv6-lan-endx-isis": [ {} ]'.format(', '.join([json.dumps(d, indent=compact) for d in self.content]))
 
+    def as_dict(self):
+        return {"srv6-lan-endx-isis": self.content}
+
 
 @LinkState.register()
 class Srv6LanEndXOSPF(FlagLS):
@@ -162,3 +165,6 @@ class Srv6LanEndXOSPF(FlagLS):
 
     def json(self, compact=None):
         return '"srv6-lan-endx-ospf": [ {} ]'.format(', '.join([json.dumps(d, indent=compact) for d in self.content]))
+
+    def as_dict(self):
+        return {"srv6-lan-endx-ospf": self.content}

--- a/src/exabgp/bgp/message/update/attribute/bgpls/link/srv6locator.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/link/srv6locator.py
@@ -61,3 +61,12 @@ class Srv6Locator(FlagLS):
             },
             indent=compact,
         )
+
+    def as_dict(self):
+        return {
+            "srv6-locator": {
+                "flags": self.flags,
+                "algorithm": self.algorithm,
+                "metric": self.metric,
+            }
+        }

--- a/src/exabgp/bgp/message/update/attribute/bgpls/link/srv6sidstructure.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/link/srv6sidstructure.py
@@ -70,3 +70,13 @@ class Srv6SidStructure(BaseLS):
             },
             indent=compact,
         )
+
+    def as_dict(self):
+        return {
+            "srv6-sid-structure": {
+                "loc_block_len": self.loc_block_len,
+                "loc_node_len": self.loc_node_len,
+                "func_len": self.func_len,
+                "arg_len": self.arg_len,
+            }
+        }

--- a/src/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/linkstate.py
@@ -93,6 +93,12 @@ class LinkState(Attribute):
         content = ', '.join(d.json() for d in self.ls_attrs)
         return f'{{ {content} }}'
 
+    def as_dict(self):
+        result = {}
+        for d in self.ls_attrs:
+            result.update(d.as_dict())
+        return result
+
     def __str__(self):
         return ', '.join(str(d) for d in self.ls_attrs)
 
@@ -115,6 +121,11 @@ class BaseLS:
         except TypeError:
             # not a basic type
             return f'"{self.JSON}": "{self.content.decode("utf-8")}"'
+
+    def as_dict(self):
+        if isinstance(self.content, bytes):
+            return {self.JSON: self.content.decode("utf-8")}
+        return {self.JSON: self.content}
 
     def __repr__(self):
         return '{}: {}'.format(self.REPR, self.content)
@@ -153,6 +164,9 @@ class GenericLSID(BaseLS):
         merged = ', '.join([f'"{hexstring(_)}"' for _ in self.content])
         return f'"generic-lsid-{self.TLV}": [{merged}]'
 
+    def as_dict(self):
+        return {f"generic-lsid-{self.TLV}": [hexstring(c) for c in self.content]}
+
     @classmethod
     def unpack(cls, data):
         return cls(data)
@@ -167,6 +181,9 @@ class FlagLS(BaseLS):
 
     def json(self, compact=None):
         return f'"{self.JSON}": {json.dumps(self.flags)}'
+
+    def as_dict(self):
+        return {self.JSON: self.flags}
 
     @classmethod
     def unpack_flags(cls, data):

--- a/src/exabgp/bgp/message/update/attribute/bgpls/node/srcap.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/node/srcap.py
@@ -98,3 +98,8 @@ class SrCapabilities(FlagLS):
 
     def json(self, compact=None):
         return f'{FlagLS.json(self)}, "sids": {self.sids}'
+
+    def as_dict(self):
+        result = FlagLS.as_dict(self)
+        result["sids"] = self.sids
+        return result

--- a/src/exabgp/bgp/message/update/attribute/bgpls/prefix/srprefix.py
+++ b/src/exabgp/bgp/message/update/attribute/bgpls/prefix/srprefix.py
@@ -86,3 +86,11 @@ class SrPrefix(FlagLS):
 
     def json(self, compact=None):
         return f'"sr-prefix-flags": {json.dumps(self.flags)}, "sids": {json.dumps(self.sids)}, "undecoded-sids": {json.dumps(self.undecoded)}, "sr-algorithm": {json.dumps(self.sr_algo)}'
+
+    def as_dict(self):
+        return {
+            "sr-prefix-flags": self.flags,
+            "sids": self.sids,
+            "undecoded-sids": self.undecoded,
+            "sr-algorithm": self.sr_algo,
+        }

--- a/src/exabgp/bgp/message/update/attribute/clusterlist.py
+++ b/src/exabgp/bgp/message/update/attribute/clusterlist.py
@@ -52,6 +52,9 @@ class ClusterList(Attribute):
     def json(self):
         return '[ {} ]'.format(', '.join(['"{}"'.format(str(_)) for _ in self.clusters]))
 
+    def as_dict(self):
+        return [str(_) for _ in self.clusters]
+
     @classmethod
     def unpack(cls, data, direction, negotiated):
         clusters = []

--- a/src/exabgp/bgp/message/update/attribute/community/initial/communities.py
+++ b/src/exabgp/bgp/message/update/attribute/community/initial/communities.py
@@ -52,6 +52,9 @@ class Communities(Attribute):
             return repr(self.communities[0])
         return ''
 
+    def as_dict(self):
+        return [str(community) for community in self.communities]
+
     def json(self):
         return '[ {} ]'.format(', '.join(community.json() for community in self.communities))
 

--- a/src/exabgp/bgp/message/update/attribute/sr/labelindex.py
+++ b/src/exabgp/bgp/message/update/attribute/sr/labelindex.py
@@ -62,3 +62,6 @@ class SrLabelIndex:
 
     def json(self, compact=None):
         return '"sr-label-index": %d' % (self.labelindex)
+
+    def as_dict(self):
+        return {"sr-label-index": self.labelindex}

--- a/src/exabgp/bgp/message/update/attribute/sr/prefixsid.py
+++ b/src/exabgp/bgp/message/update/attribute/sr/prefixsid.py
@@ -67,6 +67,12 @@ class PrefixSid(Attribute):
         content = ', '.join(d.json() for d in self.sr_attrs)
         return f'{{ {content} }}'
 
+    def as_dict(self):
+        result = {}
+        for d in self.sr_attrs:
+            result.update(d.as_dict())
+        return result
+
     def __str__(self):
         # First, we try to decode path attribute for SR-MPLS
         label_index = next((i for i in self.sr_attrs if i.TLV == 1), None)
@@ -99,3 +105,6 @@ class GenericSRId:
 
     def json(self, compact=None):
         return '"attribute-not-implemented-{}": "{}"'.format(self.code, hexstring(self.rep))
+
+    def as_dict(self):
+        return {f"attribute-not-implemented-{self.code}": hexstring(self.rep)}

--- a/src/exabgp/bgp/message/update/attribute/sr/srgb.py
+++ b/src/exabgp/bgp/message/update/attribute/sr/srgb.py
@@ -77,3 +77,6 @@ class SrGb:
 
     def json(self, compact=None):
         return f'"sr-srgbs": {json.dumps(self.srgbs)}'
+
+    def as_dict(self):
+        return {"sr-srgbs": self.srgbs}

--- a/src/exabgp/bgp/message/update/attribute/sr/srv6/generic.py
+++ b/src/exabgp/bgp/message/update/attribute/sr/srv6/generic.py
@@ -17,6 +17,9 @@ class GenericSrv6ServiceSubTlv:
         # TODO:
         return ''
 
+    def as_dict(self):
+        return {"generic-sub-tlv": self.code}
+
     def pack(self):
         return self.packed
 
@@ -32,6 +35,9 @@ class GenericSrv6ServiceDataSubSubTlv:
     def json(self, compact=None):
         # TODO:
         return ''
+
+    def as_dict(self):
+        return {"generic-sub-sub-tlv": self.code}
 
     def pack(self):
         return self.packed

--- a/src/exabgp/bgp/message/update/attribute/sr/srv6/l2service.py
+++ b/src/exabgp/bgp/message/update/attribute/sr/srv6/l2service.py
@@ -76,3 +76,6 @@ class Srv6L2Service:
     def json(self, compact=None):
         content = '[ ' + ', '.join(subtlv.json() for subtlv in self.subtlvs) + ' ]'
         return '"l2-service": {}'.format(content)
+
+    def as_dict(self):
+        return {"l2-service": [subtlv.as_dict() for subtlv in self.subtlvs]}

--- a/src/exabgp/bgp/message/update/attribute/sr/srv6/l3service.py
+++ b/src/exabgp/bgp/message/update/attribute/sr/srv6/l3service.py
@@ -76,3 +76,6 @@ class Srv6L3Service:
     def json(self, compact=None):
         content = '[ ' + ', '.join(subtlv.json() for subtlv in self.subtlvs) + ' ]'
         return '"l3-service": {}'.format(content)
+
+    def as_dict(self):
+        return {"l3-service": [subtlv.as_dict() for subtlv in self.subtlvs]}

--- a/src/exabgp/bgp/message/update/attribute/sr/srv6/sidinformation.py
+++ b/src/exabgp/bgp/message/update/attribute/sr/srv6/sidinformation.py
@@ -106,3 +106,13 @@ class Srv6SidInformation:
             s += ', {}'.format(content)
         s += ' }'
         return s
+
+    def as_dict(self):
+        result = {
+            "sid": str(self.sid),
+            "flags": 0,
+            "endpoint_behavior": self.behavior,
+        }
+        for subsubtlv in self.subsubtlvs:
+            result.update(subsubtlv.as_dict())
+        return result

--- a/src/exabgp/bgp/message/update/attribute/sr/srv6/sidstructure.py
+++ b/src/exabgp/bgp/message/update/attribute/sr/srv6/sidstructure.py
@@ -96,3 +96,15 @@ class Srv6SidStructure:
         }
 
         return '"structure": {}'.format(json.dumps(pairs))
+
+    def as_dict(self):
+        return {
+            "structure": {
+                "locator-block-length": self.loc_block_len,
+                "locator-node-length": self.loc_node_len,
+                "function-length": self.func_len,
+                "argument-length": self.arg_len,
+                "transposition-length": self.tpose_len,
+                "transposition-offset": self.tpose_offset,
+            }
+        }

--- a/src/exabgp/bgp/message/update/nlri/bgpls/link.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/link.py
@@ -201,6 +201,20 @@ class LINK(BGPLS):
             return self._packed
         raise RuntimeError('Not implemented')
 
+    def as_dict(self):
+        nlri = BGPLS.as_dict(self)
+        nlri["parsed"] = True
+        nlri["l3-routing-topology"] = int(self.domain)
+        nlri["protocol-id"] = int(self.proto_id)
+        nlri["local-node-descriptors"] = [n.as_dict() for n in self.local_node]
+        nlri["remote-node-descriptors"] = [n.as_dict() for n in self.remote_node]
+        nlri["interface-addresses"] = [a.as_dict() for a in self.iface_addrs]
+        nlri["neighbor-addresses"] = [a.as_dict() for a in self.neigh_addrs]
+        nlri["multi-topology-ids"] = [t.as_dict() for t in self.topology_ids]
+        nlri["link-identifiers"] = [l.as_dict() for l in self.link_ids]
+        nlri["rd"] = None if self.route_d is None else self.route_d._str()
+        return nlri
+
     def json(self, compact=None):
         content = f'"ls-nlri-type": "{self.NAME}", '
         content += f'"l3-routing-topology": {int(self.domain)}, '

--- a/src/exabgp/bgp/message/update/nlri/bgpls/nlri.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/nlri.py
@@ -105,6 +105,16 @@ class BGPLS(NLRI):
             '0x' + ''.join('{:02x}'.format(_) for _ in self._packed),
         )
 
+    def as_dict(self):
+        family = self.family().afi_safi()
+        return {
+            "code": self.CODE,
+            "parsed": False,
+            "raw": self._raw(),
+            "name": self.NAME,
+            "family": {"afi": str(family[0]), "safi": str(family[1])},
+        }
+
     @classmethod
     def register(cls, klass):
         if klass.CODE in cls.registered_bgpls:

--- a/src/exabgp/bgp/message/update/nlri/bgpls/node.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/node.py
@@ -51,6 +51,16 @@ class NODE(BGPLS):
         self._pack = packed
         self.route_d = route_d
 
+    def as_dict(self):
+        nlri = BGPLS.as_dict(self)
+        nlri["parsed"] = True
+        nlri["l3-routing-topology"] = int(self.domain)
+        nlri["protocol-id"] = int(self.proto_id)
+        nlri["node-descriptors"] = [d.as_dict() for d in self.node_ids]
+        nlri["nexthop"] = None if self.nexthop is None else str(self.nexthop)
+        nlri["rd"] = None if self.route_d is None else self.route_d._str()
+        return nlri
+
     def json(self, compact=None):
         nodes = ', '.join(d.json() for d in self.node_ids)
         content = ', '.join(

--- a/src/exabgp/bgp/message/update/nlri/bgpls/prefixv4.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/prefixv4.py
@@ -134,6 +134,19 @@ class PREFIXv4(BGPLS):
     def __hash__(self):
         return hash((self.CODE, self.domain, self.proto_id, self.route_d))
 
+    def as_dict(self):
+        nlri = BGPLS.as_dict(self)
+        nlri["parsed"] = True
+        nlri["l3-routing-topology"] = int(self.domain)
+        nlri["protocol-id"] = int(self.proto_id)
+        nlri["node-descriptors"] = [d.as_dict() for d in self.local_node]
+        nlri.update(self.prefix.as_dict())
+        nlri["nexthop"] = None if self.nexthop is None else str(self.nexthop)
+        if self.ospf_type:
+            nlri.update(self.ospf_type.as_dict())
+        nlri["rd"] = None if self.route_d is None else self.route_d._str()
+        return nlri
+
     def json(self, compact=None):
         nodes = ', '.join(d.json() for d in self.local_node)
         content = ', '.join(

--- a/src/exabgp/bgp/message/update/nlri/bgpls/prefixv6.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/prefixv6.py
@@ -134,6 +134,19 @@ class PREFIXv6(BGPLS):
     def __hash__(self):
         return hash((self.CODE, self.domain, self.proto_id, self.route_d))
 
+    def as_dict(self):
+        nlri = BGPLS.as_dict(self)
+        nlri["parsed"] = True
+        nlri["l3-routing-topology"] = int(self.domain)
+        nlri["protocol-id"] = int(self.proto_id)
+        nlri["node-descriptors"] = [d.as_dict() for d in self.local_node]
+        nlri.update(self.prefix.as_dict())
+        nlri["nexthop"] = None if self.nexthop is None else str(self.nexthop)
+        if self.ospf_type:
+            nlri.update(self.ospf_type.as_dict())
+        nlri["rd"] = None if self.route_d is None else self.route_d._str()
+        return nlri
+
     def json(self, compact=None):
         nodes = ', '.join(d.json() for d in self.local_node)
         content = ', '.join(

--- a/src/exabgp/bgp/message/update/nlri/bgpls/srv6sid.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/srv6sid.py
@@ -109,6 +109,15 @@ class SRv6SID(BGPLS):
     def __repr__(self):
         return f'{self.NAME}(protocol_id={self.proto_id}, domain={self.domain})'
 
+    def as_dict(self):
+        nlri = BGPLS.as_dict(self)
+        nlri["parsed"] = True
+        nlri["l3-routing-topology"] = int(self.domain)
+        nlri["protocol-id"] = int(self.proto_id)
+        nlri["node-descriptors"] = [d.as_dict() for d in self.local_node_descriptors]
+        nlri["srv6-sid-descriptors"] = self.srv6_sid_descriptors
+        return nlri
+
     def json(self, compact=None):
         nodes = ', '.join(d.json() for d in self.local_node_descriptors)
         content = ', '.join(

--- a/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/ifaceaddr.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/ifaceaddr.py
@@ -40,6 +40,9 @@ class IfaceAddr:
     def json(self, compact=None):
         return '"{}"'.format(self.iface_address)
 
+    def as_dict(self):
+        return str(self.iface_address)
+
     def __eq__(self, other):
         return self.iface_address == other.iface_address
 

--- a/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/ipreach.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/ipreach.py
@@ -87,6 +87,12 @@ class IpReach:
             ],
         )
 
+    def as_dict(self):
+        return {
+            "ip-reachability-tlv": str(self.prefix),
+            "ip-reach-prefix": f"{self.prefix}/{self.plength}",
+        }
+
     def __eq__(self, other):
         return self.prefix == other.prefix
 

--- a/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/linkid.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/linkid.py
@@ -37,6 +37,9 @@ class LinkIdentifier:
         content = '"link-local-id": {}, '.format(self.local_id) + '"link-remote-id": {}'.format(self.remote_id)
         return content
 
+    def as_dict(self):
+        return {"link-local-id": self.local_id, "link-remote-id": self.remote_id}
+
     def __eq__(self, other):
         return (self.local_id == other.local_id) and (self.remote_id == other.remote_id)
 

--- a/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/multitopology.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/multitopology.py
@@ -68,6 +68,9 @@ class MTID:
         # tids = ', '.join(_ for _ in self.topologies)
         # return f'[{tids}]'
 
+    def as_dict(self):
+        return self.topologies
+
     def __eq__(self, other):
         return self.topologies == other.topologies
 

--- a/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/neighaddr.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/neighaddr.py
@@ -38,6 +38,9 @@ class NeighAddr:
     def json(self):
         return '"{}"'.format(self.addr)
 
+    def as_dict(self):
+        return str(self.addr)
+
     def __eq__(self, other):
         return self.addr == other.addr
 

--- a/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/node.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/node.py
@@ -147,6 +147,22 @@ class NodeDescriptor:
         content = ', '.join(_ for _ in [node, designated, psn] if _)
         return f'{{ {content} }}'
 
+    def as_dict(self):
+        result = {}
+        if self.node_type == NODE_DESC_TLV_AS:
+            result["autonomous-system"] = self.node_id
+        if self.node_type == NODE_DESC_TLV_BGPLS_ID:
+            result["bgp-ls-identifier"] = str(self.node_id)
+        if self.node_type == NODE_DESC_TLV_OSPF_AREA:
+            result["ospf-area-id"] = str(self.node_id)
+        if self.node_type == NODE_DESC_TLV_IGP_ROUTER:
+            result["router-id"] = str(self.node_id[0])
+        if self.dr_id:
+            result["designated-router-id"] = str(self.dr_id)
+        if self.psn:
+            result["psn"] = str(self.psn)
+        return result
+
     def __eq__(self, other):
         return isinstance(other, NodeDescriptor) and self.node_id == other.node_id
 

--- a/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/ospfroute.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/ospfroute.py
@@ -49,6 +49,9 @@ class OspfRoute:
         content = '"ospf-route-type": {}'.format(self.ospf_type)
         return content
 
+    def as_dict(self):
+        return {"ospf-route-type": self.ospf_type}
+
     def __eq__(self, other):
         return self.ospf_type == other.ospf_type
 

--- a/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/srv6sidinformation.py
+++ b/src/exabgp/bgp/message/update/nlri/bgpls/tlvs/srv6sidinformation.py
@@ -39,6 +39,9 @@ class Srv6SIDInformation:
     def json(self, compact=None):
         return '"srv6-sid": "{}"'.format(str(self.sid))
 
+    def as_dict(self):
+        return {"srv6-sid": str(self.sid)}
+
     def __eq__(self, other):
         return self.sid == other.sid
 

--- a/src/exabgp/bgp/message/update/nlri/evpn/ethernetad.py
+++ b/src/exabgp/bgp/message/update/nlri/evpn/ethernetad.py
@@ -81,6 +81,19 @@ class EthernetAD(EVPN):
 
         return cls(rd, esi, etag, label, data)
 
+    def as_dict(self):
+        nlri = EVPN.as_dict(self)
+        nlri["parsed"] = True
+        nlri["nexthop"] = None if self.nexthop is None else str(self.nexthop)
+        nlri["rd"] = None if self.rd is RouteDistinguisher.NORD else self.rd._str()
+        nlri["esi"] = str(self.esi)
+        nlri["ethernet-tag"] = self.etag.tag
+        label = []
+        for value, raw in zip(self.label.labels, self.label.raw_labels):
+            label.append([value] if raw is None else [value, raw])
+        nlri["label"] = label
+        return nlri
+
     def json(self, compact=None):
         content = ' "code": %d, ' % self.CODE
         content += '"parsed": true, '

--- a/src/exabgp/bgp/message/update/nlri/evpn/mac.py
+++ b/src/exabgp/bgp/message/update/nlri/evpn/mac.py
@@ -171,6 +171,22 @@ class MAC(EVPN):
 
         return cls(rd, esi, etag, mac, maclength, label, ip, data)
 
+    def as_dict(self):
+        nlri = EVPN.as_dict(self)
+        nlri["parsed"] = True
+        nlri["nexthop"] = None if self.nexthop is None else str(self.nexthop)
+        nlri["rd"] = None if self.rd is RouteDistinguisher.NORD else self.rd._str()
+        nlri["esi"] = str(self.esi)
+        nlri["ethernet-tag"] = self.etag.tag
+        nlri["mac"] = str(self.mac)
+        nlri["maclen"] = self.maclen
+        label = []
+        for value, raw in zip(self.label.labels, self.label.raw_labels):
+            label.append([value] if raw is None else [value, raw])
+        nlri["label"] = label
+        nlri["ip"] = None if self.ip is None else str(self.ip)
+        return nlri
+
     def json(self, compact=None):
         content = ' "code": %d, ' % self.CODE
         content += '"parsed": true, '

--- a/src/exabgp/bgp/message/update/nlri/evpn/multicast.py
+++ b/src/exabgp/bgp/message/update/nlri/evpn/multicast.py
@@ -76,6 +76,15 @@ class Multicast(EVPN):
         ip = IP.unpack(data[13 : 13 + iplen // 8])
         return cls(rd, etag, ip, data)
 
+    def as_dict(self):
+        nlri = EVPN.as_dict(self)
+        nlri["parsed"] = True
+        nlri["nexthop"] = None if self.nexthop is None else str(self.nexthop)
+        nlri["rd"] = None if self.rd is RouteDistinguisher.NORD else self.rd._str()
+        nlri["ethernet-tag"] = self.etag.tag
+        nlri["ip"] = None if self.ip is None else str(self.ip)
+        return nlri
+
     def json(self, compact=None):
         content = ' "code": %d, ' % self.CODE
         content += '"parsed": true, '

--- a/src/exabgp/bgp/message/update/nlri/evpn/nlri.py
+++ b/src/exabgp/bgp/message/update/nlri/evpn/nlri.py
@@ -68,6 +68,16 @@ class EVPN(NLRI):
     def _prefix(self):
         return 'evpn:{}:'.format(self.registered_evpn.get(self.CODE, self).SHORT_NAME.lower())
 
+    def as_dict(self):
+        family = self.family().afi_safi()
+        return {
+            "code": self.CODE,
+            "parsed": False,
+            "raw": self._raw(),
+            "name": self.NAME,
+            "family": {"afi": str(family[0]), "safi": str(family[1])},
+        }
+
     def pack_nlri(self, negotiated=None):
         # XXX: addpath not supported yet
         return pack('!BB', self.CODE, len(self._packed)) + self._packed

--- a/src/exabgp/bgp/message/update/nlri/evpn/prefix.py
+++ b/src/exabgp/bgp/message/update/nlri/evpn/prefix.py
@@ -167,6 +167,22 @@ class Prefix(EVPN):
 
         return cls(rd, esi, etag, label, ip, iplen, gwip, exdata)
 
+    def as_dict(self):
+        nlri = EVPN.as_dict(self)
+        nlri["parsed"] = True
+        nlri["nexthop"] = None if self.nexthop is None else str(self.nexthop)
+        nlri["rd"] = None if self.rd is RouteDistinguisher.NORD else self.rd._str()
+        nlri["esi"] = str(self.esi)
+        nlri["ethernet-tag"] = self.etag.tag
+        label = []
+        for value, raw in zip(self.label.labels, self.label.raw_labels):
+            label.append([value] if raw is None else [value, raw])
+        nlri["label"] = label
+        nlri["ip"] = str(self.ip)
+        nlri["iplen"] = self.iplen
+        nlri["gateway"] = str(self.gwip)
+        return nlri
+
     def json(self, compact=None):
         content = ' "code": %d, ' % self.CODE
         content += '"parsed": true, '

--- a/src/exabgp/bgp/message/update/nlri/evpn/segment.py
+++ b/src/exabgp/bgp/message/update/nlri/evpn/segment.py
@@ -98,6 +98,15 @@ class EthernetSegment(EVPN):
 
         return cls(rd, esi, ip, data)
 
+    def as_dict(self):
+        nlri = EVPN.as_dict(self)
+        nlri["parsed"] = True
+        nlri["nexthop"] = None if self.nexthop is None else str(self.nexthop)
+        nlri["rd"] = None if self.rd is RouteDistinguisher.NORD else self.rd._str()
+        nlri["esi"] = str(self.esi)
+        nlri["ip"] = None if self.ip is None else str(self.ip)
+        return nlri
+
     def json(self, compact=None):
         content = ' "code": %d, ' % self.CODE
         content += '"parsed": true, '

--- a/src/exabgp/bgp/message/update/nlri/flow.py
+++ b/src/exabgp/bgp/message/update/nlri/flow.py
@@ -633,6 +633,27 @@ class Flow(NLRI):
     def __str__(self):
         return self.extensive()
 
+    def as_dict(self):
+        family = self.family().afi_safi()
+        r = {}
+        for index in sorted(self.rules):
+            rules = self.rules[index]
+            s = []
+            for idx, rule in enumerate(rules):
+                if idx and rule.operations & NumericOperator.AND:
+                    s[-1] = f"{s[-1]}{rule}"
+                else:
+                    s.append(f"{rule}")
+            r[rules[0].NAME] = s
+
+        flow = {
+            "rules": r,
+            "nexthop": None if self.nexthop is NoNextHop else str(self.nexthop),
+            "rd": None if self.rd is RouteDistinguisher.NORD else self.rd._str(),
+            "family": {"afi": f"{family[0]}", "safi": f"{family[1]}"}
+        }
+        return flow
+
     def json(self, compact=None):
         string = []
         for index in sorted(self.rules):

--- a/src/exabgp/bgp/message/update/nlri/inet.py
+++ b/src/exabgp/bgp/message/update/nlri/inet.py
@@ -84,6 +84,14 @@ class INET(NLRI):
             return '"{}"'.format(self.cidr.prefix())
         return '{{ "nlri": "{}" }}'.format(self.cidr.prefix())
 
+    def as_dict(self):
+        family = self.family().afi_safi()
+        nlri = {"prefix": self.cidr.prefix(),
+                "nexthop": None if self.nexthop is NoNextHop else str(self.nexthop),
+                "family": {"afi": str(family[0]), "safi": str(family[1])}
+               }
+        return nlri
+
     @classmethod
     def _pathinfo(cls, data, addpath):
         if addpath:

--- a/src/exabgp/bgp/message/update/nlri/ipvpn.py
+++ b/src/exabgp/bgp/message/update/nlri/ipvpn.py
@@ -90,6 +90,12 @@ class IPVPN(Label):
             r.append(self.rd.json())
         return r
 
+    def as_dict(self):
+        nlri = Label.as_dict(self)
+        if self.rd is not RouteDistinguisher.NORD:
+            nlri["rd"] = self.rd._str()
+        return nlri
+
     # @classmethod
     # def _rd (cls, data, mask):
     # 	mask -= 8*8  # the 8 bytes of the route distinguisher

--- a/src/exabgp/bgp/message/update/nlri/label.py
+++ b/src/exabgp/bgp/message/update/nlri/label.py
@@ -71,6 +71,15 @@ class Label(INET):
             r.append(self.labels.json())
         return r
 
+    def as_dict(self):
+        nlri = INET.as_dict(self)
+        if self.labels.labels:
+            label = []
+            for value, raw in zip(self.labels.labels, self.labels.raw_labels):
+                label.append([value] if raw is None else [value, raw])
+            nlri["label"] = label
+        return nlri
+
     # @classmethod
     # def _labels (cls, data, action):
     # 	mask = data[0]

--- a/src/exabgp/bgp/message/update/nlri/mup/dsd.py
+++ b/src/exabgp/bgp/message/update/nlri/mup/dsd.py
@@ -80,6 +80,12 @@ class DirectSegmentDiscoveryRoute(MUP):
 
         return cls(rd, ip, afi)
 
+    def as_dict(self):
+        nlri = MUP.as_dict(self)
+        nlri["rd"] = None if self.rd is RouteDistinguisher.NORD else self.rd._str()
+        nlri["ip"] = str(self.ip)
+        return nlri
+
     def json(self, compact=None):
         content = '"name": "{}", '.format(self.NAME)
         content += '"arch": %d, ' % self.ARCHTYPE

--- a/src/exabgp/bgp/message/update/nlri/mup/isd.py
+++ b/src/exabgp/bgp/message/update/nlri/mup/isd.py
@@ -94,6 +94,13 @@ class InterworkSegmentDiscoveryRoute(MUP):
 
         return cls(rd, prefix_ip_len, prefix_ip, afi)
 
+    def as_dict(self):
+        nlri = MUP.as_dict(self)
+        nlri["rd"] = None if self.rd is RouteDistinguisher.NORD else self.rd._str()
+        nlri["prefix_ip_len"] = self.prefix_ip_len
+        nlri["prefix_ip"] = str(self.prefix_ip)
+        return nlri
+
     def json(self, compact=None):
         content = '"name": "{}", '.format(self.NAME)
         content += '"arch": %d, ' % self.ARCHTYPE

--- a/src/exabgp/bgp/message/update/nlri/mup/nlri.py
+++ b/src/exabgp/bgp/message/update/nlri/mup/nlri.py
@@ -64,6 +64,16 @@ class MUP(NLRI):
     def _prefix(self):
         return 'mup:{}:'.format(self.registered.get(self.CODE, self).SHORT_NAME.lower())
 
+    def as_dict(self):
+        family = self.family().afi_safi()
+        return {
+            "arch": self.ARCHTYPE,
+            "code": self.CODE,
+            "raw": self._raw(),
+            "name": self.NAME,
+            "family": {"afi": str(family[0]), "safi": str(family[1])},
+        }
+
     def pack_nlri(self, negotiated=None):
         return pack('!BHB', self.ARCHTYPE, self.CODE, len(self._packed)) + self._packed
 

--- a/src/exabgp/bgp/message/update/nlri/mup/t1st.py
+++ b/src/exabgp/bgp/message/update/nlri/mup/t1st.py
@@ -213,6 +213,19 @@ class Type1SessionTransformedRoute(MUP):
 
         return cls(rd, prefix_ip_len, prefix_ip, teid, qfi, endpoint_ip_len, endpoint_ip, source_ip_len, source_ip, afi)
 
+    def as_dict(self):
+        nlri = MUP.as_dict(self)
+        nlri["rd"] = None if self.rd is RouteDistinguisher.NORD else self.rd._str()
+        nlri["prefix_ip_len"] = self.prefix_ip_len
+        nlri["prefix_ip"] = str(self.prefix_ip)
+        nlri["teid"] = self.teid
+        nlri["qfi"] = self.qfi
+        nlri["endpoint_ip_len"] = self.endpoint_ip_len
+        nlri["endpoint_ip"] = str(self.endpoint_ip)
+        nlri["source_ip_len"] = self.source_ip_len
+        nlri["source_ip"] = str(self.source_ip)
+        return nlri
+
     def json(self, compact=None):
         content = '"name": "{}", '.format(self.NAME)
         content += '"arch": %d, ' % self.ARCHTYPE

--- a/src/exabgp/bgp/message/update/nlri/mup/t2st.py
+++ b/src/exabgp/bgp/message/update/nlri/mup/t2st.py
@@ -149,6 +149,14 @@ class Type2SessionTransformedRoute(MUP):
 
         return cls(rd, endpoint_len, endpoint_ip, teid, afi)
 
+    def as_dict(self):
+        nlri = MUP.as_dict(self)
+        nlri["rd"] = None if self.rd is RouteDistinguisher.NORD else self.rd._str()
+        nlri["endpoint_len"] = self.endpoint_len
+        nlri["endpoint_ip"] = str(self.endpoint_ip)
+        nlri["teid"] = self.teid
+        return nlri
+
     def json(self, compact=None):
         content = '"name": "{}", '.format(self.NAME)
         content += ' "arch": %d, ' % self.ARCHTYPE

--- a/src/exabgp/bgp/message/update/nlri/mvpn/nlri.py
+++ b/src/exabgp/bgp/message/update/nlri/mvpn/nlri.py
@@ -62,6 +62,16 @@ class MVPN(NLRI):
     def _prefix(self):
         return 'mvpn:{}:'.format(self.registered_mvpn.get(self.CODE, self).SHORT_NAME.lower())
 
+    def as_dict(self):
+        family = self.family().afi_safi()
+        return {
+            "code": self.CODE,
+            "parsed": False,
+            "raw": self._raw(),
+            "name": self.NAME,
+            "family": {"afi": str(family[0]), "safi": str(family[1])},
+        }
+
     def pack_nlri(self, negotiated=None):
         # XXX: addpath not supported yet
         return pack('!BB', self.CODE, len(self._packed)) + self._packed

--- a/src/exabgp/bgp/message/update/nlri/mvpn/sharedjoin.py
+++ b/src/exabgp/bgp/message/update/nlri/mvpn/sharedjoin.py
@@ -106,6 +106,15 @@ class SharedJoin(MVPN):
         groupip = IP.unpack(data[cursor : cursor + groupiplen])
         return cls(afi=afi, rd=rd, source=sourceip, group=groupip, source_as=source_as, packed=data)
 
+    def as_dict(self):
+        nlri = MVPN.as_dict(self)
+        nlri["parsed"] = True
+        nlri["rd"] = None if self.rd is RouteDistinguisher.NORD else self.rd._str()
+        nlri["source-as"] = self.source_as
+        nlri["source"] = str(self.source)
+        nlri["group"] = str(self.group)
+        return nlri
+
     def json(self, compact=None):
         content = ' "code": %d, ' % self.CODE
         content += '"parsed": true, '

--- a/src/exabgp/bgp/message/update/nlri/mvpn/sourcead.py
+++ b/src/exabgp/bgp/message/update/nlri/mvpn/sourcead.py
@@ -105,6 +105,14 @@ class SourceAD(MVPN):
 
         return cls(afi=afi, rd=rd, source=sourceip, group=groupip, packed=data)
 
+    def as_dict(self):
+        nlri = MVPN.as_dict(self)
+        nlri["parsed"] = True
+        nlri["rd"] = None if self.rd is RouteDistinguisher.NORD else self.rd._str()
+        nlri["source"] = str(self.source)
+        nlri["group"] = str(self.group)
+        return nlri
+
     def json(self, compact=None):
         content = ' "code": %d, ' % self.CODE
         content += '"parsed": true, '

--- a/src/exabgp/bgp/message/update/nlri/mvpn/sourcejoin.py
+++ b/src/exabgp/bgp/message/update/nlri/mvpn/sourcejoin.py
@@ -106,6 +106,15 @@ class SourceJoin(MVPN):
         groupip = IP.unpack(data[cursor : cursor + groupiplen])
         return cls(afi=afi, rd=rd, source=sourceip, group=groupip, source_as=source_as, packed=data)
 
+    def as_dict(self):
+        nlri = MVPN.as_dict(self)
+        nlri["parsed"] = True
+        nlri["rd"] = None if self.rd is RouteDistinguisher.NORD else self.rd._str()
+        nlri["source-as"] = self.source_as
+        nlri["source"] = str(self.source)
+        nlri["group"] = str(self.group)
+        return nlri
+
     def json(self, compact=None):
         content = ' "code": %d, ' % self.CODE
         content += '"parsed": true, '

--- a/src/exabgp/bgp/message/update/nlri/rtc.py
+++ b/src/exabgp/bgp/message/update/nlri/rtc.py
@@ -59,6 +59,16 @@ class RTC(NLRI):
     def __repr__(self):
         return str(self)
 
+    def as_dict(self):
+        family = self.family().afi_safi()
+        nlri = {
+            "origin": int(self.origin) if self.rt else None,
+            "rt": str(self.rt) if self.rt else None,
+            "nexthop": None if self.nexthop is NoNextHop else str(self.nexthop),
+            "family": {"afi": str(family[0]), "safi": str(family[1])},
+        }
+        return nlri
+
     @staticmethod
     def resetFlags(char):
         return char & ~(Attribute.Flag.TRANSITIVE | Attribute.Flag.OPTIONAL)

--- a/src/exabgp/bgp/message/update/nlri/vpls.py
+++ b/src/exabgp/bgp/message/update/nlri/vpls.py
@@ -70,6 +70,19 @@ class VPLS(NLRI):
             + pack('!L', (self.base << 4) | 0x1)[1:]  # setting the bottom of stack, should we ?
         )
 
+    def as_dict(self):
+        family = self.family().afi_safi()
+        nlri = {
+            "rd": self.rd._str() if self.rd.rd else None,
+            "endpoint": self.endpoint,
+            "base": self.base,
+            "offset": self.offset,
+            "size": self.size,
+            "nexthop": None if self.nexthop is None else str(self.nexthop),
+            "family": {"afi": str(family[0]), "safi": str(family[1])},
+        }
+        return nlri
+
     # XXX: FIXME: we need an unique key here.
     # XXX: What can we use as unique key ?
     def json(self, compact=None):

--- a/src/exabgp/reactor/api/command/rib.py
+++ b/src/exabgp/reactor/api/command/rib.py
@@ -45,29 +45,21 @@ def _show_adjrib_callback(reactor, service, last, route_type, advertised, rib_na
         jason = {}
         neighbor = reactor.neighbor(key)
         neighbor_ip = reactor.neighbor_ip(key)
-        routes = jason.setdefault(neighbor_ip, {'routes': []})['routes']
+        jason = {"peer": {"address": neighbor_ip}}
 
         if extensive:
-            jason[neighbor_ip].update(NeighborTemplate.to_json(neighbor))
+            jason.update(NeighborTemplate.as_dict(reactor.neighbor_cli_data(key)))
 
         for change in changes:
             if not isinstance(change.nlri, route_type):
                 # log something about this drop?
                 continue
-
-            routes.append(
-                {
-                    'prefix': str(change.nlri.cidr.prefix()),
-                    'family': str(change.nlri.family()).strip('()').replace(',', ''),
-                },
-            )
-
-            for line in json.dumps(jason).split('\n'):
-                reactor.processes.write(service, line)
+            jason["route"] = change.as_dict()
+            reactor.processes.write(service, json.dumps(jason))
 
     def callback():
         lines_per_yield = getenv().api.chunk
-        if last in ('routes', 'extensive', 'static', 'flow', 'l2vpn'):
+        if last in ('routes', 'extensive', 'static', 'inet', 'flow', 'l2vpn'):
             peers = reactor.peers()
         else:
             peers = [n for n in reactor.peers() if f'neighbor {last}' in n]

--- a/src/exabgp/rib/change.py
+++ b/src/exabgp/rib/change.py
@@ -42,6 +42,9 @@ class Change:
     def __ge__(self, other):
         raise RuntimeError('comparing Change for ordering does not make sense')
 
+    def as_dict(self):
+        return {"nlri": self.nlri.as_dict(), "attributes": self.attributes.as_dict()}
+
     def extensive(self):
         # If you change this you must change as well extensive in Update
         return f'{self.nlri!s}{self.attributes!s}'


### PR DESCRIPTION
This commit is a bit more extensive but there are currently several broken issues with the json output for the "show adj-rib" command. 

The first is that it doesn't work when trying to uses the extensive modifier the whole command throws an exception and errors out. 

Secondly they way it is currently written it only works it will only work when all your routes are inet based due to its use of calling cider.prefix() on each nlri.

There were also some issues when changing the api.chunk setting causing it to return the same routes multiple times.

This command had several issues with it that made it not work.
   * Extensive option was throwing an exception when used.
   * Listing the routes only worked for inet nrlis.
   * Splitting json.dumps at newline is not needed, as it only outputs a single line.
   * No longer include an array of routes, this was not really behaving as intended with api.chuncks set to any value higher then 1 and in that case the array only ever had one value anyways.