### PR TITLE
Install and use sysusers.d config file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Section: net
 Priority: optional
 Build-Depends: debhelper-compat (= 13),
                dh-python,
+               dh-sequence-installsysusers,
                python3-all,
                python3-setuptools,
 Build-Depends-Indep: python3-hypothesis,
@@ -38,8 +39,7 @@ Description: BGP swiss army knife of networking - Python 3 module
 Package: exabgp
 Architecture: all
 Pre-Depends: ${misc:Pre-Depends}
-Depends: adduser,
-         python3-exabgp (= ${binary:Version}),
+Depends: python3-exabgp (= ${binary:Version}),
          ucf,
          ${misc:Depends},
          ${python3:Depends},

--- a/debian/exabgp.postinst
+++ b/debian/exabgp.postinst
@@ -16,7 +16,6 @@ gen_env_config() {
 
 case "$1" in
 configure)
-    adduser --quiet --system --group --disabled-login --home /run/exabgp exabgp
     gen_env_config
     ;;
 esac

--- a/debian/exabgp.sysusers
+++ b/debian/exabgp.sysusers
@@ -1,0 +1,1 @@
+u! exabgp - "ExaBGP" /run/exabgp


### PR DESCRIPTION
sysusers.d config files allow a package to use declarative configuration instead of manually written maintainer scripts. This also allows image-based systems to be created with /usr/ only, and also allows for factory resetting a system and recreating /etc/ on boot. https://www.freedesktop.org/software/systemd/man/latest/sysusers.d.html