### PR TITLE
Remove md5 socket option when md5 password is cleared

### DIFF
--- a/src/exabgp/reactor/listener.py
+++ b/src/exabgp/reactor/listener.py
@@ -63,8 +63,7 @@ class Listener:
                 continue
             if local_port != port:
                 continue
-            if use_md5:
-                md5(sock, peer_ip.top(), 0, use_md5, md5_base64)
+            md5(sock, peer_ip.top(), 0, use_md5, md5_base64)
             if ttl_in:
                 min_ttl(sock, peer_ip, ttl_in)
             return

--- a/src/exabgp/reactor/network/tcp.py
+++ b/src/exabgp/reactor/network/tcp.py
@@ -180,9 +180,9 @@ def md5(io, ip, port, md5, md5_base64):
                 md5_bytes = bytes(md5, 'ascii')
                 key = pack('2xH4x%ds' % TCP_MD5SIG_MAXKEYLEN, len(md5_bytes), md5_bytes)
                 io.setsockopt(socket.IPPROTO_TCP, TCP_MD5SIG, sockaddr + key)
-            # else:
-            # 	key = pack('2xH4x%ds' % TCP_MD5SIG_MAXKEYLEN, 0, b'')
-            # 	io.setsockopt(socket.IPPROTO_TCP, TCP_MD5SIG, sockaddr + key)
+            else:
+                key = pack('2xH4x%ds' % TCP_MD5SIG_MAXKEYLEN, 0, b'')
+                io.setsockopt(socket.IPPROTO_TCP, TCP_MD5SIG, sockaddr + key)
 
         except OSError as exc:
             if exc.errno != errno.ENOENT:


### PR DESCRIPTION
This fixes an error under linux  where the listening socket will not disable md5 authentication.

This is a bit of an edge case, but if you start exabgp with an md5 password set and then remove the md5 option and reload the config, the md5 socket option is left on the listening socket. This will cause a BGP peering session to fail if exabgp is operating as a passive peer.