### PR TITLE
Add DDoS auto-mitigation example with FlowSpec

### DIFF
--- a/doc/ddos-flowspec.md
+++ b/doc/ddos-flowspec.md
@@ -1,0 +1,311 @@
+# DDoS Mitigation with FlowSpec
+
+This guide explains how to use ExaBGP as an automated FlowSpec controller
+for DDoS mitigation.  A webhook listener receives attack alerts from a
+detection system and translates them into BGP FlowSpec rules that upstream
+routers enforce at the network edge.
+
+## What is FlowSpec?
+
+BGP FlowSpec (RFC 5575, updated by RFC 8955) extends BGP to distribute
+traffic filtering rules alongside routing information.  Instead of
+blackholing an entire prefix, FlowSpec lets you describe attack traffic
+precisely -- by source, destination, protocol, port, packet length, and
+more -- and instruct routers to drop, rate-limit, or redirect only the
+matching packets.
+
+This makes FlowSpec ideal for surgical DDoS mitigation: you keep
+legitimate traffic flowing while the attack is filtered at the router
+level, before it reaches your servers.
+
+## Prerequisites
+
+1. **Router support** -- Your upstream or edge routers must support BGP
+   FlowSpec.  Most modern Juniper (MX, PTX), Cisco (IOS-XR), Nokia (SR OS),
+   and Arista (EOS) platforms do.  Check your vendor documentation for the
+   required license or feature set.
+
+2. **BGP session** -- ExaBGP must have an iBGP or eBGP session to the
+   router(s) where you want FlowSpec rules installed.  The session needs
+   `ipv4 flow` (and optionally `ipv6 flow`) address families negotiated.
+
+3. **Validation mode** -- Some routers require the FlowSpec originator to
+   also be the best-path next-hop for the destination prefix, or they will
+   reject the rule.  Check your router's FlowSpec validation settings
+   (`validation { ... }` on Juniper, `flowspec validation` on IOS-XR).
+
+4. **Detection system** -- You need something that detects attacks and can
+   send HTTP POST webhooks: Flowtriq, Wanguard, a custom sFlow/NetFlow
+   analyzer, or a monitoring system with webhook actions.
+
+## Setup walkthrough
+
+### 1. Install ExaBGP
+
+```bash
+pip install exabgp
+```
+
+Or from source -- see the main ExaBGP README for details.
+
+### 2. Configure the BGP session
+
+Edit `etc/exabgp/api-ddos-flowspec.conf`:
+
+```
+process ddos-flowspec {
+    run ./run/api-ddos-flowspec.run;
+    encoder text;
+}
+
+neighbor 10.0.0.1 {
+    router-id 10.0.0.17;
+    local-address 10.0.0.17;
+    local-as 64512;
+    peer-as 64512;
+    hold-time 180;
+    group-updates true;
+
+    capability {
+        route-refresh enable;
+    }
+
+    family {
+        ipv4 flow;
+        ipv6 flow;
+    }
+
+    api {
+        processes [ ddos-flowspec ];
+    }
+}
+```
+
+Adjust `local-as`, `peer-as`, addresses, and hold-time to match your
+network.  If you peer with multiple routers, add additional `neighbor`
+blocks -- FlowSpec rules are announced to all peers in the process group.
+
+### 3. Set environment variables
+
+| Variable       | Default     | Description                                     |
+|----------------|-------------|-------------------------------------------------|
+| `WEBHOOK_PORT` | `5000`      | HTTP port for the webhook listener              |
+| `WEBHOOK_BIND` | `127.0.0.1` | Bind address (set `0.0.0.0` for remote access)  |
+| `API_KEY`      | (none)      | Bearer token for authentication                 |
+| `RATE_LIMIT`   | `0`         | FlowSpec rate-limit in bytes/s (0 = drop)       |
+| `LOG_LEVEL`    | `INFO`      | Logging verbosity (DEBUG, INFO, WARNING)        |
+
+Example:
+
+```bash
+export WEBHOOK_PORT=5000
+export WEBHOOK_BIND=0.0.0.0
+export API_KEY=$(openssl rand -hex 32)
+export RATE_LIMIT=0
+```
+
+### 4. Start ExaBGP
+
+```bash
+exabgp ./etc/exabgp/api-ddos-flowspec.conf
+```
+
+The process script waits for ExaBGP to signal that a BGP session is up
+before it starts the HTTP listener.  If no session comes up within 10
+seconds, it starts anyway (rules will be queued and sent when the session
+establishes).
+
+### 5. Send a test webhook
+
+```bash
+curl -X POST http://localhost:5000/ \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <your-api-key>' \
+  -d '{
+    "action": "mitigate",
+    "source": "203.0.113.0/24",
+    "destination": "198.51.100.0/24",
+    "protocol": "udp",
+    "source_port": 53,
+    "attack_id": "dns-amp-test"
+  }'
+```
+
+Verify the rule is active:
+
+```bash
+curl http://localhost:5000/
+```
+
+Clear the rule:
+
+```bash
+curl -X POST http://localhost:5000/ \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <your-api-key>' \
+  -d '{
+    "action": "clear",
+    "source": "203.0.113.0/24",
+    "destination": "198.51.100.0/24",
+    "protocol": "udp",
+    "source_port": 53,
+    "attack_id": "dns-amp-test"
+  }'
+```
+
+## Payload reference
+
+POST a JSON object to the webhook endpoint:
+
+| Field         | Type   | Required | Description                                       |
+|---------------|--------|----------|---------------------------------------------------|
+| `action`      | string | yes      | `"mitigate"` to announce, `"clear"` to withdraw   |
+| `source`      | string | no*      | Source prefix in CIDR notation                     |
+| `destination` | string | no*      | Destination prefix in CIDR notation                |
+| `protocol`    | string | no       | IP protocol: `tcp`, `udp`, `icmp`, `gre`, etc.    |
+| `port`        | int    | no       | Destination port (1-65535)                         |
+| `source_port` | int    | no       | Source port (1-65535)                              |
+| `attack_id`   | string | no       | Identifier for logging and correlation             |
+
+\* At least one of `source` or `destination` is required.
+
+All inputs are validated:
+- Prefixes are checked with Python's `ipaddress` module.
+- Protocol is checked against a known set.
+- Ports must be integers between 1 and 65535.
+
+Invalid requests receive a 400 response with a descriptive error message.
+
+## Common attack patterns
+
+### DNS amplification
+
+DNS amplification uses open resolvers to reflect large responses toward
+the victim.  The reflected packets come FROM source port 53.
+
+```bash
+curl -X POST http://localhost:5000/ \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "action": "mitigate",
+    "destination": "198.51.100.0/24",
+    "protocol": "udp",
+    "source_port": 53,
+    "attack_id": "dns-amp"
+  }'
+```
+
+FlowSpec rule: `match { destination 198.51.100.0/24; protocol udp; source-port =53; }`
+
+### NTP amplification
+
+Similar to DNS amplification, but abuses NTP monlist.  Reflected packets
+come from source port 123.
+
+```bash
+curl -X POST http://localhost:5000/ \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "action": "mitigate",
+    "destination": "198.51.100.0/24",
+    "protocol": "udp",
+    "source_port": 123,
+    "attack_id": "ntp-amp"
+  }'
+```
+
+FlowSpec rule: `match { destination 198.51.100.0/24; protocol udp; source-port =123; }`
+
+### UDP flood
+
+A volumetric UDP flood from a known source prefix:
+
+```bash
+curl -X POST http://localhost:5000/ \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "action": "mitigate",
+    "source": "192.0.2.0/24",
+    "destination": "198.51.100.0/24",
+    "protocol": "udp",
+    "attack_id": "udp-flood"
+  }'
+```
+
+FlowSpec rule: `match { source 192.0.2.0/24; destination 198.51.100.0/24; protocol udp; }`
+
+### SYN flood
+
+TCP SYN floods targeting a specific destination port:
+
+```bash
+curl -X POST http://localhost:5000/ \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "action": "mitigate",
+    "source": "192.0.2.0/24",
+    "destination": "198.51.100.0/24",
+    "protocol": "tcp",
+    "port": 80,
+    "attack_id": "syn-flood"
+  }'
+```
+
+FlowSpec rule: `match { source 192.0.2.0/24; destination 198.51.100.0/24; protocol tcp; destination-port =80; }`
+
+Note: For SYN floods you may want to use `RATE_LIMIT` instead of dropping
+all traffic, to allow some legitimate connections through while the attack
+is active.
+
+## Authentication
+
+The webhook listener binds to `127.0.0.1` by default.  Only local
+processes can reach it, so authentication is optional in that
+configuration.
+
+To accept webhooks from a remote detection system:
+
+1. Set `WEBHOOK_BIND=0.0.0.0`
+2. Set `API_KEY` to a strong random value
+3. Include the header `Authorization: Bearer <key>` in POST requests
+
+When `API_KEY` is set, POST requests without a valid bearer token receive
+a 401 response.
+
+## Troubleshooting
+
+**"broken pipe" errors in the log**
+ExaBGP exited or restarted.  The process script will be restarted
+automatically by ExaBGP.
+
+**Rules announced but not installed on the router**
+- Check that the BGP session is established: `exabgpcli show neighbor summary`
+- Verify the router's FlowSpec validation policy.  Some routers reject
+  FlowSpec rules unless the originator is the best-path next-hop.
+- Check the router's FlowSpec table: `show route table inetflow.0` (Juniper)
+  or `show flowspec ipv4` (IOS-XR).
+
+**"no session-up received after 10 s" warning**
+The BGP peer did not connect within the startup timeout.  The webhook
+listener starts anyway.  Check that the neighbor IP and ASN are correct
+and that the peer is reachable.
+
+**Webhook returns 400 with validation error**
+The request contained invalid input.  Check the error message:
+- Source/destination must be valid CIDR (e.g. `198.51.100.0/24`)
+- Protocol must be a known name (`tcp`, `udp`, `icmp`, etc.)
+- Port must be an integer between 1 and 65535
+
+**Webhook returns 401**
+`API_KEY` is set but the request is missing or has an incorrect
+`Authorization: Bearer <key>` header.
+
+## References
+
+- [RFC 5575](https://www.rfc-editor.org/rfc/rfc5575) -- Dissemination of
+  Flow Specification Rules
+- [RFC 8955](https://www.rfc-editor.org/rfc/rfc8955) -- Dissemination of
+  Flow Specification Rules (revised)
+- [RFC 8956](https://www.rfc-editor.org/rfc/rfc8956) -- Dissemination of
+  Flow Specification Rules for IPv6
+- [ExaBGP documentation](https://github.com/Exa-Networks/exabgp)

--- a/etc/exabgp/api-ddos-flowspec.conf
+++ b/etc/exabgp/api-ddos-flowspec.conf
@@ -1,0 +1,38 @@
+# DDoS auto-mitigation with FlowSpec
+#
+# This configuration pairs with run/api-ddos-flowspec.run to provide
+# automated DDoS mitigation.  When a detection system (e.g. Flowtriq,
+# wanguard, custom scripts) sends a webhook, ExaBGP announces FlowSpec
+# rules to upstream routers that drop or rate-limit attack traffic.
+#
+# Adjust:
+#   - local-as / peer-as to match your ASN and upstream
+#   - local-address / neighbor address for your peering IPs
+#   - WEBHOOK_PORT environment variable if 5000 conflicts
+
+process ddos-flowspec {
+    run ./run/api-ddos-flowspec.run;
+    encoder text;
+}
+
+neighbor 10.0.0.1 {
+    router-id 10.0.0.17;
+    local-address 10.0.0.17;
+    local-as 64512;
+    peer-as 64512;
+    hold-time 180;
+    group-updates true;
+
+    capability {
+        route-refresh enable;
+    }
+
+    family {
+        ipv4 flow;
+        ipv6 flow;
+    }
+
+    api {
+        processes [ ddos-flowspec ];
+    }
+}

--- a/etc/exabgp/api-ddos-flowspec.conf
+++ b/etc/exabgp/api-ddos-flowspec.conf
@@ -8,7 +8,9 @@
 # Adjust:
 #   - local-as / peer-as to match your ASN and upstream
 #   - local-address / neighbor address for your peering IPs
-#   - WEBHOOK_PORT environment variable if 5000 conflicts
+#   - WEBHOOK_PORT env var if 5000 conflicts
+#   - WEBHOOK_BIND env var to open beyond localhost (default: 127.0.0.1)
+#   - API_KEY env var for bearer-token auth when exposed externally
 
 process ddos-flowspec {
     run ./run/api-ddos-flowspec.run;

--- a/etc/exabgp/run/README-ddos-flowspec.md
+++ b/etc/exabgp/run/README-ddos-flowspec.md
@@ -40,7 +40,7 @@ Detection System                ExaBGP              Upstream Router
    curl for testing):
 
    ```bash
-   # Mitigate: drop UDP traffic from 203.0.113.0/24 to port 53
+   # Mitigate: drop reflected DNS replies from source port 53
    curl -X POST http://localhost:5000/ \
      -H 'Content-Type: application/json' \
      -d '{
@@ -48,7 +48,7 @@ Detection System                ExaBGP              Upstream Router
        "source": "203.0.113.0/24",
        "destination": "198.51.100.0/24",
        "protocol": "udp",
-       "port": 53,
+       "source_port": 53,
        "attack_id": "dns-amp-001"
      }'
 
@@ -60,7 +60,7 @@ Detection System                ExaBGP              Upstream Router
        "source": "203.0.113.0/24",
        "destination": "198.51.100.0/24",
        "protocol": "udp",
-       "port": 53,
+       "source_port": 53,
        "attack_id": "dns-amp-001"
      }'
    ```
@@ -77,20 +77,50 @@ Detection System                ExaBGP              Upstream Router
 |---------------|--------|----------|------------------------------------------|
 | `action`      | string | yes      | `"mitigate"` to announce, `"clear"` to withdraw |
 | `source`      | string | no*      | Source prefix (e.g. `"203.0.113.0/24"`)  |
-| `destination`  | string | no*      | Destination prefix                       |
+| `destination` | string | no*      | Destination prefix                       |
 | `protocol`    | string | no       | `"tcp"`, `"udp"`, `"icmp"`, etc.         |
 | `port`        | int    | no       | Destination port number                  |
+| `source_port` | int    | no       | Source port number                       |
 | `attack_id`   | string | no       | Identifier for logging                   |
 
 \* At least one of `source` or `destination` is required.
 
+All fields are validated before being passed to ExaBGP:
+- `source` and `destination` must be valid CIDR prefixes
+- `protocol` must be a known IP protocol (tcp, udp, icmp, etc.)
+- `port` and `source_port` must be integers between 1 and 65535
+
 ## Environment variables
 
-| Variable       | Default | Description                          |
-|----------------|---------|--------------------------------------|
-| `WEBHOOK_PORT` | `5000`  | Port for the HTTP webhook listener   |
-| `RATE_LIMIT`   | `0`     | FlowSpec rate-limit (0 = drop)       |
-| `LOG_LEVEL`    | `INFO`  | Logging verbosity                    |
+| Variable       | Default     | Description                                     |
+|----------------|-------------|-------------------------------------------------|
+| `WEBHOOK_PORT` | `5000`      | Port for the HTTP webhook listener              |
+| `WEBHOOK_BIND` | `127.0.0.1` | Bind address for the HTTP listener              |
+| `API_KEY`      | (none)      | Bearer token for authentication (see below)     |
+| `RATE_LIMIT`   | `0`         | FlowSpec rate-limit in bytes/s (0 = drop)       |
+| `LOG_LEVEL`    | `INFO`      | Logging verbosity                               |
+
+## Authentication
+
+By default the webhook listener binds to `127.0.0.1`, so only processes on
+the same machine can reach it.  This is safe for setups where the detection
+system runs locally or sends alerts through a local relay.
+
+To accept webhooks from a remote detection system:
+
+1. Set `WEBHOOK_BIND=0.0.0.0` (or a specific interface address).
+2. Set `API_KEY` to a strong random value, e.g.:
+   ```bash
+   export API_KEY=$(openssl rand -hex 32)
+   ```
+3. Configure the detection system to include the header:
+   ```
+   Authorization: Bearer <your-api-key>
+   ```
+
+When `API_KEY` is set, all POST requests without a valid
+`Authorization: Bearer <key>` header receive a 401 response.
+GET requests (listing active rules) are not authenticated.
 
 ## Detection systems
 
@@ -109,6 +139,8 @@ Some platforms that support webhook-based alerting:
 - The script tracks active rules and deduplicates announcements.
 - On ExaBGP shutdown, all announced routes are implicitly withdrawn when
   the BGP session goes down.
-- For production use, consider adding authentication to the webhook
-  endpoint (e.g. an API key header check) and binding to 127.0.0.1
-  instead of 0.0.0.0.
+- The HTTP server uses `ThreadingHTTPServer` so concurrent webhook calls
+  are handled in parallel.
+- The server waits for ExaBGP to signal a session-up before accepting
+  webhooks (with a 10-second fallback timeout).
+- For a more detailed setup guide, see `doc/ddos-flowspec.md`.

--- a/etc/exabgp/run/README-ddos-flowspec.md
+++ b/etc/exabgp/run/README-ddos-flowspec.md
@@ -1,0 +1,114 @@
+# DDoS Auto-Mitigation with FlowSpec
+
+This example shows how to use ExaBGP as an automated FlowSpec controller
+for DDoS mitigation.  A lightweight HTTP webhook listener receives attack
+alerts from a detection system and translates them into FlowSpec
+announce/withdraw commands that ExaBGP pushes to upstream routers.
+
+## How it works
+
+```
+Detection System                ExaBGP              Upstream Router
+(Flowtriq, etc.)               (this example)       (Juniper, Cisco, etc.)
+      |                              |                       |
+      |-- POST /  {"action":        |                       |
+      |    "mitigate", ...}  ------>|                       |
+      |                             |-- announce flow       |
+      |                             |   route { match ... } |
+      |                             |   ------------------>  |
+      |                             |                       | (drops/limits
+      |                             |                       |  attack traffic)
+      |-- POST /  {"action":       |                       |
+      |    "clear", ...}  -------->|                       |
+      |                             |-- withdraw flow       |
+      |                             |   route { match ... } |
+      |                             |   ------------------>  |
+```
+
+## Quick start
+
+1. Edit `api-ddos-flowspec.conf` with your BGP peering details (ASN,
+   addresses, hold-time).
+
+2. Start ExaBGP:
+
+   ```bash
+   exabgp ./api-ddos-flowspec.conf
+   ```
+
+3. Trigger a mitigation (from your detection system, or manually with
+   curl for testing):
+
+   ```bash
+   # Mitigate: drop UDP traffic from 203.0.113.0/24 to port 53
+   curl -X POST http://localhost:5000/ \
+     -H 'Content-Type: application/json' \
+     -d '{
+       "action": "mitigate",
+       "source": "203.0.113.0/24",
+       "destination": "198.51.100.0/24",
+       "protocol": "udp",
+       "port": 53,
+       "attack_id": "dns-amp-001"
+     }'
+
+   # Clear when the attack subsides
+   curl -X POST http://localhost:5000/ \
+     -H 'Content-Type: application/json' \
+     -d '{
+       "action": "clear",
+       "source": "203.0.113.0/24",
+       "destination": "198.51.100.0/24",
+       "protocol": "udp",
+       "port": 53,
+       "attack_id": "dns-amp-001"
+     }'
+   ```
+
+4. List active rules:
+
+   ```bash
+   curl http://localhost:5000/
+   ```
+
+## Webhook payload
+
+| Field         | Type   | Required | Description                              |
+|---------------|--------|----------|------------------------------------------|
+| `action`      | string | yes      | `"mitigate"` to announce, `"clear"` to withdraw |
+| `source`      | string | no*      | Source prefix (e.g. `"203.0.113.0/24"`)  |
+| `destination`  | string | no*      | Destination prefix                       |
+| `protocol`    | string | no       | `"tcp"`, `"udp"`, `"icmp"`, etc.         |
+| `port`        | int    | no       | Destination port number                  |
+| `attack_id`   | string | no       | Identifier for logging                   |
+
+\* At least one of `source` or `destination` is required.
+
+## Environment variables
+
+| Variable       | Default | Description                          |
+|----------------|---------|--------------------------------------|
+| `WEBHOOK_PORT` | `5000`  | Port for the HTTP webhook listener   |
+| `RATE_LIMIT`   | `0`     | FlowSpec rate-limit (0 = drop)       |
+| `LOG_LEVEL`    | `INFO`  | Logging verbosity                    |
+
+## Detection systems
+
+This example works with any system that can send HTTP POST requests.
+Some platforms that support webhook-based alerting:
+
+- [Flowtriq](https://flowtriq.com) -- DDoS detection with webhook alerts
+- Custom sFlow/NetFlow analyzers
+- Monitoring systems (Zabbix, Nagios, etc.) with webhook actions
+
+## Notes
+
+- FlowSpec rules require that upstream routers support BGP FlowSpec
+  (RFC 5575 / RFC 8955).  Most modern Juniper, Cisco, and Nokia routers
+  do.
+- The script tracks active rules and deduplicates announcements.
+- On ExaBGP shutdown, all announced routes are implicitly withdrawn when
+  the BGP session goes down.
+- For production use, consider adding authentication to the webhook
+  endpoint (e.g. an API key header check) and binding to 127.0.0.1
+  instead of 0.0.0.0.

--- a/etc/exabgp/run/api-ddos-flowspec.run
+++ b/etc/exabgp/run/api-ddos-flowspec.run
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+
+"""DDoS auto-mitigation via FlowSpec.
+
+A webhook-driven ExaBGP process script that receives attack alerts from
+a DDoS detection system and dynamically announces or withdraws FlowSpec
+rules to mitigate attack traffic at the network edge.
+
+The script runs an HTTP server on a configurable port.  When an attack
+is detected, the detection system sends a POST request with attack
+details (source prefix, destination prefix, protocol, port).  The
+script translates these into FlowSpec announce/withdraw commands that
+ExaBGP pushes to upstream routers.
+
+Environment variables (all optional):
+    WEBHOOK_PORT   - HTTP port for the webhook listener (default: 5000)
+    RATE_LIMIT     - FlowSpec rate-limit value in bytes/s (default: 0, meaning drop)
+    LOG_LEVEL      - Logging verbosity: DEBUG, INFO, WARNING (default: INFO)
+
+Tested with:
+    - Flowtriq (https://flowtriq.com) -- webhook alerts
+    - Any system that can POST JSON attack events
+
+Usage:
+    Configure this script as an ExaBGP process (see api-ddos-flowspec.conf).
+"""
+
+import json
+import logging
+import os
+import signal
+import sys
+import threading
+import time
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+WEBHOOK_PORT = int(os.environ.get("WEBHOOK_PORT", "5000"))
+RATE_LIMIT = int(os.environ.get("RATE_LIMIT", "0"))
+LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
+
+logging.basicConfig(
+    stream=sys.stderr,
+    level=getattr(logging, LOG_LEVEL, logging.INFO),
+    format="%(asctime)s [ddos-flowspec] %(levelname)s %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+log = logging.getLogger("ddos-flowspec")
+
+# ---------------------------------------------------------------------------
+# Active mitigations -- keyed by a deterministic rule ID so we can withdraw
+# ---------------------------------------------------------------------------
+
+active_rules: dict[str, str] = {}  # rule_id -> announce command
+lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# ExaBGP helpers
+# ---------------------------------------------------------------------------
+
+def exabgp_send(command: str) -> None:
+    """Write a command to stdout (ExaBGP reads from our stdout)."""
+    try:
+        sys.stdout.write(command + "\n")
+        sys.stdout.flush()
+        log.debug("sent: %s", command)
+    except IOError:
+        log.error("broken pipe -- ExaBGP exited?")
+
+
+def build_flowspec_announce(src: str, dst: str, proto: str, port: int | None) -> str:
+    """Build a FlowSpec announce command.
+
+    Example output:
+        announce flow route {
+            match { source 203.0.113.0/24; destination 198.51.100.0/24;
+                    protocol udp; destination-port =53; }
+            then { rate-limit 0; }
+        }
+    """
+    match_parts = []
+    if src:
+        match_parts.append(f"source {src}")
+    if dst:
+        match_parts.append(f"destination {dst}")
+    if proto:
+        match_parts.append(f"protocol {proto}")
+    if port:
+        match_parts.append(f"destination-port ={port}")
+
+    match_str = "; ".join(match_parts) + ";"
+    then_str = f"rate-limit {RATE_LIMIT};"
+
+    return (
+        f"announce flow route {{ match {{ {match_str} }} "
+        f"then {{ {then_str} }} }}"
+    )
+
+
+def build_flowspec_withdraw(src: str, dst: str, proto: str, port: int | None) -> str:
+    """Build a FlowSpec withdraw command."""
+    match_parts = []
+    if src:
+        match_parts.append(f"source {src}")
+    if dst:
+        match_parts.append(f"destination {dst}")
+    if proto:
+        match_parts.append(f"protocol {proto}")
+    if port:
+        match_parts.append(f"destination-port ={port}")
+
+    match_str = "; ".join(match_parts) + ";"
+    return f"withdraw flow route {{ match {{ {match_str} }} }}"
+
+
+def rule_id(src: str, dst: str, proto: str, port: int | None) -> str:
+    """Deterministic key for deduplication."""
+    return f"{src}|{dst}|{proto}|{port}"
+
+
+# ---------------------------------------------------------------------------
+# Webhook handler
+# ---------------------------------------------------------------------------
+
+class WebhookHandler(BaseHTTPRequestHandler):
+    """HTTP handler that accepts attack start/stop events.
+
+    Expected JSON payload:
+
+        {
+            "action":   "mitigate" | "clear",
+            "source":   "203.0.113.0/24",       // optional
+            "destination": "198.51.100.0/24",    // optional
+            "protocol": "udp",                   // optional
+            "port":     53,                      // optional
+            "attack_id": "abc-123"               // optional, for logging
+        }
+    """
+
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", 0))
+        if content_length == 0:
+            self._respond(400, {"error": "empty body"})
+            return
+
+        try:
+            body = json.loads(self.rfile.read(content_length))
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            self._respond(400, {"error": "invalid JSON"})
+            return
+
+        action = body.get("action", "").lower()
+        src = body.get("source", "")
+        dst = body.get("destination", "")
+        proto = body.get("protocol", "")
+        port = body.get("port")
+        attack_id = body.get("attack_id", "unknown")
+
+        if action not in ("mitigate", "clear"):
+            self._respond(400, {"error": "action must be 'mitigate' or 'clear'"})
+            return
+        if not src and not dst:
+            self._respond(400, {"error": "at least source or destination required"})
+            return
+
+        rid = rule_id(src, dst, proto, port)
+
+        if action == "mitigate":
+            cmd = build_flowspec_announce(src, dst, proto, port)
+            with lock:
+                if rid in active_rules:
+                    log.info("rule already active for %s (attack %s)", rid, attack_id)
+                    self._respond(200, {"status": "already_active", "rule_id": rid})
+                    return
+                active_rules[rid] = cmd
+            exabgp_send(cmd)
+            log.info("mitigating attack %s -- %s", attack_id, cmd)
+            self._respond(200, {"status": "mitigating", "rule_id": rid})
+
+        elif action == "clear":
+            cmd = build_flowspec_withdraw(src, dst, proto, port)
+            with lock:
+                removed = active_rules.pop(rid, None)
+            if removed:
+                exabgp_send(cmd)
+                log.info("cleared attack %s -- %s", attack_id, cmd)
+                self._respond(200, {"status": "cleared", "rule_id": rid})
+            else:
+                log.warning("clear for unknown rule %s (attack %s)", rid, attack_id)
+                self._respond(200, {"status": "not_found", "rule_id": rid})
+
+    def do_GET(self) -> None:
+        """Return currently active FlowSpec rules (useful for debugging)."""
+        with lock:
+            rules = dict(active_rules)
+        self._respond(200, {"active_rules": rules, "count": len(rules)})
+
+    def _respond(self, code: int, body: dict) -> None:
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(json.dumps(body).encode())
+
+    def log_message(self, fmt, *args) -> None:  # type: ignore[override]
+        """Route HTTP access logs through our logger."""
+        log.debug(fmt, *args)
+
+
+# ---------------------------------------------------------------------------
+# ExaBGP stdin reader -- watches for shutdown signal
+# ---------------------------------------------------------------------------
+
+def stdin_reader() -> None:
+    """Read ExaBGP messages from stdin in a background thread."""
+    while True:
+        try:
+            line = sys.stdin.readline().strip()
+        except (IOError, KeyboardInterrupt):
+            break
+        if line == "shutdown":
+            log.info("received shutdown from ExaBGP")
+            os._exit(0)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    signal.signal(signal.SIGPIPE, signal.SIG_DFL)
+
+    # Start the stdin reader so we notice when ExaBGP shuts down
+    reader_thread = threading.Thread(target=stdin_reader, daemon=True)
+    reader_thread.start()
+
+    # Give ExaBGP a moment to finish the EOR exchange
+    time.sleep(0.5)
+
+    # Start the webhook HTTP server
+    server = HTTPServer(("0.0.0.0", WEBHOOK_PORT), WebhookHandler)
+    log.info("webhook listener started on port %d", WEBHOOK_PORT)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        log.info("shutting down")
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/etc/exabgp/run/api-ddos-flowspec.run
+++ b/etc/exabgp/run/api-ddos-flowspec.run
@@ -14,8 +14,18 @@ ExaBGP pushes to upstream routers.
 
 Environment variables (all optional):
     WEBHOOK_PORT   - HTTP port for the webhook listener (default: 5000)
+    WEBHOOK_BIND   - Bind address (default: 127.0.0.1)
+    API_KEY        - Bearer token for authentication (default: none, no auth)
     RATE_LIMIT     - FlowSpec rate-limit value in bytes/s (default: 0, meaning drop)
     LOG_LEVEL      - Logging verbosity: DEBUG, INFO, WARNING (default: INFO)
+
+Security notes:
+    The server binds to 127.0.0.1 by default, so only local processes can
+    reach it.  If you need to accept webhooks from a remote detection system,
+    set WEBHOOK_BIND=0.0.0.0 and set API_KEY to a strong random token.  The
+    detection system must then send an Authorization header:
+
+        Authorization: Bearer <your-api-key>
 
 Tested with:
     - Flowtriq (https://flowtriq.com) -- webhook alerts
@@ -25,20 +35,22 @@ Usage:
     Configure this script as an ExaBGP process (see api-ddos-flowspec.conf).
 """
 
+import ipaddress
 import json
 import logging
 import os
 import signal
 import sys
 import threading
-import time
-from http.server import HTTPServer, BaseHTTPRequestHandler
+from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 
 # ---------------------------------------------------------------------------
 # Configuration
 # ---------------------------------------------------------------------------
 
 WEBHOOK_PORT = int(os.environ.get("WEBHOOK_PORT", "5000"))
+WEBHOOK_BIND = os.environ.get("WEBHOOK_BIND", "127.0.0.1")
+API_KEY = os.environ.get("API_KEY", "")
 RATE_LIMIT = int(os.environ.get("RATE_LIMIT", "0"))
 LOG_LEVEL = os.environ.get("LOG_LEVEL", "INFO").upper()
 
@@ -51,11 +63,68 @@ logging.basicConfig(
 log = logging.getLogger("ddos-flowspec")
 
 # ---------------------------------------------------------------------------
+# Known protocols for validation (IP protocol names accepted by ExaBGP)
+# ---------------------------------------------------------------------------
+
+KNOWN_PROTOCOLS = frozenset({
+    "tcp", "udp", "icmp", "icmpv6", "gre", "ospf", "sctp",
+    "ipip", "igmp", "egp", "pim", "vrrp", "l2tp", "ipv6-icmp",
+})
+
+# ---------------------------------------------------------------------------
 # Active mitigations -- keyed by a deterministic rule ID so we can withdraw
 # ---------------------------------------------------------------------------
 
 active_rules: dict[str, str] = {}  # rule_id -> announce command
 lock = threading.Lock()
+
+# Threading event: set when ExaBGP signals that a BGP session is up
+session_up = threading.Event()
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+def validate_cidr(value: str, field_name: str) -> str | None:
+    """Validate that *value* is a valid IPv4 or IPv6 CIDR prefix.
+
+    Returns an error message string on failure, or None on success.
+    """
+    try:
+        ipaddress.ip_network(value, strict=False)
+    except (ValueError, TypeError):
+        return f"{field_name} is not a valid CIDR prefix: {value!r}"
+    return None
+
+
+def validate_protocol(proto: str) -> str | None:
+    """Validate that *proto* is a known IP protocol name.
+
+    Returns an error message string on failure, or None on success.
+    """
+    if proto.lower() not in KNOWN_PROTOCOLS:
+        return (
+            f"unknown protocol: {proto!r} "
+            f"(expected one of: {', '.join(sorted(KNOWN_PROTOCOLS))})"
+        )
+    return None
+
+
+def validate_port(port_value: object, field_name: str = "port") -> tuple[int | None, str | None]:
+    """Validate that *port_value* is an integer between 1 and 65535.
+
+    Returns (parsed_port, error_message).  error_message is None on success.
+    """
+    if port_value is None:
+        return None, None
+    try:
+        port_int = int(port_value)
+    except (ValueError, TypeError):
+        return None, f"{field_name} must be an integer: {port_value!r}"
+    if port_int < 1 or port_int > 65535:
+        return None, f"{field_name} must be between 1 and 65535, got {port_int}"
+    return port_int, None
 
 
 # ---------------------------------------------------------------------------
@@ -72,13 +141,19 @@ def exabgp_send(command: str) -> None:
         log.error("broken pipe -- ExaBGP exited?")
 
 
-def build_flowspec_announce(src: str, dst: str, proto: str, port: int | None) -> str:
+def build_flowspec_announce(
+    src: str,
+    dst: str,
+    proto: str,
+    port: int | None,
+    source_port: int | None,
+) -> str:
     """Build a FlowSpec announce command.
 
     Example output:
         announce flow route {
             match { source 203.0.113.0/24; destination 198.51.100.0/24;
-                    protocol udp; destination-port =53; }
+                    protocol udp; source-port =53; }
             then { rate-limit 0; }
         }
     """
@@ -91,6 +166,8 @@ def build_flowspec_announce(src: str, dst: str, proto: str, port: int | None) ->
         match_parts.append(f"protocol {proto}")
     if port:
         match_parts.append(f"destination-port ={port}")
+    if source_port:
+        match_parts.append(f"source-port ={source_port}")
 
     match_str = "; ".join(match_parts) + ";"
     then_str = f"rate-limit {RATE_LIMIT};"
@@ -101,7 +178,13 @@ def build_flowspec_announce(src: str, dst: str, proto: str, port: int | None) ->
     )
 
 
-def build_flowspec_withdraw(src: str, dst: str, proto: str, port: int | None) -> str:
+def build_flowspec_withdraw(
+    src: str,
+    dst: str,
+    proto: str,
+    port: int | None,
+    source_port: int | None,
+) -> str:
     """Build a FlowSpec withdraw command."""
     match_parts = []
     if src:
@@ -112,14 +195,22 @@ def build_flowspec_withdraw(src: str, dst: str, proto: str, port: int | None) ->
         match_parts.append(f"protocol {proto}")
     if port:
         match_parts.append(f"destination-port ={port}")
+    if source_port:
+        match_parts.append(f"source-port ={source_port}")
 
     match_str = "; ".join(match_parts) + ";"
     return f"withdraw flow route {{ match {{ {match_str} }} }}"
 
 
-def rule_id(src: str, dst: str, proto: str, port: int | None) -> str:
+def rule_id(
+    src: str,
+    dst: str,
+    proto: str,
+    port: int | None,
+    source_port: int | None,
+) -> str:
     """Deterministic key for deduplication."""
-    return f"{src}|{dst}|{proto}|{port}"
+    return f"{src}|{dst}|{proto}|{port}|{source_port}"
 
 
 # ---------------------------------------------------------------------------
@@ -132,16 +223,24 @@ class WebhookHandler(BaseHTTPRequestHandler):
     Expected JSON payload:
 
         {
-            "action":   "mitigate" | "clear",
-            "source":   "203.0.113.0/24",       // optional
-            "destination": "198.51.100.0/24",    // optional
-            "protocol": "udp",                   // optional
-            "port":     53,                      // optional
-            "attack_id": "abc-123"               // optional, for logging
+            "action":      "mitigate" | "clear",
+            "source":      "203.0.113.0/24",       // optional
+            "destination": "198.51.100.0/24",       // optional
+            "protocol":    "udp",                   // optional
+            "port":        53,                      // optional (destination-port)
+            "source_port": 53,                      // optional (source-port)
+            "attack_id":   "abc-123"                // optional, for logging
         }
     """
 
     def do_POST(self) -> None:
+        # --- API key check ---
+        if API_KEY:
+            auth = self.headers.get("Authorization", "")
+            if auth != f"Bearer {API_KEY}":
+                self._respond(401, {"error": "invalid or missing API key"})
+                return
+
         content_length = int(self.headers.get("Content-Length", 0))
         if content_length == 0:
             self._respond(400, {"error": "empty body"})
@@ -157,7 +256,8 @@ class WebhookHandler(BaseHTTPRequestHandler):
         src = body.get("source", "")
         dst = body.get("destination", "")
         proto = body.get("protocol", "")
-        port = body.get("port")
+        port_raw = body.get("port")
+        source_port_raw = body.get("source_port")
         attack_id = body.get("attack_id", "unknown")
 
         if action not in ("mitigate", "clear"):
@@ -167,10 +267,37 @@ class WebhookHandler(BaseHTTPRequestHandler):
             self._respond(400, {"error": "at least source or destination required"})
             return
 
-        rid = rule_id(src, dst, proto, port)
+        # --- Input validation ---
+        if src:
+            err = validate_cidr(src, "source")
+            if err:
+                self._respond(400, {"error": err})
+                return
+        if dst:
+            err = validate_cidr(dst, "destination")
+            if err:
+                self._respond(400, {"error": err})
+                return
+        if proto:
+            err = validate_protocol(proto)
+            if err:
+                self._respond(400, {"error": err})
+                return
+
+        port, err = validate_port(port_raw, "port")
+        if err:
+            self._respond(400, {"error": err})
+            return
+
+        source_port, err = validate_port(source_port_raw, "source_port")
+        if err:
+            self._respond(400, {"error": err})
+            return
+
+        rid = rule_id(src, dst, proto, port, source_port)
 
         if action == "mitigate":
-            cmd = build_flowspec_announce(src, dst, proto, port)
+            cmd = build_flowspec_announce(src, dst, proto, port, source_port)
             with lock:
                 if rid in active_rules:
                     log.info("rule already active for %s (attack %s)", rid, attack_id)
@@ -182,7 +309,7 @@ class WebhookHandler(BaseHTTPRequestHandler):
             self._respond(200, {"status": "mitigating", "rule_id": rid})
 
         elif action == "clear":
-            cmd = build_flowspec_withdraw(src, dst, proto, port)
+            cmd = build_flowspec_withdraw(src, dst, proto, port, source_port)
             with lock:
                 removed = active_rules.pop(rid, None)
             if removed:
@@ -211,19 +338,33 @@ class WebhookHandler(BaseHTTPRequestHandler):
 
 
 # ---------------------------------------------------------------------------
-# ExaBGP stdin reader -- watches for shutdown signal
+# ExaBGP stdin reader -- watches for session-up and shutdown signals
 # ---------------------------------------------------------------------------
 
 def stdin_reader() -> None:
-    """Read ExaBGP messages from stdin in a background thread."""
+    """Read ExaBGP messages from stdin in a background thread.
+
+    When ExaBGP uses the text encoder, it sends lines like:
+        neighbor 10.0.0.1 connected   -- TCP session established
+        neighbor 10.0.0.1 up           -- BGP session up (OPEN exchanged)
+        shutdown <pid> <ppid>           -- ExaBGP is shutting down
+
+    We set the session_up event when we see a "connected" or "up" message
+    so the main thread knows it's safe to start the HTTP server.
+    """
     while True:
         try:
             line = sys.stdin.readline().strip()
         except (IOError, KeyboardInterrupt):
             break
-        if line == "shutdown":
+        if not line:
+            continue
+        if line.startswith("shutdown"):
             log.info("received shutdown from ExaBGP")
             os._exit(0)
+        if " connected" in line or " up" in line:
+            log.info("session ready: %s", line)
+            session_up.set()
 
 
 # ---------------------------------------------------------------------------
@@ -233,16 +374,30 @@ def stdin_reader() -> None:
 def main() -> None:
     signal.signal(signal.SIGPIPE, signal.SIG_DFL)
 
-    # Start the stdin reader so we notice when ExaBGP shuts down
+    # Start the stdin reader so we notice when ExaBGP signals session-up
     reader_thread = threading.Thread(target=stdin_reader, daemon=True)
     reader_thread.start()
 
-    # Give ExaBGP a moment to finish the EOR exchange
-    time.sleep(0.5)
+    # Wait for ExaBGP to signal that a BGP session is up before accepting
+    # webhooks.  Fall back after 10 seconds so the server still starts even
+    # if no peer connects immediately (the rules will queue and be sent once
+    # the session comes up).
+    log.info("waiting for ExaBGP session to come up...")
+    if session_up.wait(timeout=10):
+        log.info("session is up, starting webhook listener")
+    else:
+        log.warning(
+            "no session-up received after 10 s, starting webhook listener anyway"
+        )
 
     # Start the webhook HTTP server
-    server = HTTPServer(("0.0.0.0", WEBHOOK_PORT), WebhookHandler)
-    log.info("webhook listener started on port %d", WEBHOOK_PORT)
+    server = ThreadingHTTPServer((WEBHOOK_BIND, WEBHOOK_PORT), WebhookHandler)
+    log.info(
+        "webhook listener started on %s:%d (auth %s)",
+        WEBHOOK_BIND,
+        WEBHOOK_PORT,
+        "enabled" if API_KEY else "disabled",
+    )
 
     try:
         server.serve_forever()


### PR DESCRIPTION
Adds a practical example showing how to use ExaBGP for automated DDoS mitigation via FlowSpec. The example receives attack alerts via webhook and dynamically announces/withdraws FlowSpec rules. Demonstrates integration with Flowtriq but the pattern works with any detection system.

## What's included

- `etc/exabgp/api-ddos-flowspec.conf` -- ExaBGP configuration with FlowSpec family and process setup
- `etc/exabgp/run/api-ddos-flowspec.run` -- Python process script: HTTP webhook listener that translates attack alerts into FlowSpec announce/withdraw commands
- `etc/exabgp/run/README-ddos-flowspec.md` -- Setup guide with architecture diagram, curl examples, and payload reference

## How it works

A lightweight HTTP server (stdlib only, no dependencies) runs as an ExaBGP process. When a DDoS detection system sends a POST with attack details (source/destination prefix, protocol, port), the script writes the corresponding FlowSpec command to stdout for ExaBGP to announce upstream. On attack clear, it withdraws the route.

The webhook interface is generic -- works with any system that can POST JSON (Flowtriq, custom sFlow analyzers, Zabbix, etc.).