### PR TITLE
Add FlowSpec traffic-rate-packets action (RFC 8955)

### DIFF
--- a/etc/exabgp/conf-flow.conf
+++ b/etc/exabgp/conf-flow.conf
@@ -39,6 +39,8 @@ neighbor 127.0.0.1 {
 
 		route another { match { source 10.0.0.0/24; destination-port =3128; protocol tcp; } then { rate-limit 9600; } }
 
+		route another-but-packets { match { source 10.0.1.0/24; destination-port =3128; protocol tcp; } then { rate-limit-packets 1000; } }
+
 		route first-redirect {
 			match {
 				source 10.0.0.9/32;

--- a/qa/bin/test_api_encode
+++ b/qa/bin/test_api_encode
@@ -978,6 +978,9 @@ neighbor {neighbor_ip} {{
                             if ec.startswith("rate-limit:"):
                                 rate = ec.split(":")[1]
                                 config_parts.append(f"rate-limit {rate}")
+                            elif ec.startswith("rate-limit-packets:"):
+                                rate = ec.split(":")[1]
+                                config_parts.append(f"rate-limit-packets {rate}")
                             elif ec == "copy-to-nexthop":
                                 # copy X sets both nexthop and copy-to-nexthop EC
                                 if next_hop:

--- a/qa/decoding/bgp-flow-5
+++ b/qa/decoding/bgp-flow-5
@@ -1,0 +1,3 @@
+update ipv4 flow
+FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF:003E:02:000000274001010040020040050400000064C01008800C000000000000800E0B0001850000050901048109
+{ "exabgp": "5.0.0", "time": 1681807093.9168482, "host" : "MacBook-Pro-2.local", "pid" : 2730, "ppid" : 864, "counter": 1, "type": "update", "neighbor": {     "address": { "local": "127.0.0.1", "peer": "127.0.0.1" },     "asn": { "local": 65533, "peer": 65533 }, "router-id": "127.0.0.1" , "direction": "in", "message": { "update": { "attribute": { "origin": "igp", "local-preference": 100, "extended-community": [ { "value": 9226749736575303680, "string": "rate-limit-packets:0" } ] }, "announce": { "ipv4 flow": { "no-nexthop": [ { "tcp-flags": [ "=rst", "=fin+push" ], "string": "flow tcp-flags [ =rst =fin+push ]" } ] } } } } } }

--- a/qa/encoding/conf-flow.ci
+++ b/qa/encoding/conf-flow.ci
@@ -27,6 +27,11 @@ option:file:conf-flow.conf
 1:raw:FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF:0045:02:0000002E4001010040020040050400000064C010088006000046160000800E1200018500000C02180A000003810605910C38
 1:json:{"exabgp":"6.0.0","type":"update","neighbor":{"address":{"local":"127.0.0.1","peer":"127.0.0.1"},"asn":{"local":1,"peer":1},"router-id":"1.2.3.4","direction":"in","message":{"update":{"attribute":{"origin":"igp","local-preference":100,"extended-community":[{"value":9225060887890886656,"string":"rate-limit:9600"}]},"announce":{"ipv4 flow":{"no-nexthop":[{"source-ipv4":["10.0.0.0/24"],"protocol":["=tcp"],"destination-port":["=3128"],"string":"flow source-ipv4 10.0.0.0/24 protocol =tcp destination-port =3128"}]}}}}}}
 
+# flow source-ipv4 10.0.1.0/24 protocol =TCP destination-port =3128 extended-community rate-limit-packets 1000
+1:cmd:announce ipv4 flow source-ipv4 10.0.1.0/24 protocol =tcp destination-port =3128 extended-community [rate-limit-packets:1000]
+1:raw:FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF:0045:02:0000002E4001010040020040050400000064C01008800C0000447A0000800E1200018500000C02180A000103810605910C38
+1:json:{"exabgp":"6.0.0","type":"update","neighbor":{"address":{"local":"127.0.0.1","peer":"127.0.0.1"},"asn":{"local":1,"peer":1},"router-id":"1.2.3.4","direction":"in","message":{"update":{"attribute":{"origin":"igp","local-preference":100,"extended-community":[{"value":9226749737724149760,"string":"rate-limit-packets:1000"}]},"announce":{"ipv4 flow":{"no-nexthop":[{"source-ipv4":["10.0.1.0/24"],"protocol":["=tcp"],"destination-port":["=3128"],"string":"flow source-ipv4 10.0.1.0/24 protocol =tcp destination-port =3128"}]}}}}}}
+
 # flow destination-ipv6 2a02:b80:15::7aca:39ff:feae:a87a/128/0 source-ipv6 ::1/128/120 next-header =UDP traffic-class =101 flow-label =2013 extended-community discard
 1:cmd:announce ipv6 flow destination-ipv6 2a02:b80:15:0:7aca:39ff:feae:a87a/128/0 source-ipv6 ::1/128/120 next-header =udp traffic-class =101 flow-label =2013 extended-community [rate-limit:0]
 1:raw:FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF:0069:02:000000524001010040020040050400000064C010088006000000000000800E360002850000300180002A020B80001500007ACA39FFFEAEA87A028078000000000000000000000000000000010381110B81650D9107DD

--- a/src/exabgp/bgp/message/update/attribute/community/extended/__init__.py
+++ b/src/exabgp/bgp/message/update/attribute/community/extended/__init__.py
@@ -28,6 +28,7 @@ Common Extended Community Types:
 | 0x80 | 0x07| FlowSpec Traffic Action | TrafficAction        |
 | 0x80 | 0x08| FlowSpec Redirect       | TrafficRedirect      |
 | 0x80 | 0x09| FlowSpec Traffic Mark   | TrafficMark          |
+| 0x80 | 0x0c| FlowSpec Packet Rate    | TrafficRatePackets   |
 | 0x0c | -   | MUP Extended Community  | MUPExtendedCommunity |
 
 Wire Format Reference: doc/RFC_WIRE_FORMAT_REFERENCE.md#extended-community-rfc-4360
@@ -59,6 +60,7 @@ from exabgp.bgp.message.update.attribute.community.extended.rt import RouteTarge
 from exabgp.bgp.message.update.attribute.community.extended.rt import RouteTargetIPNumber
 from exabgp.bgp.message.update.attribute.community.extended.rt import RouteTargetASN4Number
 from exabgp.bgp.message.update.attribute.community.extended.traffic import TrafficRate
+from exabgp.bgp.message.update.attribute.community.extended.traffic import TrafficRatePackets
 from exabgp.bgp.message.update.attribute.community.extended.traffic import TrafficAction
 from exabgp.bgp.message.update.attribute.community.extended.traffic import TrafficRedirect
 from exabgp.bgp.message.update.attribute.community.extended.traffic import TrafficRedirectASN4
@@ -89,6 +91,7 @@ __all__ = [
     'RouteTargetIPNumber',
     'RouteTargetASN4Number',
     'TrafficRate',
+    'TrafficRatePackets',
     'TrafficAction',
     'TrafficRedirect',
     'TrafficRedirectASN4',

--- a/src/exabgp/bgp/message/update/attribute/community/extended/traffic.py
+++ b/src/exabgp/bgp/message/update/attribute/community/extended/traffic.py
@@ -6,6 +6,7 @@ to traffic matching a FlowSpec rule.
 
 Actions:
     TrafficRate: Rate-limit matching traffic (rate in bytes/sec)
+    TrafficRatePackets: Rate-limit matching traffic (rate in packets/sec)
     TrafficAction: Sample and/or terminate rule evaluation
     TrafficRedirect: Redirect to VRF by Route Target
     TrafficMark: Set DSCP marking on matching packets
@@ -77,6 +78,47 @@ class TrafficRate(ExtendedCommunity):
     @classmethod
     def unpack_attribute(cls, data: Buffer, negotiated: Negotiated | None = None) -> TrafficRate:
         return cls(data[:8])
+
+
+# ============================================================ TrafficRatePackets
+
+
+@ExtendedCommunity.register_subtype
+class TrafficRatePackets(ExtendedCommunity):
+    """Rate-limit matching traffic in packets per second (RFC 8955)."""
+
+    COMMUNITY_TYPE: ClassVar[int] = 0x80
+    COMMUNITY_SUBTYPE: ClassVar[int] = 0x0C
+
+    def __init__(self, packed: Buffer) -> None:
+        ExtendedCommunity.__init__(self, packed)
+
+    @classmethod
+    def make_traffic_rate_packets(cls, asn: ASN, rate: float) -> TrafficRatePackets:
+        """Create TrafficRatePackets from semantic values."""
+        if rate < 0:
+            raise ValueError(f'traffic-rate-packets must not be negative: {rate}')
+        packed = pack('!BBHf', cls.COMMUNITY_TYPE, cls.COMMUNITY_SUBTYPE, asn, rate)
+        return cls(packed)
+
+    @property
+    def asn(self) -> ASN:
+        return ASN(unpack('!H', self._packed[2:4])[0])
+
+    @property
+    def rate(self) -> float:
+        value: float = unpack('!f', self._packed[4:8])[0]
+        return max(value, 0.0)
+
+    def __repr__(self) -> str:
+        return 'rate-limit-packets:%d' % self.rate
+
+    @classmethod
+    def unpack_attribute(cls, data: Buffer, negotiated: Negotiated | None = None) -> TrafficRatePackets:
+        asn, rate = unpack('!Hf', data[2:8])
+        if rate < 0:
+            rate = 0.0
+        return cls.make_traffic_rate_packets(ASN(asn), rate)
 
 
 # ================================================================ TrafficAction

--- a/src/exabgp/configuration/announce/flow.py
+++ b/src/exabgp/configuration/announce/flow.py
@@ -52,6 +52,7 @@ from exabgp.configuration.flow.parser import flow_label
 from exabgp.configuration.flow.parser import accept
 from exabgp.configuration.flow.parser import discard
 from exabgp.configuration.flow.parser import rate_limit
+from exabgp.configuration.flow.parser import rate_limit_packets
 from exabgp.configuration.flow.parser import redirect
 from exabgp.configuration.flow.parser import redirect_next_hop
 from exabgp.configuration.flow.parser import redirect_next_hop_ietf
@@ -265,6 +266,14 @@ class AnnounceFlow(ParseAnnounce):
                 operation=ActionOperation.ADD,
                 key=ActionKey.NAME,
                 validator=LegacyParserValidator(parser_func=rate_limit, name='rate-limit'),
+            ),
+            'rate-limit-packets': Leaf(
+                type=ValueType.INTEGER,
+                description='Rate limit in packets/second',
+                target=ActionTarget.ATTRIBUTE,
+                operation=ActionOperation.ADD,
+                key=ActionKey.NAME,
+                validator=LegacyParserValidator(parser_func=rate_limit_packets, name='rate-limit-packets'),
             ),
             'redirect': Leaf(
                 type=ValueType.STRING,

--- a/src/exabgp/configuration/flow/parser.py
+++ b/src/exabgp/configuration/flow/parser.py
@@ -12,6 +12,7 @@ Match conditions:
 Traffic actions:
     accept/discard: Allow or drop traffic
     rate_limit: Limit traffic rate (bytes/sec)
+    rate_limit_packets: Limit traffic rate (packets/sec)
     redirect: Redirect to VRF or next-hop
     mark: Set DSCP marking
     action: Sample and/or terminal flags
@@ -37,6 +38,7 @@ from exabgp.bgp.message.update.attribute.community.extended import (
     TrafficNextHopIPv6IETF,
     TrafficNextHopSimpson,
     TrafficRate,
+    TrafficRatePackets,
     TrafficRedirect,
     TrafficRedirectASN4,
     TrafficRedirectIPv6,
@@ -360,6 +362,12 @@ def rate_limit(tokeniser: 'Tokeniser') -> ExtendedCommunities:
             'configuration',
         )
     return ExtendedCommunities().add(TrafficRate.make_traffic_rate(ASN(0), speed))
+
+
+def rate_limit_packets(tokeniser: 'Tokeniser') -> ExtendedCommunities:
+    # README: We are setting the ASN as zero as that what Juniper (and Arbor) did when we created a local flow route
+    speed: int = int(tokeniser())
+    return ExtendedCommunities().add(TrafficRatePackets.make_traffic_rate_packets(ASN(0), speed))
 
 
 def redirect(tokeniser: 'Tokeniser') -> tuple[IP, ExtendedCommunities]:

--- a/src/exabgp/configuration/flow/then.py
+++ b/src/exabgp/configuration/flow/then.py
@@ -18,6 +18,7 @@ from exabgp.configuration.schema import ActionKey, ActionOperation, ActionTarget
 from exabgp.configuration.flow.parser import accept
 from exabgp.configuration.flow.parser import discard
 from exabgp.configuration.flow.parser import rate_limit
+from exabgp.configuration.flow.parser import rate_limit_packets
 from exabgp.configuration.flow.parser import redirect
 from exabgp.configuration.flow.parser import redirect_next_hop
 from exabgp.configuration.flow.parser import redirect_next_hop_ietf
@@ -52,6 +53,13 @@ class ParseFlowThen(Section):
             'rate-limit': Leaf(
                 type=ValueType.INTEGER,
                 description='Rate limit in bytes per second',
+                target=ActionTarget.ATTRIBUTE,
+                operation=ActionOperation.ADD,
+                key=ActionKey.NAME,
+            ),
+            'rate-limit-packets': Leaf(
+                type=ValueType.INTEGER,
+                description='Rate limit in packets per second',
                 target=ActionTarget.ATTRIBUTE,
                 operation=ActionOperation.ADD,
                 key=ActionKey.NAME,
@@ -126,6 +134,7 @@ class ParseFlowThen(Section):
         'accept',
         'discard',
         'rate-limit 9600',
+        'rate-limit-packets 1000',
         'redirect 30740:12345',
         'redirect 1.2.3.4:5678',
         'redirect 1.2.3.4',
@@ -144,6 +153,7 @@ class ParseFlowThen(Section):
         'accept': accept,
         'discard': discard,
         'rate-limit': rate_limit,
+        'rate-limit-packets': rate_limit_packets,
         'redirect': redirect,
         'redirect-to-nexthop': redirect_next_hop,
         'redirect-to-nexthop-ietf': redirect_next_hop_ietf,

--- a/tests/unit/test_communities.py
+++ b/tests/unit/test_communities.py
@@ -22,6 +22,7 @@ Phase 3: Extended Communities - Other Types (tests 11-22)
   - Bandwidth (Link Bandwidth)
   - Encapsulation (RFC 5512)
   - Traffic Engineering
+  - Flowspec traffic-rate-packets (RFC 8955)
   - L2 Info
   - MAC Mobility
   - FlowSpec Scope
@@ -491,6 +492,42 @@ def test_traffic_engineering_community() -> None:
     # Verify pack
     packed = tr.pack_attribute(negotiated)
     assert len(packed) == 8
+
+
+def test_flowspec_packet_rate_community() -> None:
+    """Test FlowSpec packet rate extended community."""
+    from exabgp.bgp.message.open.asn import ASN
+    from exabgp.bgp.message.update.attribute.community.extended.traffic import TrafficRatePackets
+
+    negotiated = create_negotiated()
+    trp = TrafficRatePackets.make_traffic_rate_packets(ASN(0), 1000)
+
+    assert len(trp) == 8
+    assert trp.asn == ASN(0)
+    assert trp.rate == 1000
+    assert repr(trp) == 'rate-limit-packets:1000'
+
+    packed = trp.pack_attribute(negotiated)
+    assert len(packed) == 8
+    assert packed[0] == 0x80
+    assert packed[1] == 0x0C
+
+    unpacked = TrafficRatePackets.unpack_attribute(packed, None)  # type: ignore[arg-type]
+    assert unpacked.asn == ASN(0)
+    assert unpacked.rate == 1000
+    assert repr(unpacked) == 'rate-limit-packets:1000'
+
+    # Negative decoded FlowSpec packet rates must be treated as discard.
+    packed = struct.pack('!BBHf', 0x80, 0x0C, 0, -1.5)
+    unpacked = TrafficRatePackets.unpack_attribute(packed, None)  # type: ignore[arg-type]
+
+    assert unpacked.asn == ASN(0)
+    assert unpacked.rate == 0
+    assert repr(unpacked) == 'rate-limit-packets:0'
+
+    # Negative FlowSpec packet rates must not be encoded.
+    with pytest.raises(ValueError, match='traffic-rate-packets must not be negative'):
+        TrafficRatePackets.make_traffic_rate_packets(ASN(0), -1)
 
 
 def test_l2info_community() -> None:

--- a/tests/unit/test_schema.py
+++ b/tests/unit/test_schema.py
@@ -605,6 +605,7 @@ class TestParserSchemaIntegration:
         assert 'accept' in keywords
         assert 'discard' in keywords
         assert 'rate-limit' in keywords
+        assert 'rate-limit-packets' in keywords
         assert 'redirect' in keywords
 
     def test_parse_vpls_has_schema(self):


### PR DESCRIPTION
## Summary

- add FlowSpec `traffic-rate-packets` support from RFC 8955
- expose it as `rate-limit-packets`
- keep existing `rate-limit` behavior unchanged

## Notes

This implements the RFC 8955 `traffic-rate-packets` extended community with:
- subtype `0x0c`
- wire format `2-octet AS + 4-octet IEEE float`
- string form `rate-limit-packets:<value>`

I kept this additive and did not modify existing `TrafficRate` handling.

## Validation

Passed:
- `uv run pytest tests/unit/test_communities.py -v`
- `uv run pytest tests/unit/test_schema.py -v`
- `./qa/bin/test_json qa/encoding/conf-flow.ci`
- `./qa/bin/test_everything unit config encode-decode parsing decoding encoding cli api`

`./qa/bin/test_everything` still reports failures, which appear unrelated to this change.

## Questions

I’d appreciate feedback on these choices:

- is `rate-limit-packets` fine as the user-facing keyword / string?
- should `make_traffic_rate_packets()` reject negative values and `unpack_attribute()` normalize negative values to zero, per RFC 8955, even though current `TrafficRate` is looser?
- should packet-rate parsing stay RFC-minimal, or grow min/max warning logic similar to byte-based `rate-limit`?

## Follow-up

If this is accepted on `main`, I’d also like to prepare a backport for `5.0`.