### PR TITLE
fix peering without kernel config_tcp_md5sig enabled

### DIFF
--- a/src/exabgp/reactor/network/tcp.py
+++ b/src/exabgp/reactor/network/tcp.py
@@ -182,7 +182,13 @@ def md5(io, ip, port, md5, md5_base64):
                 io.setsockopt(socket.IPPROTO_TCP, TCP_MD5SIG, sockaddr + key)
             else:
                 key = pack('2xH4x%ds' % TCP_MD5SIG_MAXKEYLEN, 0, b'')
-                io.setsockopt(socket.IPPROTO_TCP, TCP_MD5SIG, sockaddr + key)
+                try:
+                    io.setsockopt(socket.IPPROTO_TCP, TCP_MD5SIG, sockaddr + key)
+                except OSError as exc:
+                    # no md5 is configured, so there is no key to clear on a
+                    # kernel which does not implement the option at all
+                    if exc.errno != errno.ENOPROTOOPT:
+                        raise
 
         except OSError as exc:
             if exc.errno != errno.ENOENT:


### PR DESCRIPTION
i happen to be using a kernel that doesn't have config_tcp_md5sig enabled [alpine on a raspberry pi], and at the moment, for some experimentation, an exabgp config that doesn't use authentication.

even though authentication isn't enabled, exabgp still seems to set tcp_md5sig. as a client, that fails and the connection is dropped. as a server it logs a failure, but then appears to actually work.

client [i had to enable debug logging to figure this out, so maybe that's something else worth consideration]:

outgoing-1      attempting connection to 192.0.2.1:179
outgoing-1      connection to 192.0.2.1:179 failed
outgoing-1      This linux machine does not support TCP_MD5SIG, you can not use MD5 ([Errno ENOPROTOOPT] [Errno 92] Protocol not available)
that repeats about once a second.

server:

network         can not bind to 192.0.2.21:179 (This linux machine does not support TCP_MD5SIG, you can not use MD5 ([Errno ENOPROTOOPT] [Errno 92] Protocol not available))
network         unset exabgp.tcp.bind if you do not want listen for incoming connections
network         and check that no other daemon is already binding to port 179
at first i thought it wasn't working, because of the log message, but it actually was — it is listening, and if the peer initiates the session comes up fine.

with the change, connecting to the peer as a client works, and the server log message is gone:

reactor         connected to peer-1 with outgoing-1 192.0.2.21-192.0.2.1
i also checked on a kernel that does support it: setting a key and then clearing it still succeeds, and clearing when there is no key still returns enoent. with an md5 password configured on my kernel it still raises the error, which i assume is right since the kernel genuinely can't do it.

this change lets exabgp continue when no authentication is configured and the kernel doesn't have config_tcp_md5sig enabled.

i'm not experienced with python, so i may have this wrong.  i saw the change for #1388, so hopefully this doesn't contradict anything there.

- exabgp 5.0.13 [pip]
- python 3.14
- linux 6.18.35-0-rpi aarch64
- alpine