### PR TITLE
fix: use os.read() to avoid BufferedReader/poll() data stranding

### DIFF
--- a/src/exabgp/reactor/api/processes.py
+++ b/src/exabgp/reactor/api/processes.py
@@ -255,7 +255,7 @@ class Processes:
                     # Calling next() on Linux and OSX works perfectly well
                     # but not on OpenBSD where it always raise StopIteration
                     # and only read() works (not even readline)
-                    buf = str(proc.stdout.read(16384), 'ascii')
+                    buf = str(os.read(proc.stdout.fileno(), 16384), 'ascii')
                     if buf == '' and poll is not None:
                         # if proc.poll() is None then
                         # process is fine, we received an empty line because


### PR DESCRIPTION
Fixes #1421

## Summary

- Replace `proc.stdout.read(16384)` with `os.read(proc.stdout.fileno(), 16384)` in the sync process reader to prevent `BufferedReader`'s internal buffer from hiding data from `select.poll()`
- Fixes silent route command stranding at the tail of large batches

## Root Cause

`proc.stdout.read(16384)` goes through Python's `BufferedReader` (buffer_size=8192). When a partial read returns between 8193–16383 bytes, `BufferedReader` enters a two-phase path that fills its internal buffer with bytes beyond what it returns to the caller. On the next reactor cycle, `poll(0)` sees an empty kernel fd and skips the process — those bytes are stranded until new data arrives on the pipe.

This is harmless mid-batch (new writes keep triggering poll), but **fatal at the batch tail**: once the writer has flushed all commands, no further writes will re-trigger poll, and the stranded commands are lost.

`os.read(fd, 16384)` bypasses `BufferedReader` entirely — it reads directly from the kernel fd, never consuming more than it returns, so `poll()` and `read()` always agree.

## The bug was introduced in

| Date | Commit | Change |
| :--- | :--- | :--- |
| 2017-07-20 | `898d54ab` | `readline()` → `read()` (unbounded) — safe |
| **2017-07-20** | **`51aeeaf2`** | **`read()` → `read(16384)`** — bug introduced |

The unbounded `read()` was safe because it drains everything from the kernel. Adding the 16384 cap created the mismatch.