### PR TITLE
Add the ability to use Link Local Ipv6 addresses which are scoped to an interface as BGP neighbors and local addresses

### DIFF
--- a/src/exabgp/protocol/ip/__init__.py
+++ b/src/exabgp/protocol/ip/__init__.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from exabgp.bgp.message.open.capability.negotiated import Negotiated
 
 
+
 class IPFactory(Protocol):
     """Protocol for IP subclass constructors that accept packed data.
 
@@ -71,6 +72,7 @@ class IP(IPBase):
     def init(self, packed: Buffer) -> IP:
         self._packed = packed
         self.afi = IP.toafi(IP.ntop(packed))
+        self._zone = ''
         return self
 
     def __iter__(self) -> Iterator[str]:
@@ -79,14 +81,23 @@ class IP(IPBase):
 
     @staticmethod
     def pton(ip: str) -> bytes:
-        return socket.inet_pton(IP.toaf(ip), ip)
+        return socket.inet_pton(IP.toaf(ip), IP.strip_zone(ip))
 
     @staticmethod
     def ntop(data: Buffer) -> str:
         return socket.inet_ntop(socket.AF_INET if len(data) == IPv4.BYTES else socket.AF_INET6, data)
 
+    @staticmethod
+    def strip_zone(ip: str) -> str:
+        """Return the address portion of a zone-qualified IP string(address%interface)."""
+        if '%' in ip:
+            return ip.split('%', 1)[0]
+        return ip
+
     def top(self, negotiated: Negotiated | None = None, afi: AFI = AFI.undefined) -> str:
-        return IP.ntop(self._packed)
+        base = IP.ntop(self._packed)
+        zone = getattr(self, '_zone', '')
+        return base + '%' + zone if zone else base
 
     # Mapping from socket address family to AFI
     _AF_TO_AFI: ClassVar[dict[int, AFI]] = {
@@ -204,13 +215,20 @@ class IP(IPBase):
 
     @classmethod
     def from_string(cls, string: str, klass: IPFactory | None = None) -> 'IP':
+        zone = ''
+        if '%' in string:
+            string, zone = string.split('%', 1)
         data = IP.pton(string)
         if klass:
-            return klass(data)
-        factory = cls.klass(string)
-        if factory is None:
-            raise ValueError(f'Unknown IP address format: {string}')
-        return factory(data)
+            inst = klass(data)
+        else:
+            factory = cls.klass(string)
+            if factory is None:
+                raise ValueError(f'Unknown IP address format: {string}')
+            inst = factory(data)
+        if zone:
+            inst._zone = zone
+        return inst
 
     @classmethod
     def register(cls) -> None:
@@ -452,7 +470,7 @@ class IPv6(IP):
 
     @staticmethod
     def pton(ip: str) -> builtins.bytes:
-        return socket.inet_pton(socket.AF_INET6, ip)
+        return socket.inet_pton(socket.AF_INET6, IP.strip_zone(ip))
 
     @staticmethod
     def ntop(data: Buffer) -> str:

--- a/src/exabgp/reactor/network/tcp.py
+++ b/src/exabgp/reactor/network/tcp.py
@@ -57,12 +57,26 @@ def create(afi: AFI, interface: str | None = None) -> socket.socket:
     return io
 
 
+
+def split_zone(ip: str) -> tuple:
+    """Split an addr%zone string into a tuple of (string addr, int scope_id) if a zone is provided."""
+    if '%' in ip:
+        addr, zone = ip.split('%', 1)
+        try:
+            scope_id = socket.if_nametoindex(zone)
+        except OSError:
+            scope_id = 0
+        return addr, scope_id
+    return ip, 0
+
+
 def bind(io: socket.socket, ip: str, afi: AFI) -> None:
     try:
         if afi == AFI.ipv4:
             io.bind((ip, 0))
         if afi == AFI.ipv6:
-            io.bind((ip, 0, 0, 0))
+            addr, scope_id = split_zone(ip)
+            io.bind((addr, 0, 0, scope_id))
     except OSError as exc:
         raise BindingError(f'Could not bind to local ip {ip} - {exc!s}') from None
 
@@ -72,7 +86,8 @@ def connect(io: socket.socket, ip: str, port: int, afi: AFI, md5: str) -> None:
         if afi == AFI.ipv4:
             io.connect((ip, port))
         if afi == AFI.ipv6:
-            io.connect((ip, port, 0, 0))
+            addr, scope_id = split_zone(ip)
+            io.connect((addr, port, 0, scope_id))
     except OSError as exc:
         if exc.errno == errno.EINPROGRESS:
             return

--- a/tests/unit/test_ip_link_local.py
+++ b/tests/unit/test_ip_link_local.py
@@ -11,7 +11,8 @@ Created for ExaBGP testing framework
 License: 3-clause BSD
 """
 
-from exabgp.protocol.ip import IPv4, IPv6
+import pytest
+from exabgp.protocol.ip import IP, IPv4, IPv6
 
 
 # ==============================================================================
@@ -117,12 +118,47 @@ def test_ipv6_not_link_local_boundary() -> None:
 
 
 # ==============================================================================
+# IPv6 Zone Identifier for Link Local
+# ==============================================================================
+
+
+@pytest.mark.parametrize(
+    'addr, is_link_local, expected_zone',
+    [
+        # Zoned link-local addresses (RFC 4007).
+        ('fe80::1%eth0', True, 'eth0'),
+        ('fe80::1%lo', True, 'lo'),
+        ('fe80::dead:beef%wlan0', True, 'wlan0'),
+        ('fe80::2050:7ff:fe82:ca44%eth2', True, 'eth2'),
+        ('fe80::fc54:ff:fe52:2002%eth2', True, 'eth2'),
+
+        # Bare link-local addresses (no zone attached).
+        ('fe80::1', True, ''),
+        ('fe80::dead:beef', True, ''),
+
+        # Non-link-local IPv6 addresses (must not be flagged link-local).
+        ('2001:db8::1', False, ''),
+        ('::1', False, ''),
+    ],
+)
+def test_ipv6_zoned_and_nonzoned(addr: str, is_link_local: bool, expected_zone: str) -> None:
+    """Test parametrized link local and non link local calls to top and strip work as expected. """
+    inst = IP.from_string(addr)
+    assert inst.is_link_local() is is_link_local
+    assert inst.top() == addr
+    assert inst._zone == expected_zone
+    assert IP.pton(addr) == inst._packed
+
+
+
+# ==============================================================================
 # Summary
 # ==============================================================================
-# Total tests: 11
+# Total tests: 12
 #
 # Coverage:
 # - IPv4 always returns False (1 test)
 # - IPv6 valid link-local detection (2 tests)
 # - IPv6 non-link-local addresses (7 tests)
+# - IPv6 zone-identifier (1 test)
 # ==============================================================================

--- a/tests/unit/test_network_tcp.py
+++ b/tests/unit/test_network_tcp.py
@@ -17,6 +17,7 @@ from unittest.mock import patch, MagicMock
 
 from exabgp.protocol.family import AFI
 from exabgp.reactor.network import tcp
+from exabgp.reactor.network.tcp import split_zone
 from exabgp.reactor.network.error import (
     NotConnected,
     BindingError,
@@ -588,3 +589,30 @@ class TestIntegration:
 
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])
+
+
+# ==============================================================================
+# split_zone helper (zone ID parsing)
+# ==============================================================================
+
+class TestSplitZone:
+    """Test the split_zone helper for RFC 4007 zone ID parsing."""
+
+    def test_returns_scope_id_for_loopback(self) -> None:
+        """``lo`` is always index 1 on Linux and present on every host we test on."""
+        addr, scope_id = split_zone('fe80::1%lo')
+        assert addr == 'fe80::1'
+        assert scope_id == socket.if_nametoindex('lo')
+        assert scope_id > 0
+
+    def test_no_zone(self) -> None:
+        """Addresses without a %zone must yield scope_id 0 and pass through."""
+        addr, scope_id = split_zone('2001:db8::1')
+        assert addr == '2001:db8::1'
+        assert scope_id == 0
+
+    def test_unknown_interface_returns_zero(self) -> None:
+        """Unknown interface name must not raise — scope_id falls back to 0."""
+        addr, scope_id = split_zone('fe80::1%doesnotexist999')
+        assert addr == 'fe80::1'
+        assert scope_id == 0


### PR DESCRIPTION
Why I made this change?
Failure to bringup a Link Local IPv6 neighbor by following the steps listed in https://github.com/exa-networks/exabgp/wiki/Neighbor-Configuration#link-local-next-hop-600, with neighbor configuration containing the following:

```
neighbor fe80::1%eth0 {
    router-id 192.168.1.2;
    local-address fe80::2%eth0;
    local-as 65001;
    peer-as 65000;

    capability {
        link-local-nexthop enable;
        link-local-prefer true;
    }
}
```

Changes made:
1. Modify the config parser to accept zones
2. Modify sock.connect call to use the scope_id from ```neighbor <ip>%<intf>```
3. Modify sock.bind call to use the scope_id from ```local-address <ip>%<intf>```

Potential documentation update needed: Supporting zone field on local address ```local-address fe80::2%eth0``` after this PR merges

