### PR TITLE
Fix issue with UnicodeDecodeError in notifications

### DIFF
--- a/src/exabgp/bgp/message/notification.py
+++ b/src/exabgp/bgp/message/notification.py
@@ -147,7 +147,10 @@ class Notification(Message, Exception):
     def __str__(self):
         code_str = self._str_code.get(self.code, 'unknown error')
         subcode_str = self._str_subcode.get((self.code, self.subcode), 'unknow reason')
-        data_str = f' / {self.data.decode("ascii")}' if self.data else ''
+        try:
+            data_str = f' / {self.data.decode("ascii")}' if self.data else ''
+        except UnicodeDecodeError:
+            data_str = f' / {hexstring(self.data)}'
         return f'{code_str} / {subcode_str}{data_str}'
 
     @classmethod


### PR DESCRIPTION
This fixes a logging issue with the Bad AS Notification. When this notification is sent by a peer the current `__str__` function causes a UnicodeDecodeError when logging it to your log file: peer reset, message [notification received (2,2)] error['ascii' codec can't decode byte 0xfd in position 2: ordinal not in range(128)]

This will catch and handle that exception resulting in a proper log of the received notification: peer reset, message [notification received (2,2)] error[OPEN message error / Bad Peer AS / 0x0000FDED]