### PR TITLE
Add api show-routes-format env to allow using old behaviour

### DIFF
--- a/src/exabgp/bgp/message/update/nlri/qualifier/rd.py
+++ b/src/exabgp/bgp/message/update/nlri/qualifier/rd.py
@@ -54,6 +54,16 @@ class RouteDistinguisher:
     def __len__(self):
         return self._len
 
+    def __copy__(self):
+        if self == RouteDistinguisher.NORD:
+            return RouteDistinguisher.NORD
+        return RouteDistinguisher(self.rd)
+
+    def __deepcopy__(self, memo):
+        if self == RouteDistinguisher.NORD:
+            return RouteDistinguisher.NORD
+        return RouteDistinguisher(self.rd)
+
     def _str(self):
         t, c1, c2, c3 = unpack('!HHHH', self.rd)
         if t == self.TYPE_AS2_ADMIN:

--- a/src/exabgp/environment/parsing.py
+++ b/src/exabgp/environment/parsing.py
@@ -59,6 +59,13 @@ def api(_):
     return encoder
 
 
+def show_routes_format(_):
+    fmt = _.lower()
+    if fmt not in ('v1', 'v2'):
+        raise TypeError('invalid show-routes-format (must be v1 or v2)')
+    return fmt
+
+
 def methods(_):
     return _.upper().split()
 

--- a/src/exabgp/environment/setup.py
+++ b/src/exabgp/environment/setup.py
@@ -260,6 +260,12 @@ CONFIGURATION = {
             'value': '1',
             'help': 'maximum lines to print before yielding in show routes api',
         },
+        'show-routes-format': {
+            'read': parsing.show_routes_format,
+            'write': parsing.lower,
+            'value': 'v1',
+            'help': 'json output format for show adj-rib (v1 or v2)',
+        },
         'encoder': {
             'read': parsing.api,
             'write': parsing.lower,

--- a/src/exabgp/reactor/api/command/rib.py
+++ b/src/exabgp/reactor/api/command/rib.py
@@ -41,9 +41,31 @@ def _show_adjrib_callback(reactor, service, last, route_type, advertised, rib_na
             msg = f'{neighbor} {family} {details}'
             reactor.processes.write(service, msg)
 
-    def to_json(key, changes):
+    def to_json_v1(key, changes):
         jason = {}
-        neighbor = reactor.neighbor(key)
+        neighbor_ip = reactor.neighbor_ip(key)
+        routes = jason.setdefault(neighbor_ip, {'routes': []})['routes']
+
+        if extensive:
+            jason[neighbor_ip].update(NeighborTemplate.as_dict(reactor.neighbor_cli_data(key)))
+
+        for change in changes:
+            if not isinstance(change.nlri, route_type):
+                # log something about this drop?
+                continue
+            if not hasattr(change.nlri, 'cidr'):
+                continue
+
+            routes.append(
+                {
+                    'prefix': str(change.nlri.cidr.prefix()),
+                    'family': str(change.nlri.family()).strip('()').replace(',', ''),
+                },
+            )
+
+            reactor.processes.write(service, json.dumps(jason))
+
+    def to_json_v2(key, changes):
         neighbor_ip = reactor.neighbor_ip(key)
         jason = {"peer": {"address": neighbor_ip}}
 
@@ -58,7 +80,9 @@ def _show_adjrib_callback(reactor, service, last, route_type, advertised, rib_na
             reactor.processes.write(service, json.dumps(jason))
 
     def callback():
-        lines_per_yield = getenv().api.chunk
+        env = getenv()
+        lines_per_yield = env.api.chunk
+        to_json = to_json_v2 if env.api.show_routes_format == 'v2' else to_json_v1
         if last in ('routes', 'extensive', 'static', 'inet', 'flow', 'l2vpn'):
             peers = reactor.peers()
         else:


### PR DESCRIPTION
This updates my previous PR #1385 to allow selecting which json version "show adj-rib" gives.  If the environment api.show-routes-format is set to v1 you will get the original output, but still only for inet based routes. When set to v2 it will use the format supporting all route types. V1 mode has been at least fixed so it does not actually generate exceptions when non inet NLRI is encountered and instead it just skips it. 

This also patches another issue I discovered as well. I was using pattern 'if self.rd is not RouteDistinguisher.NORD' in my code. However there are places in the code that perform a deepcopy of a change object which in turn makes a copy of the rd object and in doing so destroys the IS relationship in python since the rd is no longer the same object as NORD. To fix this i implemented the `__copy__` and `__deepcopy__` functions in the RouteDistinguisher class so if an rd equals b'' then it returns the NORD singleton.