### PR TITLE
Fix enabling logging source functionality

### DIFF
--- a/src/exabgp/logger/option.py
+++ b/src/exabgp/logger/option.py
@@ -63,7 +63,7 @@ class option:
 
         cls._set_level(env.log.level)
 
-        cls.option = {
+        cls.enabled = {
             'pdb': env.debug.pdb,
             'reactor': env.log.enable and (env.log.all or env.log.reactor),
             'daemon': env.log.enable and (env.log.all or env.log.daemon),


### PR DESCRIPTION
When initializing the enabled log sources from the environment the wrong dictionary was being used. log_enabled uses cls.enabled, but load was using cls.option.