### PR TITLE
Implement BGP paths limit capability

### DIFF
--- a/etc/exabgp/conf-cap-paths-limit.conf
+++ b/etc/exabgp/conf-cap-paths-limit.conf
@@ -1,0 +1,16 @@
+neighbor 127.0.0.1 {
+	router-id 10.0.0.2;
+	local-address 127.0.0.1;
+	local-as 65533;
+	peer-as 65533;
+	hold-time 180;
+
+	capability {
+		add-path send/receive;
+		paths-limit 10;
+	}
+
+	family {
+		ipv4 unicast;
+	}
+}

--- a/src/exabgp/bgp/message/open/capability/__init__.py
+++ b/src/exabgp/bgp/message/open/capability/__init__.py
@@ -18,6 +18,7 @@ from exabgp.bgp.message.open.capability.negotiated import Negotiated
 
 from exabgp.bgp.message.open.capability.nexthop import NextHop
 from exabgp.bgp.message.open.capability.addpath import AddPath
+from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
 from exabgp.bgp.message.open.capability.asn4 import ASN4
 from exabgp.bgp.message.open.capability.graceful import Graceful
 from exabgp.bgp.message.open.capability.mp import MultiProtocol
@@ -37,6 +38,7 @@ __all__ = [
     'Negotiated',
     'NextHop',
     'AddPath',
+    'PathsLimit',
     'ASN4',
     'Graceful',
     'MultiProtocol',

--- a/src/exabgp/bgp/message/open/capability/capabilities.py
+++ b/src/exabgp/bgp/message/open/capability/capabilities.py
@@ -16,6 +16,7 @@ from exabgp.bgp.message.open.capability.capability import Capability
 from exabgp.bgp.message.open.capability.capability import CapabilityCode
 from exabgp.bgp.message.open.capability.nexthop import NextHop
 from exabgp.bgp.message.open.capability.addpath import AddPath
+from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
 from exabgp.bgp.message.open.capability.asn4 import ASN4
 from exabgp.bgp.message.open.capability.graceful import Graceful
 from exabgp.bgp.message.open.capability.mp import MultiProtocol
@@ -170,6 +171,30 @@ class Capabilities(dict[int, Capability]):
             return
         self[Capability.CODE.OPERATIONAL] = Operational()
 
+    def _pathslimit(self, neighbor: Neighbor) -> None:
+        has_per_family = bool(neighbor.capability.paths_limit_per_family)
+        has_default = bool(neighbor.capability.paths_limit)
+        if not has_per_family and not has_default:
+            return
+        if not neighbor.capability.add_path:
+            return
+
+        addpath_cap = self.get(Capability.CODE.ADD_PATH, None)
+        if not isinstance(addpath_cap, AddPath):
+            return
+
+        from exabgp.bgp.message.open.capability.negotiated import RequirePath
+
+        families_with_limit: dict[FamilyTuple, int] = {}
+        for family, direction in addpath_cap.items():
+            if direction & RequirePath.RECEIVE:
+                limit = neighbor.capability.paths_limit_per_family.get(family, neighbor.capability.paths_limit)
+                if limit > 0:
+                    families_with_limit[family] = limit
+
+        if families_with_limit:
+            self[Capability.CODE.PATHS_LIMIT] = PathsLimit(families_with_limit)
+
     def _linklocal(self, neighbor: Neighbor) -> None:
         if not neighbor.capability.link_local_nexthop.is_enabled():
             return
@@ -188,6 +213,7 @@ class Capabilities(dict[int, Capability]):
         self._asn4(neighbor)
         self._nexthop(neighbor)
         self._addpath(neighbor)
+        self._pathslimit(neighbor)
         self._graceful(neighbor, restarted)
         self._refresh(neighbor)
         self._operational(neighbor)

--- a/src/exabgp/bgp/message/open/capability/capability.py
+++ b/src/exabgp/bgp/message/open/capability/capability.py
@@ -34,8 +34,9 @@ class CapabilityCode(int):
     MULTISESSION: ClassVar[int] = 0x44  # [draft-ietf-idr-bgp-multisession]
     ADD_PATH: ClassVar[int] = 0x45  # [draft-ietf-idr-add-paths]
     ENHANCED_ROUTE_REFRESH: ClassVar[int] = 0x46  # [draft-ietf-idr-bgp-enhanced-route-refresh]
+    PATHS_LIMIT: ClassVar[int] = 0x4C  # [draft-abraitis-idr-addpath-paths-limit]
     LINK_LOCAL_NEXTHOP: ClassVar[int] = 0x4D  # [draft-ietf-idr-linklocal-capability]
-    # 70-127    Unassigned
+    # 78-127    Unassigned
     ROUTE_REFRESH_CISCO: ClassVar[int] = 0x80  # I Can only find reference to this in the router logs
     # 128-255   Reserved for Private Use [RFC5492]
     MULTISESSION_CISCO: ClassVar[int] = (
@@ -65,6 +66,7 @@ class CapabilityCode(int):
         MULTISESSION: 'multi-session',
         ADD_PATH: 'add-path',
         ENHANCED_ROUTE_REFRESH: 'enhanced-route-refresh',
+        PATHS_LIMIT: 'paths-limit',
         LINK_LOCAL_NEXTHOP: 'link-local-nexthop',
         OPERATIONAL: 'operational',
         ROUTE_REFRESH_CISCO: 'cisco-route-refresh',
@@ -114,6 +116,7 @@ class Capability:
         MULTISESSION: ClassVar[CapabilityCode] =             CapabilityCode(CapabilityCode.MULTISESSION)
         ADD_PATH: ClassVar[CapabilityCode] =                 CapabilityCode(CapabilityCode.ADD_PATH)
         ENHANCED_ROUTE_REFRESH: ClassVar[CapabilityCode] =   CapabilityCode(CapabilityCode.ENHANCED_ROUTE_REFRESH)
+        PATHS_LIMIT: ClassVar[CapabilityCode] =              CapabilityCode(CapabilityCode.PATHS_LIMIT)
         LINK_LOCAL_NEXTHOP: ClassVar[CapabilityCode] =       CapabilityCode(CapabilityCode.LINK_LOCAL_NEXTHOP)
         ROUTE_REFRESH_CISCO: ClassVar[CapabilityCode] =      CapabilityCode(CapabilityCode.ROUTE_REFRESH_CISCO)
         MULTISESSION_CISCO: ClassVar[CapabilityCode] =       CapabilityCode(CapabilityCode.MULTISESSION_CISCO)

--- a/src/exabgp/bgp/message/open/capability/negotiated.py
+++ b/src/exabgp/bgp/message/open/capability/negotiated.py
@@ -61,6 +61,8 @@ class Negotiated:
         self.refresh: int = REFRESH.ABSENT  # pylint: disable=E1101
         self.aigp: bool = neighbor.capability.aigp.is_enabled()
         self.linklocal_nexthop: bool = False
+        self.paths_limit: dict[FamilyTuple, int] = {}
+        self.advertised_paths_limit: dict[FamilyTuple, int] = {}
         self.mismatch: list[tuple[str, FamilyTuple]] = []
 
     @classmethod
@@ -80,6 +82,8 @@ class Negotiated:
         instance.refresh = REFRESH.ABSENT
         instance.aigp = False
         instance.linklocal_nexthop = False
+        instance.paths_limit = {}
+        instance.advertised_paths_limit = {}
         instance.mismatch = []
         instance.sent_open = None
         instance.received_open = None
@@ -154,6 +158,32 @@ class Negotiated:
         self.linklocal_nexthop = sent_capa.announced(Capability.CODE.LINK_LOCAL_NEXTHOP) and recv_capa.announced(
             Capability.CODE.LINK_LOCAL_NEXTHOP,
         )
+
+        self.paths_limit = {}
+        self.advertised_paths_limit = {}
+        if recv_capa.announced(Capability.CODE.ADD_PATH) and sent_capa.announced(Capability.CODE.ADD_PATH):
+            from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+            from exabgp.bgp.message.open.capability.addpath import AddPath
+
+            recv_pl = recv_capa.get(Capability.CODE.PATHS_LIMIT, None)
+            recv_ap = recv_capa.get(Capability.CODE.ADD_PATH, None)
+            if isinstance(recv_pl, PathsLimit) and isinstance(recv_ap, AddPath):
+                for family, limit in recv_pl.items():
+                    if family not in recv_ap:
+                        continue
+                    afi, safi = family
+                    if self.addpath.send(afi, safi):
+                        self.paths_limit[family] = limit
+
+            sent_pl = sent_capa.get(Capability.CODE.PATHS_LIMIT, None)
+            sent_ap = sent_capa.get(Capability.CODE.ADD_PATH, None)
+            if isinstance(sent_pl, PathsLimit) and isinstance(sent_ap, AddPath):
+                for family, limit in sent_pl.items():
+                    if family not in sent_ap:
+                        continue
+                    afi, safi = family
+                    if self.addpath.receive(afi, safi):
+                        self.advertised_paths_limit[family] = limit
 
         self.multisession = sent_capa.announced(Capability.CODE.MULTISESSION) and recv_capa.announced(
             Capability.CODE.MULTISESSION,

--- a/src/exabgp/bgp/message/open/capability/pathslimit.py
+++ b/src/exabgp/bgp/message/open/capability/pathslimit.py
@@ -1,0 +1,75 @@
+"""pathslimit.py
+
+PATHS-LIMIT Capability (draft-abraitis-idr-addpath-paths-limit-04).
+
+Created by James Raphael Tiovalen on 2026-04-27.
+License: 3-clause BSD. (See the COPYRIGHT file)
+"""
+
+from __future__ import annotations
+
+from struct import pack
+from typing import ClassVar
+
+from exabgp.protocol.family import AFI, SAFI, FamilyTuple
+from exabgp.bgp.message.open.capability.capability import Capability
+from exabgp.bgp.message.open.capability.capability import CapabilityCode
+from exabgp.bgp.message.notification import Notify
+from exabgp.logger import log, lazymsg
+from exabgp.util.types import Buffer
+
+
+@Capability.register()
+class PathsLimit(Capability, dict[FamilyTuple, int]):
+    ID: ClassVar[int] = Capability.CODE.PATHS_LIMIT
+
+    def __init__(self, families: dict[FamilyTuple, int] | None = None) -> None:
+        if families:
+            for (afi, safi), limit in families.items():
+                self.set_limit(afi, safi, limit)
+
+    def set_limit(self, afi: AFI, safi: SAFI, limit: int) -> None:
+        if not (0 <= limit <= 65535):
+            raise ValueError(f'paths limit must be 0-65535, got {limit}')
+        self[(afi, safi)] = limit
+
+    def __str__(self) -> str:
+        entries = ', '.join(f'{afi} {safi} {self[(afi, safi)]}' for afi, safi in self)
+        return f'PathsLimit({entries})'
+
+    def json(self) -> str:
+        families = ', '.join(
+            f'"{afi}/{safi}": {self[(afi, safi)]}' for afi, safi in self
+        )
+        return '{{ "name": "paths-limit"{}{} }}'.format(', ' if families else '', families)
+
+    def extract_capability_bytes(self) -> list[bytes]:
+        rs = b''
+        for (afi, safi), limit in self.items():
+            if limit > 0:
+                rs += afi.pack_afi() + safi.pack_safi() + pack('!H', limit)
+        return [rs]
+
+    @classmethod
+    def unpack_capability(cls, instance: Capability, data: Buffer, capability: CapabilityCode) -> Capability:
+        assert isinstance(instance, PathsLimit)
+        if len(instance) > 0:
+            log.debug(lazymsg('capability.paths-limit.duplicate action=merge'), 'parser')
+        while data:
+            if len(data) < 5:
+                raise Notify(2, 0, f'PATHS-LIMIT capability truncated: need 5 bytes per entry, got {len(data)}')
+            afi = AFI.unpack_afi(data[:2])
+            safi = SAFI.unpack_safi(data[2:3])
+            limit = (data[3] << 8) | data[4]
+            if limit == 0:
+                data = data[5:]
+                continue
+            if (afi, safi) in instance:
+                def _log_dup(afi: AFI = afi, safi: SAFI = safi) -> str:
+                    return f'duplicate AFI/SAFI in PathsLimit capability: {afi}/{safi}'
+                log.debug(_log_dup, 'parser')
+                data = data[5:]
+                continue
+            instance.set_limit(afi, safi, limit)
+            data = data[5:]
+        return instance

--- a/src/exabgp/bgp/message/update/nlri/inet.py
+++ b/src/exabgp/bgp/message/update/nlri/inet.py
@@ -347,6 +347,11 @@ class INET(NLRI):
         # No AddPath - add discriminator to distinguish from has_addpath=True with 0x00000000
         return bytes(Family.index(self)) + b'disabled' + self._packed
 
+    def prefix_index(self) -> bytes:
+        if self._has_addpath:
+            return bytes(Family.index(self)) + self._packed[PATH_INFO_SIZE:]
+        return self.index()
+
     def prefix(self) -> str:
         return '{}{}'.format(self.cidr.prefix(), str(self.path_info))
 

--- a/src/exabgp/bgp/message/update/nlri/nlri.py
+++ b/src/exabgp/bgp/message/update/nlri/nlri.py
@@ -177,6 +177,9 @@ class NLRI(Family):
 
         return bytes(Family.index(self)) + self.pack_nlri(Negotiated.UNSET)
 
+    def prefix_index(self) -> bytes:
+        return self.index()
+
     def pack_nlri(self, negotiated: Negotiated) -> Buffer:
         raise Exception('unimplemented in NLRI children class')
 

--- a/src/exabgp/bgp/neighbor/capability.py
+++ b/src/exabgp/bgp/neighbor/capability.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import ClassVar
 
+from exabgp.protocol.family import FamilyTuple
 from exabgp.util.enumeration import TriState
 
 
@@ -77,6 +78,8 @@ class NeighborCapability:
     multi_session: TriState = TriState.FALSE
     operational: TriState = TriState.FALSE
     add_path: int = 0  # 0=disabled, 1=receive, 2=send, 3=send/receive
+    paths_limit: int = 0  # 0=disabled
+    paths_limit_per_family: dict[FamilyTuple, int] = field(default_factory=dict)
     route_refresh: int = 0  # REFRESH enum: ABSENT=1, NORMAL=2, ENHANCED=4
     nexthop: TriState = TriState.UNSET
     aigp: TriState = TriState.UNSET
@@ -96,6 +99,8 @@ class NeighborCapability:
             multi_session=self.multi_session,
             operational=self.operational,
             add_path=self.add_path,
+            paths_limit=self.paths_limit,
+            paths_limit_per_family=dict(self.paths_limit_per_family),
             route_refresh=self.route_refresh,
             nexthop=self.nexthop,
             aigp=self.aigp,
@@ -115,6 +120,8 @@ class NeighborCapability:
             and self.multi_session == other.multi_session
             and self.operational == other.operational
             and self.add_path == other.add_path
+            and self.paths_limit == other.paths_limit
+            and self.paths_limit_per_family == other.paths_limit_per_family
             and self.route_refresh == other.route_refresh
             and self.nexthop == other.nexthop
             and self.aigp == other.aigp

--- a/src/exabgp/bgp/neighbor/neighbor.py
+++ b/src/exabgp/bgp/neighbor/neighbor.py
@@ -461,6 +461,10 @@ Neighbor {peer-address}
         for afi, safi in neighbor.addpaths():
             addpaths += f'\n\t\t{afi.name()} {safi.name()};'
 
+        pathslimits = ''
+        for (afi, safi), limit in neighbor.capability.paths_limit_per_family.items():
+            pathslimits += f'\n\t\t\t{afi.name()} {safi.name()} {limit};'
+
         codes = Message.CODE
 
         _extension_global = {
@@ -586,7 +590,12 @@ Neighbor {peer-address}
             f'\t\tsoftware-version {"enable" if cap.software_version else "disable"};\n'
             f'\t\tnexthop {"enable" if cap.nexthop.is_enabled() else "disable"};\n'
             f'\t\tadd-path {add_path_str};\n'
-            f'\t\tmulti-session {"enable" if cap.multi_session.is_enabled() else "disable"};\n'
+            + (
+                f'\t\tpaths-limit {{\n\t\t\tall {cap.paths_limit};{pathslimits}\n\t\t}}\n'
+                if pathslimits
+                else (f'\t\tpaths-limit {cap.paths_limit};\n' if cap.paths_limit else '')
+            )
+            + f'\t\tmulti-session {"enable" if cap.multi_session.is_enabled() else "disable"};\n'
             f'\t\toperational {"enable" if cap.operational.is_enabled() else "disable"};\n'
             f'\t\taigp {"enable" if cap.aigp.is_enabled() else "disable"};\n'
             f'\t}}\n'
@@ -596,7 +605,7 @@ Neighbor {peer-address}
             f'\t}}\n'
             f'\tadd-path {{{addpaths}\n'
             f'\t}}\n'
-            f'{apis}{routes_str}'
+            + f'{apis}{routes_str}'
             f'}}'
         )
 

--- a/src/exabgp/configuration/capability.py
+++ b/src/exabgp/configuration/capability.py
@@ -44,6 +44,19 @@ def addpath(tokeniser: 'Tokeniser') -> int:
     raise ValueError(f"'{ap}' is not a valid add-path option\n  Valid options: send, receive, send/receive, disable")
 
 
+def pathslimit(tokeniser: 'Tokeniser') -> dict[str, int]:
+    token = tokeniser()
+    if not token:
+        raise ValueError('paths-limit requires a value\n  Example: paths-limit 10;')
+    try:
+        limit = int(token)
+    except ValueError:
+        raise ValueError(f'paths-limit must be a number, got: {token}')
+    if not (0 <= limit <= 65535):
+        raise ValueError(f'paths-limit must be 0-65535, got {limit}')
+    return {'all': limit}
+
+
 class ParseCapability(Section):
     TTL_SECURITY = 255
 
@@ -63,6 +76,15 @@ class ParseCapability(Section):
                 type=ValueType.ENUMERATION,
                 description='ADD-PATH capability mode',
                 choices=['disable', 'receive', 'send', 'send/receive'],
+                target=ActionTarget.SCOPE,
+                operation=ActionOperation.SET,
+                key=ActionKey.COMMAND,
+            ),
+            'paths-limit': Leaf(
+                type=ValueType.INTEGER,
+                description='Maximum paths to receive per AFI/SAFI (PATHS-LIMIT capability, 0=disabled)',
+                default=0,
+                validator=IntValidators.range(0, 65535),
                 target=ActionTarget.SCOPE,
                 operation=ActionOperation.SET,
                 key=ActionKey.COMMAND,
@@ -154,6 +176,7 @@ class ParseCapability(Section):
     syntax = (
         'capability {\n'
         '   add-path disable|send|receive|send/receive;\n'
+        '   paths-limit <0-65535>;\n'
         '   asn4 enable|disable;\n'
         '   graceful-restart <time in second>;\n'
         '   multi-session enable|disable;\n'
@@ -170,6 +193,7 @@ class ParseCapability(Section):
     # Only entries with special parsing logic remain in known:
     known = {
         'add-path': addpath,  # Returns int (0,1,2,3), not string
+        'paths-limit': pathslimit,  # Returns dict {'all': N}
     }
 
     # action dict removed - derived from schema (defaults to 'set-command')
@@ -201,3 +225,10 @@ class ParseCapability(Section):
 
     def clear(self) -> None:
         pass
+
+    @classmethod
+    def get_subsection_keywords(cls) -> list[str]:
+        keywords = super().get_subsection_keywords()
+        if 'paths-limit' not in keywords:
+            keywords.append('paths-limit')
+        return keywords

--- a/src/exabgp/configuration/configuration.py
+++ b/src/exabgp/configuration/configuration.py
@@ -37,7 +37,7 @@ from exabgp.configuration.flow import ParseFlow, ParseFlowMatch, ParseFlowRoute,
 from exabgp.configuration.l2vpn import ParseL2VPN, ParseVPLS
 from exabgp.configuration.neighbor import ParseNeighbor
 from exabgp.configuration.neighbor.api import ParseAPI, ParseReceive, ParseSend
-from exabgp.configuration.neighbor.family import ParseAddPath, ParseFamily
+from exabgp.configuration.neighbor.family import ParseAddPath, ParseFamily, ParsePathsLimit
 from exabgp.configuration.neighbor.nexthop import ParseNextHop
 from exabgp.configuration.operational import ParseOperational
 from exabgp.configuration.process import ParseProcess
@@ -293,6 +293,7 @@ class Configuration(_Configuration):
         self.neighbor = ParseNeighbor(*params)
         self.family = ParseFamily(*params)
         self.addpath = ParseAddPath(*params)
+        self.pathslimit = ParsePathsLimit(*params)
         self.nexthop = ParseNextHop(*params)
         self.capability = ParseCapability(*params)
         self.tcpao = ParseTCPAO(*params)
@@ -324,6 +325,7 @@ class Configuration(_Configuration):
                 self.neighbor,
                 self.family,
                 self.addpath,
+                self.pathslimit,
                 self.nexthop,
                 self.capability,
                 self.tcpao,

--- a/src/exabgp/configuration/neighbor/__init__.py
+++ b/src/exabgp/configuration/neighbor/__init__.py
@@ -498,6 +498,38 @@ class ParseNeighbor(Section):
                 continue
             neighbor.add_nexthop(afi, safi, nhafi)
 
+    def _post_capa_pathslimit(self, neighbor: Neighbor, local: dict[str, Any], families: list[FamilyTuple]) -> None:
+        capability = local.get('capability', {})
+        value = capability.get('paths-limit', None)
+        if value is None:
+            return
+
+        from exabgp.configuration.neighbor.family import ParsePathsLimit
+
+        if isinstance(value, int):
+            neighbor.capability.paths_limit = value
+            return
+
+        if not isinstance(value, dict):
+            return
+
+        if 'all' in value:
+            neighbor.capability.paths_limit = value['all']
+
+        for afi_name in ParsePathsLimit.convert:
+            for family_limit in value.get(afi_name, []):
+                family, limit = family_limit
+                if family not in families:
+                    log.debug(
+                        lazymsg(
+                            'paths-limit.skipped family={f} reason=not_negotiated',
+                            f=family,
+                        ),
+                        'configuration',
+                    )
+                    continue
+                neighbor.capability.paths_limit_per_family[family] = limit
+
     def _post_capa_rr(self, neighbor: Neighbor) -> None:
         if neighbor.capability.route_refresh:
             if not neighbor.adj_rib_out:
@@ -554,6 +586,7 @@ class ParseNeighbor(Section):
 
         self._post_capa_default(neighbor, local)
         self._post_capa_addpath(neighbor, local, families)
+        self._post_capa_pathslimit(neighbor, local, families)
         self._post_capa_nexthop(neighbor, local)
         self._post_capa_rr(neighbor)
         self._post_routes(neighbor, local)

--- a/src/exabgp/configuration/neighbor/family.py
+++ b/src/exabgp/configuration/neighbor/family.py
@@ -7,6 +7,7 @@ License: 3-clause BSD. (See the COPYRIGHT file)
 
 from __future__ import annotations
 
+from functools import partial
 from typing import Any
 
 from exabgp.protocol.family import AFI, SAFI, FamilyTuple
@@ -278,3 +279,116 @@ class ParseAddPath(ParseFamily):
     )
 
     name = 'add-path'
+
+
+class ParsePathsLimit(Section):
+    convert = ParseFamily.convert
+
+    schema = Container(
+        description='Per-family PATHS-LIMIT configuration',
+        children={
+            'all': Leaf(
+                type=ValueType.INTEGER,
+                description='Default paths-limit for all unspecified families',
+                target=ActionTarget.SCOPE,
+                operation=ActionOperation.SET,
+                key=ActionKey.COMMAND,
+            ),
+            'ipv4': Leaf(
+                type=ValueType.STRING,
+                description='IPv4 paths-limit (e.g. "unicast 10")',
+                target=ActionTarget.SCOPE,
+                operation=ActionOperation.APPEND,
+                key=ActionKey.COMMAND,
+            ),
+            'ipv6': Leaf(
+                type=ValueType.STRING,
+                description='IPv6 paths-limit (e.g. "unicast 20")',
+                target=ActionTarget.SCOPE,
+                operation=ActionOperation.APPEND,
+                key=ActionKey.COMMAND,
+            ),
+            'l2vpn': Leaf(
+                type=ValueType.STRING,
+                description='L2VPN paths-limit',
+                target=ActionTarget.SCOPE,
+                operation=ActionOperation.APPEND,
+                key=ActionKey.COMMAND,
+            ),
+            'bgp-ls': Leaf(
+                type=ValueType.STRING,
+                description='BGP-LS paths-limit',
+                target=ActionTarget.SCOPE,
+                operation=ActionOperation.APPEND,
+                key=ActionKey.COMMAND,
+            ),
+        },
+    )
+
+    syntax = 'paths-limit {\n   all 10;\n   ipv4 unicast 32;\n   ipv6 mpls-vpn 0;\n}\n'
+
+    name = 'paths-limit'
+
+    def __init__(self, parser: Parser, scope: Scope, error: Error) -> None:
+        Section.__init__(self, parser, scope, error)
+        self.known = {'all': self._parse_all}
+        for afi in self.convert:
+            self.known[afi] = partial(self._parse_family_limit, afi_name=afi)
+        self._seen: set[FamilyTuple] = set()
+        self._all_set: bool = False
+
+    def clear(self) -> None:
+        self._seen = set()
+        self._all_set = False
+
+    def pre(self) -> bool:
+        self.clear()
+        return True
+
+    def post(self) -> bool:
+        return True
+
+    def _parse_all(self, tokeniser: Tokeniser) -> int:
+        if self._all_set:
+            raise ValueError('duplicate "all" entry in paths-limit block')
+        limit_str = tokeniser()
+        if not limit_str:
+            raise ValueError('paths-limit "all" requires a limit value\n  Example: all 10')
+        try:
+            limit = int(limit_str)
+        except ValueError:
+            raise ValueError(f'paths-limit "all" must be a number, got: {limit_str}')
+        if not (0 <= limit <= 65535):
+            raise ValueError(f'paths-limit "all" must be 0-65535, got {limit}')
+        self._all_set = True
+        return limit
+
+    def _parse_family_limit(self, tokeniser: Tokeniser, afi_name: str) -> tuple[FamilyTuple, int]:
+        safi_name = tokeniser()
+        limit_str = tokeniser()
+
+        if not safi_name or not limit_str:
+            raise ValueError(f'paths-limit {afi_name} requires SAFI and limit value\n  Example: {afi_name} unicast 10')
+
+        afi_safis = self.convert.get(afi_name)
+        if afi_safis is None:
+            raise ValueError(f'unknown AFI: {afi_name}')
+
+        family = afi_safis.get(safi_name)
+        if family is None:
+            valid = ', '.join(sorted(afi_safis.keys()))
+            raise ValueError(f'unknown SAFI for {afi_name}: {safi_name}\n  Valid: {valid}')
+
+        try:
+            limit = int(limit_str)
+        except ValueError:
+            raise ValueError(f'paths-limit must be a number, got: {limit_str}')
+
+        if not (0 <= limit <= 65535):
+            raise ValueError(f'paths-limit must be 0-65535, got {limit}')
+
+        if family in self._seen:
+            raise ValueError(f'duplicate paths-limit for {afi_name} {safi_name}')
+        self._seen.add(family)
+
+        return (family, limit)

--- a/src/exabgp/environment/config.py
+++ b/src/exabgp/environment/config.py
@@ -240,6 +240,9 @@ class BgpSection(ConfigSection):
 
     passive: bool = option(False, 'ignore the peer configuration and make all peers passive')
     openwait: int = option(60, 'how many seconds we wait for an open once the TCP session is established')
+    paths_limit_audit: bool = option(
+        True, 'log a warning when a peer sends more paths per prefix than our advertised PATHS-LIMIT'
+    )
 
 
 class CacheSection(ConfigSection):

--- a/src/exabgp/reactor/peer/handlers/update.py
+++ b/src/exabgp/reactor/peer/handlers/update.py
@@ -8,11 +8,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Generator, cast
 
 from exabgp.bgp.message import Message, Update
+from exabgp.environment import getenv
 from exabgp.logger import lazyformat, lazymsg, log
 from exabgp.reactor.peer.handlers.base import MessageHandler
 from exabgp.rib.route import Route
 
 if TYPE_CHECKING:
+    from exabgp.bgp.message.update.nlri.nlri import NLRI
     from exabgp.reactor.peer.context import PeerContext
 
 
@@ -34,6 +36,39 @@ class UpdateHandler(MessageHandler):
         """Check if this is an UPDATE message."""
         return message.TYPE == Update.TYPE
 
+    def _audit_announce(self, ctx: PeerContext, nlri: NLRI) -> None:
+        """If PATHS-LIMIT auditing is on, count this path and warn on violation."""
+        advertised = ctx.negotiated.advertised_paths_limit
+        if not advertised:
+            return
+        if not getenv().bgp.paths_limit_audit:
+            return
+        family = nlri.family().afi_safi()
+        limit = advertised.get(family, 0)
+        if limit <= 0:
+            return
+        prefix_index = nlri.prefix_index()
+        count = ctx.neighbor.rib.incoming.track_path(family, prefix_index)
+        if count > limit and ctx.neighbor.rib.incoming.mark_warned(family, prefix_index):
+            log.warning(
+                lazymsg(
+                    'rib.paths_limit.peer_violation peer={peer} family={family} prefix={prefix} limit={limit} received={count}',
+                    peer=ctx.neighbor.session.peer_address,
+                    family=family,
+                    prefix=nlri,
+                    limit=limit,
+                    count=count,
+                ),
+                'rib',
+            )
+
+    def _audit_withdraw(self, ctx: PeerContext, nlri: NLRI) -> None:
+        """Decrement audit counter for a withdrawn NLRI (no-op if untracked)."""
+        if not ctx.negotiated.advertised_paths_limit:
+            return
+        family = nlri.family().afi_safi()
+        ctx.neighbor.rib.incoming.untrack_path(family, nlri.prefix_index())
+
     def handle(self, ctx: PeerContext, message: Message) -> Generator[Message, None, None]:
         """Process the UPDATE message synchronously.
 
@@ -51,6 +86,7 @@ class UpdateHandler(MessageHandler):
             nlri = routed.nlri
             route = Route(nlri, parsed.attributes, nexthop=routed.nexthop)
             ctx.neighbor.rib.incoming.update_cache(route)
+            self._audit_announce(ctx, nlri)
             ctx.stats['receive-prefixes'] += 1
             log.debug(
                 lazyformat('update.nlri number=%d nlri=' % self._number, nlri, str),
@@ -60,6 +96,7 @@ class UpdateHandler(MessageHandler):
         # Process withdraws - use dedicated method
         for nlri in parsed.withdraws:
             ctx.neighbor.rib.incoming.update_cache_withdraw(nlri)
+            self._audit_withdraw(ctx, nlri)
             ctx.stats['receive-withdraws'] += 1
             log.debug(
                 lazyformat('update.nlri number=%d nlri=' % self._number, nlri, str),
@@ -86,6 +123,7 @@ class UpdateHandler(MessageHandler):
             nlri = routed.nlri
             route = Route(nlri, parsed.attributes, nexthop=routed.nexthop)
             ctx.neighbor.rib.incoming.update_cache(route)
+            self._audit_announce(ctx, nlri)
             ctx.stats['receive-prefixes'] += 1
             log.debug(
                 lazyformat('update.nlri number=%d nlri=' % self._number, nlri, str),
@@ -95,6 +133,7 @@ class UpdateHandler(MessageHandler):
         # Process withdraws - use dedicated method
         for nlri in parsed.withdraws:
             ctx.neighbor.rib.incoming.update_cache_withdraw(nlri)
+            self._audit_withdraw(ctx, nlri)
             ctx.stats['receive-withdraws'] += 1
             log.debug(
                 lazyformat('update.nlri number=%d nlri=' % self._number, nlri, str),

--- a/src/exabgp/reactor/protocol.py
+++ b/src/exabgp/reactor/protocol.py
@@ -420,7 +420,10 @@ class Protocol:
         """
         assert self.connection is not None
         log.debug(lazymsg('update.generator.started'), self._session())
-        updates = self.neighbor.rib.outgoing.updates(self.neighbor.group_updates)
+        updates = self.neighbor.rib.outgoing.updates(
+            self.neighbor.group_updates,
+            paths_limit=self.negotiated.paths_limit or None,
+        )
         number: int = 0
         for update in updates:
             for message in update.messages(self.negotiated, include_withdraw):
@@ -441,7 +444,10 @@ class Protocol:
         """Send BGP UPDATE messages (runs to completion)."""
         assert self.connection is not None
         log.debug(lazymsg('update.started'), self._session())
-        updates = self.neighbor.rib.outgoing.updates(self.neighbor.group_updates)
+        updates = self.neighbor.rib.outgoing.updates(
+            self.neighbor.group_updates,
+            paths_limit=self.negotiated.paths_limit or None,
+        )
         number: int = 0
         for update in updates:
             current_update = update

--- a/src/exabgp/rib/incoming.py
+++ b/src/exabgp/rib/incoming.py
@@ -12,12 +12,43 @@ from exabgp.rib.cache import Cache
 
 
 class IncomingRIB(Cache):
+    _path_counts: dict[FamilyTuple, dict[bytes, int]]
+    _path_warned: set[tuple[FamilyTuple, bytes]]
+
     def __init__(self, cache: bool, families: set[FamilyTuple], enabled: bool = True) -> None:
         Cache.__init__(self, cache, families, enabled)
+        self._path_counts = {}
+        self._path_warned = set()
 
     # back to square one, all the routes are removed
     def clear(self) -> None:
         self.clear_cache()
+        self._path_counts = {}
+        self._path_warned = set()
 
     def reset(self) -> None:
         pass
+
+    def track_path(self, family: FamilyTuple, prefix_index: bytes) -> int:
+        per_family = self._path_counts.setdefault(family, {})
+        count = per_family.get(prefix_index, 0) + 1
+        per_family[prefix_index] = count
+        return count
+
+    def untrack_path(self, family: FamilyTuple, prefix_index: bytes) -> None:
+        per_family = self._path_counts.get(family)
+        if per_family is None:
+            return
+        count = per_family.get(prefix_index, 0) - 1
+        if count <= 0:
+            per_family.pop(prefix_index, None)
+            self._path_warned.discard((family, prefix_index))
+        else:
+            per_family[prefix_index] = count
+
+    def mark_warned(self, family: FamilyTuple, prefix_index: bytes) -> bool:
+        key = (family, prefix_index)
+        if key in self._path_warned:
+            return False
+        self._path_warned.add(key)
+        return True

--- a/src/exabgp/rib/outgoing.py
+++ b/src/exabgp/rib/outgoing.py
@@ -343,7 +343,11 @@ class OutgoingRIB(Cache):
         new_attr[route_attr_index] = route.attributes
         self.update_cache(route)
 
-    def updates(self, grouped: bool) -> Iterator[UpdateCollection | RouteRefresh]:
+    def updates(
+        self,
+        grouped: bool,
+        paths_limit: dict[FamilyTuple, int] | None = None,
+    ) -> Iterator[UpdateCollection | RouteRefresh]:
         if not self.enabled:
             return
         attr_af_nlri = self._new_attr_af_nlri
@@ -388,6 +392,8 @@ class OutgoingRIB(Cache):
                 # Withdraws include attributes for proper BGP encoding (e.g., FlowSpec rate-limit)
                 yield UpdateCollection([], [nlri], attrs)
 
+        prefix_counts: dict[FamilyTuple, dict[bytes, int]] = {}
+
         # Generate Updates for announces from _new_attr_af_nlri
         # All routes here are announces (add_to_rib only handles announces)
         for attr_index, per_family in attr_af_nlri.items():
@@ -396,6 +402,31 @@ class OutgoingRIB(Cache):
                     continue
 
                 attributes = new_attr[attr_index]
+
+                limit = paths_limit.get(family, 0) if paths_limit else 0
+
+                if limit > 0:
+                    family_counts = prefix_counts.setdefault(family, {})
+                    filtered: dict[bytes, 'Route'] = {}
+                    for route_index, route in routes.items():
+                        pkey = route.nlri.prefix_index()
+                        count = family_counts.get(pkey, 0)
+                        if count < limit:
+                            filtered[route_index] = route
+                            family_counts[pkey] = count + 1
+                        else:
+                            log.debug(
+                                lazymsg(
+                                    'rib.paths_limit.exceeded family={f} prefix={p} limit={l}',
+                                    f=family,
+                                    p=route.nlri,
+                                    l=limit,
+                                ),
+                                'rib',
+                            )
+                    routes = filtered
+                    if not routes:
+                        continue
 
                 # All routes are announces - create RoutedNLRI (nlri + nexthop)
                 announces = [RoutedNLRI(route.nlri, route.nexthop) for route in routes.values()]

--- a/tests/unit/reactor/peer/handlers/test_update.py
+++ b/tests/unit/reactor/peer/handlers/test_update.py
@@ -1,11 +1,13 @@
 """Tests for UpdateHandler."""
 
 import pytest
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 from exabgp.bgp.message import UpdateCollection, KeepAlive
+from exabgp.protocol.family import AFI, SAFI
 from exabgp.reactor.peer.handlers.update import UpdateHandler
 from exabgp.reactor.peer.context import PeerContext
+from exabgp.rib.incoming import IncomingRIB
 
 
 class TestUpdateHandler:
@@ -19,6 +21,8 @@ class TestUpdateHandler:
         ctx.neighbor = Mock()
         ctx.neighbor.rib = Mock()
         ctx.neighbor.rib.incoming = Mock()
+        ctx.negotiated = Mock()
+        ctx.negotiated.advertised_paths_limit = {}
         ctx.peer_id = 'test-peer'
         ctx.stats = {'receive-prefixes': 0, 'receive-withdraws': 0}
         return ctx
@@ -129,6 +133,8 @@ class TestUpdateHandlerAsync:
         ctx.neighbor = Mock()
         ctx.neighbor.rib = Mock()
         ctx.neighbor.rib.incoming = Mock()
+        ctx.negotiated = Mock()
+        ctx.negotiated.advertised_paths_limit = {}
         ctx.peer_id = 'test-peer'
         ctx.stats = {'receive-prefixes': 0, 'receive-withdraws': 0}
         return ctx
@@ -164,3 +170,161 @@ class TestUpdateHandlerAsync:
         await handler.handle_async(mock_context, update)
 
         assert handler._number == 2
+
+
+def _make_announce(prefix_index_bytes: bytes, family: tuple) -> Mock:
+    nlri = Mock()
+    nlri.prefix_index = Mock(return_value=prefix_index_bytes)
+    afi_safi_mock = Mock()
+    afi_safi_mock.afi_safi = Mock(return_value=family)
+    nlri.family = Mock(return_value=afi_safi_mock)
+    nlri.__str__ = Mock(return_value=f'<nlri {prefix_index_bytes!r}>')
+    routed = Mock()
+    routed.nlri = nlri
+    routed.nexthop = Mock()
+    return routed
+
+
+def _make_withdraw(prefix_index_bytes: bytes, family: tuple) -> Mock:
+    nlri = Mock()
+    nlri.prefix_index = Mock(return_value=prefix_index_bytes)
+    afi_safi_mock = Mock()
+    afi_safi_mock.afi_safi = Mock(return_value=family)
+    nlri.family = Mock(return_value=afi_safi_mock)
+    nlri.__str__ = Mock(return_value=f'<nlri {prefix_index_bytes!r}>')
+    return nlri
+
+
+def _make_update(announces: list, withdraws: list) -> Mock:
+    parsed = Mock()
+    parsed.announces = announces
+    parsed.withdraws = withdraws
+    parsed.attributes = Mock()
+    msg = Mock()
+    msg.TYPE = UpdateCollection.TYPE
+    msg.data = parsed
+    return msg
+
+
+class TestUpdateHandlerPathsLimitAudit:
+    FAMILY = (AFI.ipv4, SAFI.unicast)
+
+    @pytest.fixture
+    def handler(self) -> UpdateHandler:
+        return UpdateHandler()
+
+    @pytest.fixture
+    def ctx_with_real_rib(self):
+        ctx = Mock(spec=PeerContext)
+        ctx.neighbor = Mock()
+        ctx.neighbor.session = Mock()
+        ctx.neighbor.session.peer_address = '192.0.2.99'
+        ctx.neighbor.rib = Mock()
+        ctx.neighbor.rib.incoming = IncomingRIB(cache=False, families={self.FAMILY})
+        ctx.negotiated = Mock()
+        ctx.negotiated.advertised_paths_limit = {self.FAMILY: 2}
+        ctx.peer_id = 'test-peer'
+        ctx.stats = {'receive-prefixes': 0, 'receive-withdraws': 0}
+        return ctx
+
+    def test_no_audit_when_advertised_limit_empty(self, handler, ctx_with_real_rib):
+        ctx_with_real_rib.negotiated.advertised_paths_limit = {}
+        msg = _make_update([_make_announce(b'p1', self.FAMILY)], [])
+        list(handler.handle(ctx_with_real_rib, msg))
+        assert ctx_with_real_rib.neighbor.rib.incoming._path_counts == {}
+
+    def test_audit_disabled_via_env_var(self, handler, ctx_with_real_rib):
+        with patch('exabgp.reactor.peer.handlers.update.getenv') as mock_env:
+            mock_env.return_value.bgp.paths_limit_audit = False
+            msg = _make_update([_make_announce(b'p1', self.FAMILY)] * 5, [])
+            list(handler.handle(ctx_with_real_rib, msg))
+        assert ctx_with_real_rib.neighbor.rib.incoming._path_counts == {}
+
+    def test_within_limit_no_warning(self, handler, ctx_with_real_rib, caplog):
+        with patch('exabgp.reactor.peer.handlers.update.getenv') as mock_env:
+            mock_env.return_value.bgp.paths_limit_audit = True
+            with caplog.at_level('WARNING'):
+                msg = _make_update([_make_announce(b'p1', self.FAMILY)] * 2, [])
+                list(handler.handle(ctx_with_real_rib, msg))
+        assert ctx_with_real_rib.neighbor.rib.incoming._path_counts[self.FAMILY][b'p1'] == 2
+        assert ctx_with_real_rib.neighbor.rib.incoming._path_warned == set()
+
+    def test_violation_logs_warning(self, handler, ctx_with_real_rib, caplog):
+        with patch('exabgp.reactor.peer.handlers.update.getenv') as mock_env:
+            mock_env.return_value.bgp.paths_limit_audit = True
+            with caplog.at_level('WARNING'):
+                msg = _make_update([_make_announce(b'p1', self.FAMILY)] * 3, [])
+                list(handler.handle(ctx_with_real_rib, msg))
+        rib = ctx_with_real_rib.neighbor.rib.incoming
+        assert rib._path_counts[self.FAMILY][b'p1'] == 3
+        assert (self.FAMILY, b'p1') in rib._path_warned
+
+    def test_dedup_warns_once_per_prefix(self, handler, ctx_with_real_rib):
+        with patch('exabgp.reactor.peer.handlers.update.getenv') as mock_env:
+            mock_env.return_value.bgp.paths_limit_audit = True
+            for _ in range(5):
+                msg = _make_update([_make_announce(b'p1', self.FAMILY)], [])
+                list(handler.handle(ctx_with_real_rib, msg))
+        rib = ctx_with_real_rib.neighbor.rib.incoming
+        assert rib._path_counts[self.FAMILY][b'p1'] == 5
+        assert rib._path_warned == {(self.FAMILY, b'p1')}
+
+    def test_independent_prefixes_independent_warnings(self, handler, ctx_with_real_rib):
+        with patch('exabgp.reactor.peer.handlers.update.getenv') as mock_env:
+            mock_env.return_value.bgp.paths_limit_audit = True
+            msg = _make_update(
+                [_make_announce(b'p1', self.FAMILY)] * 3 + [_make_announce(b'p2', self.FAMILY)] * 3,
+                [],
+            )
+            list(handler.handle(ctx_with_real_rib, msg))
+        rib = ctx_with_real_rib.neighbor.rib.incoming
+        assert (self.FAMILY, b'p1') in rib._path_warned
+        assert (self.FAMILY, b'p2') in rib._path_warned
+
+    def test_only_audited_family_counts(self, handler, ctx_with_real_rib):
+        other = (AFI.ipv6, SAFI.unicast)
+        with patch('exabgp.reactor.peer.handlers.update.getenv') as mock_env:
+            mock_env.return_value.bgp.paths_limit_audit = True
+            msg = _make_update([_make_announce(b'p1', other)] * 5, [])
+            list(handler.handle(ctx_with_real_rib, msg))
+        assert other not in ctx_with_real_rib.neighbor.rib.incoming._path_counts
+
+    def test_withdraw_decrements_counter(self, handler, ctx_with_real_rib):
+        with patch('exabgp.reactor.peer.handlers.update.getenv') as mock_env:
+            mock_env.return_value.bgp.paths_limit_audit = True
+            msg = _make_update([_make_announce(b'p1', self.FAMILY)] * 2, [])
+            list(handler.handle(ctx_with_real_rib, msg))
+            wmsg = _make_update([], [_make_withdraw(b'p1', self.FAMILY)])
+            list(handler.handle(ctx_with_real_rib, wmsg))
+        assert ctx_with_real_rib.neighbor.rib.incoming._path_counts[self.FAMILY][b'p1'] == 1
+
+    def test_withdraw_to_zero_clears_warning(self, handler, ctx_with_real_rib):
+        with patch('exabgp.reactor.peer.handlers.update.getenv') as mock_env:
+            mock_env.return_value.bgp.paths_limit_audit = True
+            list(handler.handle(ctx_with_real_rib, _make_update([_make_announce(b'p1', self.FAMILY)] * 3, [])))
+            rib = ctx_with_real_rib.neighbor.rib.incoming
+            assert (self.FAMILY, b'p1') in rib._path_warned
+            list(
+                handler.handle(
+                    ctx_with_real_rib,
+                    _make_update([], [_make_withdraw(b'p1', self.FAMILY)] * 3),
+                )
+            )
+            assert (self.FAMILY, b'p1') not in rib._path_warned
+            list(handler.handle(ctx_with_real_rib, _make_update([_make_announce(b'p1', self.FAMILY)] * 3, [])))
+            assert (self.FAMILY, b'p1') in rib._path_warned
+
+    def test_withdraw_no_audit_when_no_limit(self, handler, ctx_with_real_rib):
+        ctx_with_real_rib.negotiated.advertised_paths_limit = {}
+        wmsg = _make_update([], [_make_withdraw(b'p1', self.FAMILY)])
+        list(handler.handle(ctx_with_real_rib, wmsg))
+
+    @pytest.mark.asyncio
+    async def test_audit_in_async_path(self, handler, ctx_with_real_rib):
+        with patch('exabgp.reactor.peer.handlers.update.getenv') as mock_env:
+            mock_env.return_value.bgp.paths_limit_audit = True
+            msg = _make_update([_make_announce(b'p1', self.FAMILY)] * 3, [])
+            await handler.handle_async(ctx_with_real_rib, msg)
+        rib = ctx_with_real_rib.neighbor.rib.incoming
+        assert rib._path_counts[self.FAMILY][b'p1'] == 3
+        assert (self.FAMILY, b'p1') in rib._path_warned

--- a/tests/unit/test_open_capabilities.py
+++ b/tests/unit/test_open_capabilities.py
@@ -28,6 +28,7 @@ from exabgp.bgp.message.open.capability.addpath import AddPath
 from exabgp.bgp.message.open.capability.extended import ExtendedMessage
 from exabgp.bgp.message.direction import Direction
 from exabgp.bgp.message.open.capability.negotiated import Negotiated
+from exabgp.bgp.message.update.nlri.inet import INET
 from exabgp.protocol.family import AFI, SAFI
 
 
@@ -41,6 +42,25 @@ def create_negotiated() -> Negotiated:
     neighbor = Mock()
     neighbor.__getitem__ = Mock(return_value={'aigp': False})
     return Negotiated.make_negotiated(neighbor, Direction.OUT)
+
+
+def make_inet(prefix: str, afi: AFI = AFI.ipv4, safi: SAFI = SAFI.unicast, path_id: int = 0) -> INET:
+    """Helper to create INET NLRI for tests."""
+    import socket
+    from exabgp.bgp.message.update.nlri.cidr import CIDR
+    from exabgp.bgp.message.update.nlri.qualifier.path import PathInfo
+
+    ip_str, mask_str = prefix.split('/')
+    if afi == AFI.ipv4:
+        packed_ip = socket.inet_pton(socket.AF_INET, ip_str)
+    else:
+        packed_ip = socket.inet_pton(socket.AF_INET6, ip_str)
+    cidr = CIDR.create_cidr(packed_ip, int(mask_str))
+    if path_id:
+        pi = PathInfo.make_from_integer(path_id)
+    else:
+        pi = PathInfo.DISABLED
+    return INET.from_cidr(cidr, afi, safi, pi)
 
 
 # ==============================================================================
@@ -749,9 +769,752 @@ def test_link_local_nexthop_unpack_duplicate() -> None:
 
 
 # ==============================================================================
+# Phase 13: PATHS-LIMIT Capability (draft-abraitis-idr-addpath-paths-limit-04)
+# ==============================================================================
+
+
+def test_paths_limit_capability_code() -> None:
+    """Test PATHS-LIMIT capability code.
+
+    draft-abraitis-idr-addpath-paths-limit-04: Code 76 (0x4C).
+    """
+    assert Capability.CODE.PATHS_LIMIT == 76
+
+
+def test_paths_limit_creation() -> None:
+    """Test PathsLimit capability creation."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    assert cap.ID == Capability.CODE.PATHS_LIMIT
+    assert len(cap) == 0
+
+
+def test_paths_limit_set_limit() -> None:
+    """Test setting path limits per AFI/SAFI."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    cap.set_limit(AFI.ipv4, SAFI.unicast, 10)
+    cap.set_limit(AFI.ipv6, SAFI.unicast, 20)
+
+    assert cap[(AFI.ipv4, SAFI.unicast)] == 10
+    assert cap[(AFI.ipv6, SAFI.unicast)] == 20
+    assert len(cap) == 2
+
+
+def test_paths_limit_init_with_families() -> None:
+    """Test PathsLimit creation with families."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    families = {
+        (AFI.ipv4, SAFI.unicast): 5,
+        (AFI.ipv6, SAFI.unicast): 15,
+    }
+    cap = PathsLimit(families)
+
+    assert cap[(AFI.ipv4, SAFI.unicast)] == 5
+    assert cap[(AFI.ipv6, SAFI.unicast)] == 15
+
+
+def test_paths_limit_extract_bytes() -> None:
+    """Test PathsLimit wire encoding.
+
+    Each tuple: AFI(2) + SAFI(1) + limit(2) = 5 bytes.
+    """
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    cap.set_limit(AFI.ipv4, SAFI.unicast, 10)
+
+    bytes_list = cap.extract_capability_bytes()
+    assert len(bytes_list) == 1
+    data = bytes_list[0]
+    assert len(data) == 5
+    # AFI IPv4 = 0x0001, SAFI unicast = 0x01, limit = 0x000A
+    assert data == b'\x00\x01\x01\x00\x0a'
+
+
+def test_paths_limit_extract_bytes_multiple() -> None:
+    """Test PathsLimit wire encoding with multiple families."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    cap.set_limit(AFI.ipv4, SAFI.unicast, 10)
+    cap.set_limit(AFI.ipv6, SAFI.unicast, 20)
+
+    bytes_list = cap.extract_capability_bytes()
+    data = bytes_list[0]
+    assert len(data) == 10  # 2 * 5 bytes
+
+
+def test_paths_limit_extract_bytes_skip_zero() -> None:
+    """Test that zero limit entries are not encoded."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    cap.set_limit(AFI.ipv4, SAFI.unicast, 0)
+
+    bytes_list = cap.extract_capability_bytes()
+    data = bytes_list[0]
+    assert len(data) == 0
+
+
+def test_paths_limit_unpack() -> None:
+    """Test PathsLimit wire decoding."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    # AFI IPv4 = 0x0001, SAFI unicast = 0x01, limit = 10 (0x000A)
+    data = b'\x00\x01\x01\x00\x0a'
+    result = PathsLimit.unpack_capability(cap, data, Capability.CODE.PATHS_LIMIT)
+
+    assert isinstance(result, PathsLimit)
+    assert result[(AFI.ipv4, SAFI.unicast)] == 10
+
+
+def test_paths_limit_unpack_multiple() -> None:
+    """Test PathsLimit decoding with multiple tuples."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    data = (
+        b'\x00\x01\x01\x00\x0a'  # IPv4 unicast, limit=10
+        b'\x00\x02\x01\x00\x14'  # IPv6 unicast, limit=20
+    )
+    result = PathsLimit.unpack_capability(cap, data, Capability.CODE.PATHS_LIMIT)
+
+    assert result[(AFI.ipv4, SAFI.unicast)] == 10
+    assert result[(AFI.ipv6, SAFI.unicast)] == 20
+
+
+def test_paths_limit_unpack_zero_ignored() -> None:
+    """Test that tuples with limit=0 are ignored."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    data = (
+        b'\x00\x01\x01\x00\x00'  # IPv4 unicast, limit=0 (ignored)
+        b'\x00\x02\x01\x00\x14'  # IPv6 unicast, limit=20
+    )
+    result = PathsLimit.unpack_capability(cap, data, Capability.CODE.PATHS_LIMIT)
+
+    assert (AFI.ipv4, SAFI.unicast) not in result
+    assert result[(AFI.ipv6, SAFI.unicast)] == 20
+
+
+def test_paths_limit_unpack_duplicate_first_wins() -> None:
+    """Test that duplicate AFI/SAFI uses first tuple only."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    data = (
+        b'\x00\x01\x01\x00\x0a'  # IPv4 unicast, limit=10 (first)
+        b'\x00\x01\x01\x00\x14'  # IPv4 unicast, limit=20 (duplicate, ignored)
+    )
+    result = PathsLimit.unpack_capability(cap, data, Capability.CODE.PATHS_LIMIT)
+
+    assert result[(AFI.ipv4, SAFI.unicast)] == 10
+
+
+def test_paths_limit_unpack_truncated() -> None:
+    """Test that truncated data raises Notify."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+    from exabgp.bgp.message.notification import Notify
+    import pytest
+
+    cap = PathsLimit()
+    data = b'\x00\x01\x01'  # Only 3 bytes, need 5
+
+    with pytest.raises(Notify):
+        PathsLimit.unpack_capability(cap, data, Capability.CODE.PATHS_LIMIT)
+
+
+def test_paths_limit_round_trip() -> None:
+    """Test pack -> unpack returns same data."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    original = PathsLimit()
+    original.set_limit(AFI.ipv4, SAFI.unicast, 10)
+    original.set_limit(AFI.ipv6, SAFI.unicast, 20)
+
+    packed = original.extract_capability_bytes()[0]
+    unpacked = PathsLimit()
+    PathsLimit.unpack_capability(unpacked, packed, Capability.CODE.PATHS_LIMIT)
+
+    assert dict(unpacked) == dict(original)
+
+
+def test_paths_limit_empty() -> None:
+    """Test empty PathsLimit capability."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    bytes_list = cap.extract_capability_bytes()
+    assert bytes_list == [b'']
+
+
+def test_paths_limit_json() -> None:
+    """Test PathsLimit JSON representation."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    cap.set_limit(AFI.ipv4, SAFI.unicast, 10)
+    json_str = cap.json()
+    assert '"name": "paths-limit"' in json_str
+    assert '"ipv4/unicast": 10' in json_str
+
+
+def test_paths_limit_str() -> None:
+    """Test PathsLimit string representation."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    cap.set_limit(AFI.ipv4, SAFI.unicast, 10)
+    s = str(cap)
+    assert 'PathsLimit' in s
+    assert '10' in s
+
+
+def test_open_with_paths_limit_capability() -> None:
+    """Test OPEN message with PATHS-LIMIT capability."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    capabilities = Capabilities()
+
+    addpath = AddPath()
+    addpath.add_path(AFI.ipv4, SAFI.unicast, 3)
+    capabilities[Capability.CODE.ADD_PATH] = addpath
+
+    pl = PathsLimit()
+    pl.set_limit(AFI.ipv4, SAFI.unicast, 10)
+    capabilities[Capability.CODE.PATHS_LIMIT] = pl
+
+    open_msg = Open.make_open(Version(4), ASN(65500), HoldTime(180), RouterID('192.0.2.1'), capabilities)
+
+    assert Capability.CODE.PATHS_LIMIT in open_msg.capabilities
+    assert Capability.CODE.ADD_PATH in open_msg.capabilities
+
+
+def test_paths_limit_max_value() -> None:
+    """Test PathsLimit with maximum uint16 value (65535)."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    cap = PathsLimit()
+    cap.set_limit(AFI.ipv4, SAFI.unicast, 65535)
+
+    packed = cap.extract_capability_bytes()[0]
+    assert packed == b'\x00\x01\x01\xff\xff'
+
+    unpacked = PathsLimit()
+    PathsLimit.unpack_capability(unpacked, packed, Capability.CODE.PATHS_LIMIT)
+    assert unpacked[(AFI.ipv4, SAFI.unicast)] == 65535
+
+
+def test_paths_limit_set_limit_rejects_negative() -> None:
+    """Test that set_limit rejects negative values."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+    import pytest
+
+    cap = PathsLimit()
+    with pytest.raises(ValueError, match='paths limit must be 0-65535'):
+        cap.set_limit(AFI.ipv4, SAFI.unicast, -1)
+
+
+def test_paths_limit_set_limit_rejects_overflow() -> None:
+    """Test that set_limit rejects values exceeding uint16."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+    import pytest
+
+    cap = PathsLimit()
+    with pytest.raises(ValueError, match='paths limit must be 0-65535'):
+        cap.set_limit(AFI.ipv4, SAFI.unicast, 65536)
+
+
+def test_paths_limit_negotiation_stores_peer_limit_only() -> None:
+    """Test that negotiated paths_limit stores only the peer's limits."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+    from exabgp.bgp.message.open.capability.mp import MultiProtocol
+
+    # Our OPEN: ADD-PATH send/receive + PATHS-LIMIT=5
+    sent_caps = Capabilities()
+    sent_mp = MultiProtocol()
+    sent_mp.append((AFI.ipv4, SAFI.unicast))
+    sent_caps[Capability.CODE.MULTIPROTOCOL] = sent_mp
+    sent_ap = AddPath()
+    sent_ap.add_path(AFI.ipv4, SAFI.unicast, 3)
+    sent_caps[Capability.CODE.ADD_PATH] = sent_ap
+    sent_pl = PathsLimit()
+    sent_pl.set_limit(AFI.ipv4, SAFI.unicast, 5)
+    sent_caps[Capability.CODE.PATHS_LIMIT] = sent_pl
+
+    # Peer's OPEN: ADD-PATH send/receive + PATHS-LIMIT=10
+    recv_caps = Capabilities()
+    recv_mp = MultiProtocol()
+    recv_mp.append((AFI.ipv4, SAFI.unicast))
+    recv_caps[Capability.CODE.MULTIPROTOCOL] = recv_mp
+    recv_ap = AddPath()
+    recv_ap.add_path(AFI.ipv4, SAFI.unicast, 3)
+    recv_caps[Capability.CODE.ADD_PATH] = recv_ap
+    recv_pl = PathsLimit()
+    recv_pl.set_limit(AFI.ipv4, SAFI.unicast, 10)
+    recv_caps[Capability.CODE.PATHS_LIMIT] = recv_pl
+
+    sent_open = Open.make_open(Version(4), ASN(65500), HoldTime(180), RouterID('192.0.2.1'), sent_caps)
+    recv_open = Open.make_open(Version(4), ASN(65501), HoldTime(180), RouterID('192.0.2.2'), recv_caps)
+
+    negotiated = create_negotiated()
+    negotiated.sent(sent_open)
+    negotiated.received(recv_open)
+
+    assert negotiated.paths_limit[(AFI.ipv4, SAFI.unicast)] == 10
+
+
+def test_paths_limit_negotiation_ignores_family_not_in_addpath() -> None:
+    """Test that PATHS-LIMIT tuples not in received ADD-PATH are ignored."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+    from exabgp.bgp.message.open.capability.mp import MultiProtocol
+
+    # Both sides: ADD-PATH for IPv4 only
+    sent_caps = Capabilities()
+    sent_mp = MultiProtocol()
+    sent_mp.append((AFI.ipv4, SAFI.unicast))
+    sent_mp.append((AFI.ipv6, SAFI.unicast))
+    sent_caps[Capability.CODE.MULTIPROTOCOL] = sent_mp
+    sent_ap = AddPath()
+    sent_ap.add_path(AFI.ipv4, SAFI.unicast, 3)
+    sent_caps[Capability.CODE.ADD_PATH] = sent_ap
+
+    recv_caps = Capabilities()
+    recv_mp = MultiProtocol()
+    recv_mp.append((AFI.ipv4, SAFI.unicast))
+    recv_mp.append((AFI.ipv6, SAFI.unicast))
+    recv_caps[Capability.CODE.MULTIPROTOCOL] = recv_mp
+    recv_ap = AddPath()
+    recv_ap.add_path(AFI.ipv4, SAFI.unicast, 3)
+    recv_caps[Capability.CODE.ADD_PATH] = recv_ap
+
+    # Peer's PATHS-LIMIT includes IPv6 which is NOT in their ADD-PATH
+    recv_pl = PathsLimit()
+    recv_pl.set_limit(AFI.ipv4, SAFI.unicast, 10)
+    recv_pl.set_limit(AFI.ipv6, SAFI.unicast, 20)
+    recv_caps[Capability.CODE.PATHS_LIMIT] = recv_pl
+
+    sent_open = Open.make_open(Version(4), ASN(65500), HoldTime(180), RouterID('192.0.2.1'), sent_caps)
+    recv_open = Open.make_open(Version(4), ASN(65501), HoldTime(180), RouterID('192.0.2.2'), recv_caps)
+
+    negotiated = create_negotiated()
+    negotiated.sent(sent_open)
+    negotiated.received(recv_open)
+
+    assert negotiated.paths_limit[(AFI.ipv4, SAFI.unicast)] == 10
+    assert (AFI.ipv6, SAFI.unicast) not in negotiated.paths_limit
+
+
+def test_paths_limit_negotiation_ignored_without_addpath() -> None:
+    """Test PATHS-LIMIT is ignored when ADD-PATH is not present."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+    from exabgp.bgp.message.open.capability.mp import MultiProtocol
+
+    sent_caps = Capabilities()
+    sent_mp = MultiProtocol()
+    sent_mp.append((AFI.ipv4, SAFI.unicast))
+    sent_caps[Capability.CODE.MULTIPROTOCOL] = sent_mp
+    # No ADD-PATH on our side
+
+    recv_caps = Capabilities()
+    recv_mp = MultiProtocol()
+    recv_mp.append((AFI.ipv4, SAFI.unicast))
+    recv_caps[Capability.CODE.MULTIPROTOCOL] = recv_mp
+
+    # Peer sends PATHS-LIMIT but no ADD-PATH
+    recv_pl = PathsLimit()
+    recv_pl.set_limit(AFI.ipv4, SAFI.unicast, 10)
+    recv_caps[Capability.CODE.PATHS_LIMIT] = recv_pl
+
+    sent_open = Open.make_open(Version(4), ASN(65500), HoldTime(180), RouterID('192.0.2.1'), sent_caps)
+    recv_open = Open.make_open(Version(4), ASN(65501), HoldTime(180), RouterID('192.0.2.2'), recv_caps)
+
+    negotiated = create_negotiated()
+    negotiated.sent(sent_open)
+    negotiated.received(recv_open)
+
+    assert negotiated.paths_limit == {}
+
+
+def test_paths_limit_negotiation_send_only_not_stored() -> None:
+    """Test PATHS-LIMIT not stored for families where addpath is send-only."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+    from exabgp.bgp.message.open.capability.mp import MultiProtocol
+
+    # We send ADD-PATH receive-only, peer sends ADD-PATH receive-only
+    sent_caps = Capabilities()
+    sent_mp = MultiProtocol()
+    sent_mp.append((AFI.ipv4, SAFI.unicast))
+    sent_caps[Capability.CODE.MULTIPROTOCOL] = sent_mp
+    sent_ap = AddPath()
+    sent_ap.add_path(AFI.ipv4, SAFI.unicast, 1)
+    sent_caps[Capability.CODE.ADD_PATH] = sent_ap
+
+    recv_caps = Capabilities()
+    recv_mp = MultiProtocol()
+    recv_mp.append((AFI.ipv4, SAFI.unicast))
+    recv_caps[Capability.CODE.MULTIPROTOCOL] = recv_mp
+    recv_ap = AddPath()
+    recv_ap.add_path(AFI.ipv4, SAFI.unicast, 1)
+    recv_caps[Capability.CODE.ADD_PATH] = recv_ap
+    recv_pl = PathsLimit()
+    recv_pl.set_limit(AFI.ipv4, SAFI.unicast, 10)
+    recv_caps[Capability.CODE.PATHS_LIMIT] = recv_pl
+
+    sent_open = Open.make_open(Version(4), ASN(65500), HoldTime(180), RouterID('192.0.2.1'), sent_caps)
+    recv_open = Open.make_open(Version(4), ASN(65501), HoldTime(180), RouterID('192.0.2.2'), recv_caps)
+
+    negotiated = create_negotiated()
+    negotiated.sent(sent_open)
+    negotiated.received(recv_open)
+
+    assert negotiated.paths_limit == {}
+
+
+def test_paths_limit_prefix_index_without_addpath() -> None:
+    """Test INET prefix_index() without addpath returns same as index()."""
+    nlri = make_inet('10.0.0.0/24')
+    assert nlri.prefix_index() == nlri.index()
+
+
+def test_paths_limit_prefix_index_with_addpath() -> None:
+    """Test INET prefix_index() with addpath strips path_id."""
+    nlri1 = make_inet('10.0.0.0/24', path_id=1)
+    nlri2 = make_inet('10.0.0.0/24', path_id=2)
+
+    assert nlri1.index() != nlri2.index()
+    assert nlri1.prefix_index() == nlri2.prefix_index()
+
+
+def test_paths_limit_prefix_index_different_prefixes() -> None:
+    """Test prefix_index() differs for different prefixes."""
+    nlri1 = make_inet('10.0.0.0/24', path_id=1)
+    nlri2 = make_inet('10.0.1.0/24', path_id=1)
+
+    assert nlri1.prefix_index() != nlri2.prefix_index()
+
+
+def test_paths_limit_outgoing_rib_enforcement() -> None:
+    """Test OutgoingRIB.updates() enforces paths-limit per prefix."""
+    from exabgp.bgp.message.update.attribute.collection import AttributeCollection
+    from exabgp.rib.outgoing import OutgoingRIB
+    from exabgp.rib.route import Route
+    from exabgp.protocol.ip import IP
+
+    family = (AFI.ipv4, SAFI.unicast)
+    rib = OutgoingRIB(cache=False, families={family})
+
+    attrs = AttributeCollection()
+
+    for pid in (1, 2, 3):
+        nlri = make_inet('10.0.0.0/24', path_id=pid)
+        route = Route(nlri, attrs, nexthop=IP.from_string('1.2.3.4'))
+        rib.add_to_rib(route, force=True)
+
+    updates_no_limit = list(rib.updates(grouped=True, paths_limit=None))
+    total_no_limit = sum(len(u.announces) for u in updates_no_limit if hasattr(u, 'announces'))
+    assert total_no_limit == 3
+
+    for pid in (1, 2, 3):
+        nlri = make_inet('10.0.0.0/24', path_id=pid)
+        route = Route(nlri, attrs, nexthop=IP.from_string('1.2.3.4'))
+        rib.add_to_rib(route, force=True)
+
+    updates_limited = list(rib.updates(grouped=True, paths_limit={family: 2}))
+    total_limited = sum(len(u.announces) for u in updates_limited if hasattr(u, 'announces'))
+    assert total_limited == 2
+
+
+def test_paths_limit_outgoing_rib_different_prefixes() -> None:
+    """Test paths-limit counts independently per prefix."""
+    from exabgp.bgp.message.update.attribute.collection import AttributeCollection
+    from exabgp.rib.outgoing import OutgoingRIB
+    from exabgp.rib.route import Route
+    from exabgp.protocol.ip import IP
+
+    family = (AFI.ipv4, SAFI.unicast)
+    rib = OutgoingRIB(cache=False, families={family})
+
+    attrs = AttributeCollection()
+
+    for pid in (1, 2):
+        nlri = make_inet('10.0.0.0/24', path_id=pid)
+        rib.add_to_rib(Route(nlri, attrs, nexthop=IP.from_string('1.2.3.4')), force=True)
+    for pid in (1, 2):
+        nlri = make_inet('10.0.1.0/24', path_id=pid)
+        rib.add_to_rib(Route(nlri, attrs, nexthop=IP.from_string('1.2.3.4')), force=True)
+
+    updates = list(rib.updates(grouped=True, paths_limit={family: 1}))
+    total = sum(len(u.announces) for u in updates if hasattr(u, 'announces'))
+    assert total == 2
+
+
+def test_paths_limit_outgoing_rib_no_limit_family() -> None:
+    """Test paths-limit doesn't affect families without a limit."""
+    from exabgp.bgp.message.update.attribute.collection import AttributeCollection
+    from exabgp.rib.outgoing import OutgoingRIB
+    from exabgp.rib.route import Route
+    from exabgp.protocol.ip import IP
+
+    family = (AFI.ipv4, SAFI.unicast)
+    rib = OutgoingRIB(cache=False, families={family})
+
+    attrs = AttributeCollection()
+    for pid in (1, 2, 3):
+        nlri = make_inet('10.0.0.0/24', path_id=pid)
+        rib.add_to_rib(Route(nlri, attrs, nexthop=IP.from_string('1.2.3.4')), force=True)
+
+    updates = list(rib.updates(grouped=True, paths_limit={(AFI.ipv6, SAFI.unicast): 1}))
+    total = sum(len(u.announces) for u in updates if hasattr(u, 'announces'))
+    assert total == 3
+
+
+def test_neighbor_capability_paths_limit_per_family_default() -> None:
+    """Test NeighborCapability has empty per-family limits by default."""
+    from exabgp.bgp.neighbor.capability import NeighborCapability
+
+    cap = NeighborCapability()
+    assert cap.paths_limit_per_family == {}
+
+
+def test_neighbor_capability_paths_limit_per_family_copy() -> None:
+    """Test per-family limits are copied correctly."""
+    from exabgp.bgp.neighbor.capability import NeighborCapability
+
+    cap = NeighborCapability()
+    cap.paths_limit_per_family[(AFI.ipv4, SAFI.unicast)] = 5
+    cap.paths_limit_per_family[(AFI.ipv6, SAFI.unicast)] = 10
+
+    copy = cap.copy()
+    assert copy.paths_limit_per_family == cap.paths_limit_per_family
+    copy.paths_limit_per_family[(AFI.ipv4, SAFI.unicast)] = 99
+    assert cap.paths_limit_per_family[(AFI.ipv4, SAFI.unicast)] == 5
+
+
+def test_pathslimit_capability_per_family_override() -> None:
+    """Test _pathslimit() uses per-family override over default."""
+    from unittest.mock import Mock
+    from exabgp.bgp.neighbor.capability import NeighborCapability
+
+    neighbor = Mock()
+    cap = NeighborCapability()
+    cap.add_path = 3
+    cap.paths_limit = 10
+    cap.paths_limit_per_family = {(AFI.ipv4, SAFI.unicast): 5}
+    neighbor.capability = cap
+
+    addpath = AddPath()
+    addpath.add_path(AFI.ipv4, SAFI.unicast, 3)
+    addpath.add_path(AFI.ipv6, SAFI.unicast, 3)
+
+    caps = Capabilities()
+    caps[Capability.CODE.ADD_PATH] = addpath
+    caps._pathslimit(neighbor)
+
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+    pl = caps.get(Capability.CODE.PATHS_LIMIT)
+    assert isinstance(pl, PathsLimit)
+    assert pl[(AFI.ipv4, SAFI.unicast)] == 5
+    assert pl[(AFI.ipv6, SAFI.unicast)] == 10
+
+
+def test_advertised_paths_limit_default_empty() -> None:
+    """advertised_paths_limit is empty before negotiation."""
+    n = create_negotiated()
+    assert n.advertised_paths_limit == {}
+
+
+def test_advertised_paths_limit_unset_sentinel_empty() -> None:
+    """Negotiated.UNSET sentinel exposes empty advertised_paths_limit."""
+    assert Negotiated.UNSET.advertised_paths_limit == {}
+
+
+def test_advertised_paths_limit_populated_from_sent_open() -> None:
+    """advertised_paths_limit captures our own PATHS-LIMIT for receive-direction families."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+    from exabgp.bgp.message.open.capability.mp import MultiProtocol
+
+    sent_caps = Capabilities()
+    sent_mp = MultiProtocol()
+    sent_mp.append((AFI.ipv4, SAFI.unicast))
+    sent_caps[Capability.CODE.MULTIPROTOCOL] = sent_mp
+    sent_ap = AddPath()
+    sent_ap.add_path(AFI.ipv4, SAFI.unicast, 3)
+    sent_caps[Capability.CODE.ADD_PATH] = sent_ap
+    sent_pl = PathsLimit()
+    sent_pl.set_limit(AFI.ipv4, SAFI.unicast, 7)
+    sent_caps[Capability.CODE.PATHS_LIMIT] = sent_pl
+
+    recv_caps = Capabilities()
+    recv_mp = MultiProtocol()
+    recv_mp.append((AFI.ipv4, SAFI.unicast))
+    recv_caps[Capability.CODE.MULTIPROTOCOL] = recv_mp
+    recv_ap = AddPath()
+    recv_ap.add_path(AFI.ipv4, SAFI.unicast, 3)
+    recv_caps[Capability.CODE.ADD_PATH] = recv_ap
+
+    sent_open = Open.make_open(Version(4), ASN(65500), HoldTime(180), RouterID('192.0.2.1'), sent_caps)
+    recv_open = Open.make_open(Version(4), ASN(65501), HoldTime(180), RouterID('192.0.2.2'), recv_caps)
+
+    n = create_negotiated()
+    n.sent(sent_open)
+    n.received(recv_open)
+
+    assert n.advertised_paths_limit[(AFI.ipv4, SAFI.unicast)] == 7
+
+
+def test_advertised_paths_limit_skips_send_only_addpath() -> None:
+    """advertised_paths_limit only includes families which we actually receive."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+    from exabgp.bgp.message.open.capability.mp import MultiProtocol
+
+    sent_caps = Capabilities()
+    sent_mp = MultiProtocol()
+    sent_mp.append((AFI.ipv4, SAFI.unicast))
+    sent_caps[Capability.CODE.MULTIPROTOCOL] = sent_mp
+    sent_ap = AddPath()
+    sent_ap.add_path(AFI.ipv4, SAFI.unicast, 2)
+    sent_caps[Capability.CODE.ADD_PATH] = sent_ap
+    sent_pl = PathsLimit()
+    sent_pl.set_limit(AFI.ipv4, SAFI.unicast, 9)
+    sent_caps[Capability.CODE.PATHS_LIMIT] = sent_pl
+
+    recv_caps = Capabilities()
+    recv_mp = MultiProtocol()
+    recv_mp.append((AFI.ipv4, SAFI.unicast))
+    recv_caps[Capability.CODE.MULTIPROTOCOL] = recv_mp
+    recv_ap = AddPath()
+    recv_ap.add_path(AFI.ipv4, SAFI.unicast, 1)
+    recv_caps[Capability.CODE.ADD_PATH] = recv_ap
+
+    sent_open = Open.make_open(Version(4), ASN(65500), HoldTime(180), RouterID('192.0.2.1'), sent_caps)
+    recv_open = Open.make_open(Version(4), ASN(65501), HoldTime(180), RouterID('192.0.2.2'), recv_caps)
+
+    n = create_negotiated()
+    n.sent(sent_open)
+    n.received(recv_open)
+
+    assert n.advertised_paths_limit == {}
+
+
+def test_advertised_paths_limit_skips_family_not_in_sent_addpath() -> None:
+    """A PATHS-LIMIT entry for a family not in our ADD-PATH is discarded."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+    from exabgp.bgp.message.open.capability.mp import MultiProtocol
+
+    sent_caps = Capabilities()
+    sent_mp = MultiProtocol()
+    sent_mp.append((AFI.ipv4, SAFI.unicast))
+    sent_mp.append((AFI.ipv6, SAFI.unicast))
+    sent_caps[Capability.CODE.MULTIPROTOCOL] = sent_mp
+    sent_ap = AddPath()
+    sent_ap.add_path(AFI.ipv4, SAFI.unicast, 3)
+    sent_caps[Capability.CODE.ADD_PATH] = sent_ap
+    sent_pl = PathsLimit()
+    sent_pl.set_limit(AFI.ipv4, SAFI.unicast, 5)
+    sent_pl.set_limit(AFI.ipv6, SAFI.unicast, 6)
+    sent_caps[Capability.CODE.PATHS_LIMIT] = sent_pl
+
+    recv_caps = Capabilities()
+    recv_mp = MultiProtocol()
+    recv_mp.append((AFI.ipv4, SAFI.unicast))
+    recv_mp.append((AFI.ipv6, SAFI.unicast))
+    recv_caps[Capability.CODE.MULTIPROTOCOL] = recv_mp
+    recv_ap = AddPath()
+    recv_ap.add_path(AFI.ipv4, SAFI.unicast, 3)
+    recv_caps[Capability.CODE.ADD_PATH] = recv_ap
+
+    sent_open = Open.make_open(Version(4), ASN(65500), HoldTime(180), RouterID('192.0.2.1'), sent_caps)
+    recv_open = Open.make_open(Version(4), ASN(65501), HoldTime(180), RouterID('192.0.2.2'), recv_caps)
+
+    n = create_negotiated()
+    n.sent(sent_open)
+    n.received(recv_open)
+
+    assert n.advertised_paths_limit == {(AFI.ipv4, SAFI.unicast): 5}
+
+
+def test_advertised_paths_limit_empty_without_addpath_negotiated() -> None:
+    """When ADD-PATH is not bilaterally negotiated, advertised_paths_limit is empty."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+    from exabgp.bgp.message.open.capability.mp import MultiProtocol
+
+    sent_caps = Capabilities()
+    sent_mp = MultiProtocol()
+    sent_mp.append((AFI.ipv4, SAFI.unicast))
+    sent_caps[Capability.CODE.MULTIPROTOCOL] = sent_mp
+    sent_pl = PathsLimit()
+    sent_pl.set_limit(AFI.ipv4, SAFI.unicast, 5)
+    sent_caps[Capability.CODE.PATHS_LIMIT] = sent_pl
+    # No ADD-PATH on our side
+
+    recv_caps = Capabilities()
+    recv_mp = MultiProtocol()
+    recv_mp.append((AFI.ipv4, SAFI.unicast))
+    recv_caps[Capability.CODE.MULTIPROTOCOL] = recv_mp
+    recv_ap = AddPath()
+    recv_ap.add_path(AFI.ipv4, SAFI.unicast, 3)
+    recv_caps[Capability.CODE.ADD_PATH] = recv_ap
+
+    sent_open = Open.make_open(Version(4), ASN(65500), HoldTime(180), RouterID('192.0.2.1'), sent_caps)
+    recv_open = Open.make_open(Version(4), ASN(65501), HoldTime(180), RouterID('192.0.2.2'), recv_caps)
+
+    n = create_negotiated()
+    n.sent(sent_open)
+    n.received(recv_open)
+
+    assert n.advertised_paths_limit == {}
+
+
+def test_advertised_paths_limit_independent_from_paths_limit() -> None:
+    """advertised_paths_limit (our caps) and paths_limit (peer caps) are tracked separately."""
+    from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+    from exabgp.bgp.message.open.capability.mp import MultiProtocol
+
+    sent_caps = Capabilities()
+    sent_mp = MultiProtocol()
+    sent_mp.append((AFI.ipv4, SAFI.unicast))
+    sent_caps[Capability.CODE.MULTIPROTOCOL] = sent_mp
+    sent_ap = AddPath()
+    sent_ap.add_path(AFI.ipv4, SAFI.unicast, 3)
+    sent_caps[Capability.CODE.ADD_PATH] = sent_ap
+    sent_pl = PathsLimit()
+    sent_pl.set_limit(AFI.ipv4, SAFI.unicast, 5)
+    sent_caps[Capability.CODE.PATHS_LIMIT] = sent_pl
+
+    recv_caps = Capabilities()
+    recv_mp = MultiProtocol()
+    recv_mp.append((AFI.ipv4, SAFI.unicast))
+    recv_caps[Capability.CODE.MULTIPROTOCOL] = recv_mp
+    recv_ap = AddPath()
+    recv_ap.add_path(AFI.ipv4, SAFI.unicast, 3)
+    recv_caps[Capability.CODE.ADD_PATH] = recv_ap
+    recv_pl = PathsLimit()
+    recv_pl.set_limit(AFI.ipv4, SAFI.unicast, 11)
+    recv_caps[Capability.CODE.PATHS_LIMIT] = recv_pl
+
+    sent_open = Open.make_open(Version(4), ASN(65500), HoldTime(180), RouterID('192.0.2.1'), sent_caps)
+    recv_open = Open.make_open(Version(4), ASN(65501), HoldTime(180), RouterID('192.0.2.2'), recv_caps)
+
+    n = create_negotiated()
+    n.sent(sent_open)
+    n.received(recv_open)
+
+    assert n.advertised_paths_limit == {(AFI.ipv4, SAFI.unicast): 5}
+    assert n.paths_limit == {(AFI.ipv4, SAFI.unicast): 11}
+
+
+# ==============================================================================
 # Summary
 # ==============================================================================
-# Total tests: 48
+# Total tests: 84
 #
 # Coverage:
 # - Basic OPEN message creation (4 tests)
@@ -765,6 +1528,8 @@ def test_link_local_nexthop_unpack_duplicate() -> None:
 # - Message encoding (2 tests)
 # - Message validation (3 tests)
 # - Capability code constants (6 tests)
+# - Link-Local Next Hop capability (11 tests)
+# - PATHS-LIMIT capability (40 tests)
 #
 # This test suite ensures:
 # - Proper OPEN message creation with various capabilities
@@ -772,4 +1537,5 @@ def test_link_local_nexthop_unpack_duplicate() -> None:
 # - Support for modern BGP features
 # - RFC compliance for all tested capabilities
 # - Realistic multi-capability scenarios
+# - Compliance for PATHS-LIMIT negotiation and enforcement
 # ==============================================================================

--- a/tests/unit/test_paths_limit_config.py
+++ b/tests/unit/test_paths_limit_config.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+"""test_paths_limit_config.py
+
+Comprehensive tests for PATHS-LIMIT configuration parsing.
+
+License: 3-clause BSD
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from exabgp.configuration.configuration import Configuration
+from exabgp.protocol.family import AFI, SAFI
+
+
+def _parse(cfg: str) -> tuple[bool, Configuration]:
+    c = Configuration([cfg], text=True)
+    ok = c.reload()
+    return ok, c
+
+
+def _neighbor_template(extra_capability: str = '', extra_neighbor: str = '', families: str = 'ipv4 unicast;') -> str:
+    return f"""neighbor 127.0.0.1 {{
+    router-id 10.0.0.2;
+    local-address 127.0.0.1;
+    local-as 65500;
+    peer-as 65500;
+    capability {{
+        add-path send/receive;
+        {extra_capability}
+    }}
+    family {{ {families} }}
+    {extra_neighbor}
+}}"""
+
+
+class TestSugarForm:
+    def test_sugar_sets_default(self) -> None:
+        ok, c = _parse(_neighbor_template('paths-limit 10;'))
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit == 10
+        assert n.capability.paths_limit_per_family == {}
+
+    def test_sugar_zero_allowed(self) -> None:
+        ok, c = _parse(_neighbor_template('paths-limit 0;'))
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit == 0
+
+    def test_sugar_max_uint16(self) -> None:
+        ok, c = _parse(_neighbor_template('paths-limit 65535;'))
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit == 65535
+
+    def test_sugar_negative_rejected(self) -> None:
+        ok, _ = _parse(_neighbor_template('paths-limit -1;'))
+        assert not ok
+
+    def test_sugar_overflow_rejected(self) -> None:
+        ok, _ = _parse(_neighbor_template('paths-limit 70000;'))
+        assert not ok
+
+    def test_sugar_non_numeric_rejected(self) -> None:
+        ok, _ = _parse(_neighbor_template('paths-limit foo;'))
+        assert not ok
+
+
+class TestBlockForm:
+    def test_block_with_all_only(self) -> None:
+        ok, c = _parse(_neighbor_template('paths-limit { all 7; }'))
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit == 7
+        assert n.capability.paths_limit_per_family == {}
+
+    def test_block_with_all_and_override(self) -> None:
+        ok, c = _parse(
+            _neighbor_template(
+                'paths-limit { all 7; ipv4 unicast 32; }',
+                families='ipv4 unicast; ipv6 unicast;',
+            )
+        )
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit == 7
+        assert n.capability.paths_limit_per_family == {(AFI.ipv4, SAFI.unicast): 32}
+
+    def test_block_per_family_only_no_default(self) -> None:
+        ok, c = _parse(
+            _neighbor_template(
+                'paths-limit { ipv4 unicast 5; ipv6 unicast 0; }',
+                families='ipv4 unicast; ipv6 unicast;',
+            )
+        )
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit == 0  # untouched
+        assert n.capability.paths_limit_per_family == {
+            (AFI.ipv4, SAFI.unicast): 5,
+            (AFI.ipv6, SAFI.unicast): 0,
+        }
+
+    def test_block_empty(self) -> None:
+        ok, c = _parse(_neighbor_template('paths-limit { }'))
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit == 0
+        assert n.capability.paths_limit_per_family == {}
+
+    def test_block_zero_per_family_disables(self) -> None:
+        ok, c = _parse(
+            _neighbor_template(
+                'paths-limit { all 10; ipv6 unicast 0; }',
+                families='ipv4 unicast; ipv6 unicast;',
+            )
+        )
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit == 10
+        assert n.capability.paths_limit_per_family == {(AFI.ipv6, SAFI.unicast): 0}
+
+    def test_block_multiple_families_across_afis(self) -> None:
+        ok, c = _parse(
+            _neighbor_template(
+                'paths-limit { ipv4 unicast 10; ipv6 unicast 20; l2vpn evpn 5; }',
+                families='ipv4 unicast; ipv6 unicast; l2vpn evpn;',
+            )
+        )
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit_per_family == {
+            (AFI.ipv4, SAFI.unicast): 10,
+            (AFI.ipv6, SAFI.unicast): 20,
+            (AFI.l2vpn, SAFI.evpn): 5,
+        }
+
+
+class TestCombinationSemantics:
+    def test_sugar_then_block_block_wins_with_merge(self) -> None:
+        ok, c = _parse(
+            _neighbor_template(
+                'paths-limit 5; paths-limit { all 9; ipv4 unicast 33; }',
+            )
+        )
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit == 9
+        assert n.capability.paths_limit_per_family == {(AFI.ipv4, SAFI.unicast): 33}
+
+    def test_block_then_sugar_sugar_overwrites(self) -> None:
+        ok, c = _parse(
+            _neighbor_template(
+                'paths-limit { ipv4 unicast 33; } paths-limit 5;',
+            )
+        )
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit == 5
+        assert n.capability.paths_limit_per_family == {}
+
+
+class TestValidation:
+    def test_block_duplicate_all_rejected(self) -> None:
+        ok, _ = _parse(_neighbor_template('paths-limit { all 5; all 10; }'))
+        assert not ok
+
+    def test_block_duplicate_per_family_rejected(self) -> None:
+        ok, _ = _parse(_neighbor_template('paths-limit { ipv4 unicast 5; ipv4 unicast 10; }'))
+        assert not ok
+
+    def test_block_per_family_overflow_rejected(self) -> None:
+        ok, _ = _parse(_neighbor_template('paths-limit { ipv4 unicast 70000; }'))
+        assert not ok
+
+    def test_block_per_family_negative_rejected(self) -> None:
+        ok, _ = _parse(_neighbor_template('paths-limit { ipv4 unicast -1; }'))
+        assert not ok
+
+    def test_block_all_negative_rejected(self) -> None:
+        ok, _ = _parse(_neighbor_template('paths-limit { all -1; }'))
+        assert not ok
+
+    def test_block_all_overflow_rejected(self) -> None:
+        ok, _ = _parse(_neighbor_template('paths-limit { all 70000; }'))
+        assert not ok
+
+    def test_block_invalid_safi_rejected(self) -> None:
+        ok, _ = _parse(_neighbor_template('paths-limit { ipv4 frobnicate 5; }'))
+        assert not ok
+
+    def test_block_missing_limit_rejected(self) -> None:
+        ok, _ = _parse(_neighbor_template('paths-limit { ipv4 unicast; }'))
+        assert not ok
+
+
+class TestFamilyNotNegotiated:
+    def test_unnegotiated_family_silently_skipped(self) -> None:
+        ok, c = _parse(
+            _neighbor_template(
+                'paths-limit { ipv6 mpls-vpn 5; }',
+                families='ipv4 unicast;',
+            )
+        )
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit_per_family == {}
+
+    def test_mix_negotiated_and_unnegotiated(self) -> None:
+        ok, c = _parse(
+            _neighbor_template(
+                'paths-limit { ipv4 unicast 7; ipv6 mpls-vpn 5; }',
+                families='ipv4 unicast;',
+            )
+        )
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+        assert n.capability.paths_limit_per_family == {(AFI.ipv4, SAFI.unicast): 7}
+
+
+class TestEmissionIntegration:
+    def test_default_only_emits_for_all_addpath_families(self) -> None:
+        ok, c = _parse(
+            _neighbor_template(
+                'paths-limit 8;',
+                families='ipv4 unicast; ipv6 unicast;',
+            )
+        )
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+
+        from exabgp.bgp.message.open.capability import Capabilities, Capability
+        from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+        caps = Capabilities()
+        caps.new(n, restarted=False)
+        pl = caps.get(Capability.CODE.PATHS_LIMIT)
+        assert isinstance(pl, PathsLimit)
+        assert pl[(AFI.ipv4, SAFI.unicast)] == 8
+        assert pl[(AFI.ipv6, SAFI.unicast)] == 8
+
+    def test_per_family_overrides_default(self) -> None:
+        ok, c = _parse(
+            _neighbor_template(
+                'paths-limit { all 8; ipv6 unicast 32; }',
+                families='ipv4 unicast; ipv6 unicast;',
+            )
+        )
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+
+        from exabgp.bgp.message.open.capability import Capabilities, Capability
+        from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+        caps = Capabilities()
+        caps.new(n, restarted=False)
+        pl = caps.get(Capability.CODE.PATHS_LIMIT)
+        assert isinstance(pl, PathsLimit)
+        assert pl[(AFI.ipv4, SAFI.unicast)] == 8
+        assert pl[(AFI.ipv6, SAFI.unicast)] == 32
+
+    def test_zero_per_family_excludes_from_wire(self) -> None:
+        ok, c = _parse(
+            _neighbor_template(
+                'paths-limit { all 8; ipv6 unicast 0; }',
+                families='ipv4 unicast; ipv6 unicast;',
+            )
+        )
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+
+        from exabgp.bgp.message.open.capability import Capabilities, Capability
+        from exabgp.bgp.message.open.capability.pathslimit import PathsLimit
+
+        caps = Capabilities()
+        caps.new(n, restarted=False)
+        pl = caps.get(Capability.CODE.PATHS_LIMIT)
+        assert isinstance(pl, PathsLimit)
+        assert (AFI.ipv4, SAFI.unicast) in pl
+        assert (AFI.ipv6, SAFI.unicast) not in pl
+
+    def test_no_paths_limit_no_capability_emitted(self) -> None:
+        ok, c = _parse(_neighbor_template(''))
+        assert ok, c.error
+        n = next(iter(c.neighbors.values()))
+
+        from exabgp.bgp.message.open.capability import Capabilities, Capability
+
+        caps = Capabilities()
+        caps.new(n, restarted=False)
+        assert caps.get(Capability.CODE.PATHS_LIMIT) is None
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/tests/unit/test_rib_incoming.py
+++ b/tests/unit/test_rib_incoming.py
@@ -574,5 +574,137 @@ class TestCacheEdgeCases:
         assert str(cached[0].nlri) == '10.0.2.0/24'
 
 
+class TestIncomingRIBPathAuditTrack:
+    """Tests for IncomingRIB.track_path()."""
+
+    def test_track_path_first_call_returns_one(self):
+        rib = create_incoming_rib()
+        family = (AFI.ipv4, SAFI.unicast)
+        assert rib.track_path(family, b'p1') == 1
+
+    def test_track_path_increments_each_call(self):
+        rib = create_incoming_rib()
+        family = (AFI.ipv4, SAFI.unicast)
+        assert rib.track_path(family, b'p1') == 1
+        assert rib.track_path(family, b'p1') == 2
+        assert rib.track_path(family, b'p1') == 3
+
+    def test_track_path_different_prefixes_independent(self):
+        rib = create_incoming_rib()
+        family = (AFI.ipv4, SAFI.unicast)
+        rib.track_path(family, b'p1')
+        rib.track_path(family, b'p1')
+        assert rib.track_path(family, b'p2') == 1
+
+    def test_track_path_different_families_independent(self):
+        families = {(AFI.ipv4, SAFI.unicast), (AFI.ipv6, SAFI.unicast)}
+        rib = IncomingRIB(cache=True, families=families)
+        f4 = (AFI.ipv4, SAFI.unicast)
+        f6 = (AFI.ipv6, SAFI.unicast)
+        rib.track_path(f4, b'p1')
+        rib.track_path(f4, b'p1')
+        assert rib.track_path(f6, b'p1') == 1
+
+    def test_track_path_works_when_cache_disabled(self):
+        rib = IncomingRIB(cache=False, families={(AFI.ipv4, SAFI.unicast)})
+        family = (AFI.ipv4, SAFI.unicast)
+        assert rib.track_path(family, b'p1') == 1
+        assert rib.track_path(family, b'p1') == 2
+
+
+class TestIncomingRIBPathAuditUntrack:
+    """Tests for IncomingRIB.untrack_path()."""
+
+    def test_untrack_path_decrements(self):
+        rib = create_incoming_rib()
+        family = (AFI.ipv4, SAFI.unicast)
+        rib.track_path(family, b'p1')
+        rib.track_path(family, b'p1')
+        rib.untrack_path(family, b'p1')
+        assert rib.track_path(family, b'p1') == 2
+
+    def test_untrack_path_removes_when_zero(self):
+        rib = create_incoming_rib()
+        family = (AFI.ipv4, SAFI.unicast)
+        rib.track_path(family, b'p1')
+        rib.untrack_path(family, b'p1')
+        assert rib.track_path(family, b'p1') == 1
+
+    def test_untrack_path_missing_family_safe(self):
+        rib = create_incoming_rib()
+        rib.untrack_path((AFI.ipv4, SAFI.unicast), b'p1')
+
+    def test_untrack_path_missing_prefix_safe(self):
+        rib = create_incoming_rib()
+        family = (AFI.ipv4, SAFI.unicast)
+        rib.track_path(family, b'p1')
+        rib.untrack_path(family, b'p_unknown')
+
+    def test_untrack_path_clears_warned_flag_at_zero(self):
+        rib = create_incoming_rib()
+        family = (AFI.ipv4, SAFI.unicast)
+        rib.track_path(family, b'p1')
+        rib.mark_warned(family, b'p1')
+        rib.untrack_path(family, b'p1')
+        assert rib.mark_warned(family, b'p1') is True
+
+    def test_untrack_path_keeps_warned_flag_above_zero(self):
+        rib = create_incoming_rib()
+        family = (AFI.ipv4, SAFI.unicast)
+        rib.track_path(family, b'p1')
+        rib.track_path(family, b'p1')
+        rib.mark_warned(family, b'p1')
+        rib.untrack_path(family, b'p1')
+        assert rib.mark_warned(family, b'p1') is False
+
+
+class TestIncomingRIBPathAuditMarkWarned:
+    """Tests for IncomingRIB.mark_warned()."""
+
+    def test_mark_warned_first_returns_true(self):
+        rib = create_incoming_rib()
+        assert rib.mark_warned((AFI.ipv4, SAFI.unicast), b'p1') is True
+
+    def test_mark_warned_second_returns_false(self):
+        rib = create_incoming_rib()
+        rib.mark_warned((AFI.ipv4, SAFI.unicast), b'p1')
+        assert rib.mark_warned((AFI.ipv4, SAFI.unicast), b'p1') is False
+
+    def test_mark_warned_independent_per_prefix(self):
+        rib = create_incoming_rib()
+        family = (AFI.ipv4, SAFI.unicast)
+        rib.mark_warned(family, b'p1')
+        assert rib.mark_warned(family, b'p2') is True
+
+    def test_mark_warned_independent_per_family(self):
+        families = {(AFI.ipv4, SAFI.unicast), (AFI.ipv6, SAFI.unicast)}
+        rib = IncomingRIB(cache=True, families=families)
+        rib.mark_warned((AFI.ipv4, SAFI.unicast), b'p1')
+        assert rib.mark_warned((AFI.ipv6, SAFI.unicast), b'p1') is True
+
+
+class TestIncomingRIBPathAuditClear:
+    """Tests for IncomingRIB.clear()."""
+
+    def test_clear_resets_path_counts(self):
+        rib = create_incoming_rib()
+        family = (AFI.ipv4, SAFI.unicast)
+        rib.track_path(family, b'p1')
+        rib.track_path(family, b'p1')
+        rib.clear()
+        assert rib.track_path(family, b'p1') == 1
+
+    def test_clear_resets_warned(self):
+        rib = create_incoming_rib()
+        family = (AFI.ipv4, SAFI.unicast)
+        rib.mark_warned(family, b'p1')
+        rib.clear()
+        assert rib.mark_warned(family, b'p1') is True
+
+    def test_clear_does_not_affect_audit_when_no_state(self):
+        rib = create_incoming_rib()
+        rib.clear()
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])


### PR DESCRIPTION
Implement the capability as specified by the `draft-abraitis-idr-addpath-paths-limit-04` document.

Corresponding unit tests are also added to validate the functionality of this feature.