### PR TITLE
Fix Exabgp 5.X crash during reload if idle neighbor exists

### DIFF
--- a/src/exabgp/reactor/peer.py
+++ b/src/exabgp/reactor/peer.py
@@ -268,8 +268,8 @@ class Peer:
             # isn't running to process the _neighbor variable later.
             # GitHub issue #1126: stale adj-rib when neighbor offline during reload
             if self.fsm != FSM.ESTABLISHED and self.neighbor.rib:
-                previous = restart_neighbor.previous.routes if restart_neighbor.previous else []
-                current = restart_neighbor.routes
+                previous = restart_neighbor.previous.changes if restart_neighbor.previous else []
+                current = restart_neighbor.changes
                 self.neighbor.rib.outgoing.replace_reload(previous, current)
                 restart_neighbor.previous = None
                 self._neighbor = None  # Prevent double-processing when peer connects


### PR DESCRIPTION
Exabgp 5.X crashes during reload if an idle neighbor exists.
Tested on 5.0.2 to 5.0.9.
See the log dump below.

Issue #1126  led to commit 272725351f (backported from main branch 511cf9b6f).
During backporting the changed attribute name [`Peer.routes`](https://github.com/Exa-Networks/exabgp/blob/de3aafe2f7de67f28757c4835916628d56e88989/src/exabgp/bgp/neighbor/neighbor.py#L112) (6.X) vs. [`Peer.changes`](https://github.com/Exa-Networks/exabgp/blob/78021ed5b801f4684cf4d217be40ec80e473a5a0/src/exabgp/bgp/neighbor.py#L127) had been overlooked.

This PR changes the reconfigure code to use `.changes` to align with 5.X naming schema.
Tested on 5.0.9 to confirm reload works without issues.

Log dump:
```
exabgp[1998]: ********************************************************************************
exabgp[1998]: -- Please provide ALL the information below on :
exabgp[1998]: -- https://github.com/Exa-Networks/exabgp/issues
exabgp[1998]: ********************************************************************************
exabgp[1998]: ExaBGP version : 5.0.9
exabgp[1998]: Python version : 3.14.4 (main, Apr 14 2026, 14:26:14) [Clang 22.1.3 ]
exabgp[1998]: System Uname   : #1 SMP PREEMPT_DYNAMIC Thu Apr  9 00:36:37 PDT 2026
exabgp[1998]: System MaxInt  : 9223372036854775807
exabgp[1998]: Root           : /home/labadm/.local
exabgp[1998]: Environment:
exabgp[1998]: exabgp.daemon.user='labadm'
exabgp[1998]: exabgp.api.pipename='globepeer-fra-ipv4'
exabgp[1998]: -- Traceback
exabgp[1998]: Traceback (most recent call last):
exabgp[1998]:   File "/home/labadm/.local/bin/exabgp", line 10, in <module>
exabgp[1998]:     sys.exit(main())
exabgp[1998]:              ~~~~^^
exabgp[1998]:   File "/home/labadm/.local/share/uv/tools/exabgp/lib/python3.14/site-packages/exabgp/application/main.py", line 103, in main
exabgp[1998]:     return cmdarg.func(cmdarg)
exabgp[1998]:            ~~~~~~~~~~~^^^^^^^^
exabgp[1998]:   File "/home/labadm/.local/share/uv/tools/exabgp/lib/python3.14/site-packages/exabgp/application/server.py", line 129, in cmdline
exabgp[1998]:     run(comment, configurations)
exabgp[1998]:     ~~~^^^^^^^^^^^^^^^^^^^^^^^^^
exabgp[1998]:   File "/home/labadm/.local/share/uv/tools/exabgp/lib/python3.14/site-packages/exabgp/application/server.py", line 210, in run
exabgp[1998]:     exit_code = Reactor(configuration).run()
exabgp[1998]:   File "/home/labadm/.local/share/uv/tools/exabgp/lib/python3.14/site-packages/exabgp/reactor/loop.py", line 369, in run
exabgp[1998]:     self.reload()
exabgp[1998]:     ~~~~~~~~~~~^^
exabgp[1998]:   File "/home/labadm/.local/share/uv/tools/exabgp/lib/python3.14/site-packages/exabgp/reactor/loop.py", line 533, in reload
exabgp[1998]:     self._peers[key].reconfigure(neighbor)
exabgp[1998]:     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
exabgp[1998]:   File "/home/labadm/.local/share/uv/tools/exabgp/lib/python3.14/site-packages/exabgp/reactor/peer.py", line 271, in reconfigure
exabgp[1998]:     previous = restart_neighbor.previous.routes if restart_neighbor.previous else []
exabgp[1998]:                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
exabgp[1998]: AttributeError: 'Neighbor' object has no attribute 'routes'
exabgp[1998]: -- Logging History
exabgp[1998]: [59B blob data]
exabgp[1998]: [61B blob data]
exabgp[1998]: [84B blob data]
exabgp[1998]: [85B blob data]
```